### PR TITLE
Fixup numeric ICMP procotol checks

### DIFF
--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -182,8 +182,8 @@ class Term:
         if (
             protocols != ['icmp']
             and protocols != ['icmpv6']
-            and protocols != self.PROTO_MAP['icmp']
-            and protocols != self.PROTO_MAP['icmpv6']
+            and protocols != [self.PROTO_MAP['icmp']]
+            and protocols != [self.PROTO_MAP['icmpv6']]
         ):
             raise UnsupportedFilterError(
                 '%s %s' % ('icmp-types specified for non-icmp protocols in term: ', self.term.name)


### PR DESCRIPTION
This resolves [this follow-up item](https://github.com/ankben/aerleon/pull/81#discussion_r1033195597) from #81:

> These lines need to be wrapped in a containing array.

https://github.com/ankben/aerleon/blob/9d65888f6dc37ca13cebef456d86f0fc2d022266/aerleon/lib/aclgenerator.py#L185-L186