### PR TITLE
Delete README within the tests.

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,6 +1,0 @@
-To run all tests from trunk:
-python -m unittest discover -s . -p '*_test.py'
-
-Specific tests:
-python -m unittest discover -s . -p 'junipersrx_test.py'
-


### PR DESCRIPTION
This README just states how to run unittest. We now use poetry and nox so it is no longer valid and would be covered in the readme docs we are creating anyway.