### PR TITLE
YAML filename tweaks

### DIFF
--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -164,6 +164,10 @@ class UserMessage:
         return f"UserMessage(\"{str(self)}\")"
 
 
+def is_yaml_suffix(suffix):
+    return suffix == '.yaml' or suffix == '.yml'
+
+
 class _ItemUnit:
     """This class is a container for an index key and a list of associated values.
 
@@ -214,7 +218,7 @@ class Naming:
 
         if naming_file:
             file_path = Path(naming_dir).joinpath(naming_file)
-            if file_path.suffix == '.yaml':
+            if is_yaml_suffix(file_path.suffix):
                 if naming_type:
                     logging.warning('Naming object: ignoring unexpected naming_type.')
 
@@ -610,6 +614,7 @@ class Naming:
             '.net': DEF_TYPE_NETWORKS,
             '.svc': DEF_TYPE_SERVICES,
             '.yaml': 'yaml',
+            '.yml': 'yaml',
         }
 
         for path in Path(definitions_directory).iterdir():

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -51,7 +51,7 @@ terms:
 """
 BAD_INCLUDE_YAML_INVALID_FILENAME = """
 terms:
-- include: include_1.pol.yaml
+- include: include_1.pol
 """
 BAD_INCLUDE_YAML_INVALID_YAML = """
 %INVALID YAML% &unknown
@@ -376,7 +376,7 @@ Include stack:
             )
             self.assertEqual(
                 str(user_message),
-                """Policy include source include_1.pol.yaml must end in ".pol-include.yaml". File=include_1.pol-include.yaml, Line=3.
+                """Policy include source include_1.pol must end in ".yaml". File=include_1.pol-include.yaml, Line=3.
 Include stack:
 > File='policy_with_include.pol.yaml', Line=10 (Top Level)
 > File='include_1.pol-include.yaml', Line=3""",  # noqa: E501


### PR DESCRIPTION
Any file with suffix .yaml or .yml can now be used as a policy or policy include file. The requirement that files be named .pol.yaml or .pol-include.yaml is removed.

This change also causes .yml to be accepted for naming definition files.

When recursively scanning for policy files, this change will cause policy and policy include files to no longer be distinguishable by file suffix. What will now happen is all YAML files in the scanned directory will be opened:

1. If the top-level key is `filters:`, it is a Policy file.
2. Otherwise if the top-level key is `terms:` it is a Policy include file (and can be quietly skipped).
3. Otherwise it is an unexpected file type and an error will be raised.