### PR TITLE
Formats the mkdocs.yml file and changes nav to only have two layers.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,102 +1,100 @@
----
-dev_addr: "127.0.0.1:8001"
-edit_uri: "edit/develop/docs"
-site_dir: "site/docs"
-site_name: "Aerleon Documentation"
-site_url: "https://aerleon.readthedocs.io/en/latest/"
-repo_url: "https://github.com/aerleon/aerleon"
-copyright: "Copyright &copy; The Authors"
+dev_addr: '127.0.0.1:8001'
+edit_uri: edit/develop/docs
+site_dir: site/docs
+site_name: Aerleon Documentation
+site_url: 'https://aerleon.readthedocs.io/en/latest/'
+repo_url: 'https://github.com/aerleon/aerleon'
+copyright: Copyright &copy; The Authors
 theme: readthedocs
-
 extra:
   generator: false
   social:
-    - icon: "fontawesome/brands/slack"
-      link: "https://slack.networktocode.com/"
-      name: "Network to Code Community"
-    - icon: "fontawesome/brands/github"
-      link: "https://github.com/aerleon"
-      name: "GitHub Organization"
-    - icon: "fontawesome/brands/twitter"
-      link: "https://twitter.com/<tbd>"
-      name: "<Aerleon> Twitter"
+    - icon: fontawesome/brands/slack
+      link: 'https://slack.networktocode.com/'
+      name: Network to Code Community
+    - icon: fontawesome/brands/github
+      link: 'https://github.com/aerleon'
+      name: GitHub Organization
+    - icon: fontawesome/brands/twitter
+      link: 'https://twitter.com/<tbd>'
+      name: <Aerleon> Twitter
 markdown_extensions:
-  - "admonition"
-  - "toc":
+  - admonition
+  - toc:
       permalink: true
-  - "attr_list"
-  - "md_in_html"
-  - "pymdownx.highlight":
+  - attr_list
+  - md_in_html
+  - pymdownx.highlight:
       anchor_linenums: true
-  - "pymdownx.inlinehilite"
-  - "pymdownx.snippets"
-  - "pymdownx.superfences"
-  - "footnotes"
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - footnotes
 plugins:
-  - "search"
-  - "mkdocs-version-annotations"
-  - "mkdocstrings":
-      default_handler: "python"
+  - search
+  - mkdocs-version-annotations
+  - mkdocstrings:
+      default_handler: python
       handlers:
         python:
-          paths: ["."]
+          paths:
+            - .
           options:
             show_root_heading: true
             heading_level: 2
             show_category_heading: true
 watch:
-  - "README.md"
-
+  - README.md
 nav:
-  - Overview: "index.md"
+  - Overview: index.md
   - User Guide:
