### PR TITLE
SHA-pin install-poetry Github action to v1.3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true


### PR DESCRIPTION
This locks down the third-party Github action to a specific SHA (v1.3.3).