### PR TITLE
Add exported package aerleon.lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = [
     "LICENSE",
     "README.md",
 ]
-packages = [{include = "aerleon"}]
+packages = [{include = "aerleon"}, {include = "aerleon/lib"}]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
This fixes a regression where the "aerleon.lib" export was lost when moving to poetry.

Before:
```
from aerleon.lib import naming
...
ModuleNotFoundError: No module named 'aerleon.lib'
```

After:
```
from aerleon.lib import naming
naming
<module 'aerleon.lib.naming' from '[...]/aerleon/aerleon/lib/naming.py'>
```