-      - Library Overview: "user/lib_overview.md"
-      - Install and Configure: "user/install.md"
-      - Getting Started: "user/lib_getting_started.md"
-      - Address Files: "user/lib_address.md"
-      - Service Files: "user/lib_service.md"
-      - Policy Files: "user/lib_policy.md"
-      - Platforms: "user/lib_platforms.md"
-      - Generators:
-          - arista: "user/generators/arista.md"
-          - arista_tp: "user/generators/arista_tp.md"
-          - aruba: "user/generators/aruba.md"
-          - brocade: "user/generators/brocade.md"
-          - cisco: "user/generators/cisco.md"
-          - ciscoasa: "user/generators/ciscoasa.md"
-          - cisconx: "user/generators/cisconx.md"
-          - ciscoxr: "user/generators/ciscoxr.md"
-          - gce: "user/generators/gce.md"
-          - ipset: "user/generators/ipset.md"
-          - iptables: "user/generators/iptables.md"
-          - juniper: "user/generators/juniper.md"
-          - juniperevo: "user/generators/juniperevo.md"
-          - junipermsmpc: "user/generators/junipermsmpc.md"
-          - junipersrx: "user/generators/junipersrx.md"
-          - k8s: "user/generators/k8s.md"
-          - nftables: "user/generators/nftables.md"
-          - nsxv: "user/generators/nsxv.md"
-          - packetfilter: "user/generators/packetfilter.md"
-          - paloaltofw: "user/generators/paloaltofw.md"
-          - pcap: "user/generators/pcap.md"
-          - speedway: "user/generators/speedway.md"
-          - srxlo: "user/generators/srxlo.md"
-          - windows_advfirewall.md: "user/generators/windows_advfirewall.md"
-      - Frequently Asked Questions: "user/faq.md"
-      - Release Notes:
-          - "user/release_notes/index.md"
-          - v1.0: "user/release_notes/version_1.0.md"
+      - Library Overview: user/lib_overview.md
+      - Install and Configure: user/install.md
+      - Getting Started: user/lib_getting_started.md
+      - Address Files: user/lib_address.md
+      - Service Files: user/lib_service.md
+      - Policy Files: user/lib_policy.md
+      - Platforms: user/lib_platforms.md
+  - Generators:
+      - arista: user/generators/arista.md
+      - arista_tp: user/generators/arista_tp.md
+      - aruba: user/generators/aruba.md
+      - brocade: user/generators/brocade.md
+      - cisco: user/generators/cisco.md
+      - ciscoasa: user/generators/ciscoasa.md
+      - cisconx: user/generators/cisconx.md
+      - ciscoxr: user/generators/ciscoxr.md
+      - gce: user/generators/gce.md
+      - ipset: user/generators/ipset.md
+      - iptables: user/generators/iptables.md
+      - juniper: user/generators/juniper.md
+      - juniperevo: user/generators/juniperevo.md
+      - junipermsmpc: user/generators/junipermsmpc.md
+      - junipersrx: user/generators/junipersrx.md
+      - k8s: user/generators/k8s.md
+      - nftables: user/generators/nftables.md
+      - nsxv: user/generators/nsxv.md
+      - packetfilter: user/generators/packetfilter.md
+      - paloaltofw: user/generators/paloaltofw.md
+      - pcap: user/generators/pcap.md
+      - speedway: user/generators/speedway.md
+      - srxlo: user/generators/srxlo.md
+      - windows_advfirewall.md: user/generators/windows_advfirewall.md
+  - Frequently Asked Questions: user/faq.md
+  - Release Notes:
+      - user/release_notes/index.md
+      - v1.0: user/release_notes/version_1.0.md
   - Developer Guide:
-      - Extending the Library: "dev/extending.md"
-      - Contributing to the Library: "dev/contributing.md"
-      - Development Environment: "dev/dev_environment.md"
-      - Generator Development: "dev/generator_patterns.md"
-      - Aerleon Design: "dev/design/aerleon-design.md"
-      - Library Class Overview:
-          - Naming: "dev/design/naming.md"
-          - Policy: "dev/design/policy.md"
-          - Policy Reader: "dev/design/policy-reader.md"
-          - AclCheck: "dev/design/aclcheck.md"
-      - Code Reference:
-          - Core: "dev/code_reference/core.md"
-          - Generators: "dev/code_reference/generators.md"
+      - Extending the Library: dev/extending.md
+      - Contributing to the Library: dev/contributing.md
+      - Development Environment: dev/dev_environment.md
+      - Generator Development: dev/generator_patterns.md
+      - Aerleon Design: dev/design/aerleon-design.md
+  - Library Class Overview:
+      - Naming: dev/design/naming.md
+      - Policy: dev/design/policy.md
+      - Policy Reader: dev/design/policy-reader.md
+      - AclCheck: dev/design/aclcheck.md
+  - Code Reference:
+      - Core: dev/code_reference/core.md
+      - Generators: dev/code_reference/generators.md


### PR DESCRIPTION
Makedocs readme theme only supports two layers of navigation. See this [issue](https://github.com/mkdocs/mkdocs/issues/2010)
Anything beyond that will cause rendering issues. This change forces everything into two layers max. This will continue to be edited in future PRS following this one.

I also formatted the yaml file.