### PR TITLE
Adding xml output for coverage in noxfile.py.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,7 @@ def coverage(session):
     session.run("coverage", "run")
     session.run("coverage", "report")
     session.run("coverage", "html")
+    session.run("coverage", "xml")
 
 
 @session(python="3.10")


### PR DESCRIPTION
This is required to display code coverage gutters in vscode, our shared environment for development.