### PR TITLE
Shade Check now warns instead of errors.

### DIFF
--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -270,9 +270,6 @@ class Policy:
 
         Args:
           terms: list of Term objects.
-
-        Raises:
-          ShadingError: When a term is impossible to reach.
         """
         for index, term in enumerate(terms):
             for prior_index in range(index):

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -1147,7 +1147,7 @@ class PolicyTest(parameterized.TestCase):
         self.naming.GetServiceByProto.return_value = ['25']
 
         # same protocol, same saddr, shaded term defines a port.
-        _ = policy.ParsePolicy(pol2, self.naming, shade_check=True)
+        policy.ParsePolicy(pol2, self.naming, shade_check=True)
 
         self.naming.GetNetAddr.assert_has_calls(
             [mock.call('PROD_NETWRK'), mock.call('PROD_NETWRK')]


### PR DESCRIPTION
This fixes https://github.com/aerleon/aerleon/issues/94

Shade Checking detects when a term shades a following term. This means that the following term cannot be reached because the former term will always accept what could be accepted by the following one. For example
```
-name foo
  source-address:: ANY
  action:: accept
-name bar
  source-address:: DNS_SERVER
  action:: accept
```

There is no way that BAR will ever be reached because foo will always match.

This is not an error and should only warn the user.