### PR TITLE
[WIP] initial verification of arista generator doc:

### DIFF
--- a/docs/user/generators/arista.md
+++ b/docs/user/generators/arista.md
@@ -70,4 +70,3 @@ option:: {established|is-fragment|tcp-established}
 * _established_: Only match established connections, implements tcp-established for tcp and sets destination port to 1024-65535 for udp if destination port is not defined.
 * _is-fragment_: Matches on if a packet is a fragment.
 * _tcp-established_: Only match established tcp connections, based on statefull match or TCP flags. Not supported for other protocols.
-* _tcp-initial_: Only match initial packet for TCP protocol. #FIXME: there is no tcp-initial flag implemented in the inherited cisco.py

--- a/docs/user/generators/arista.md
+++ b/docs/user/generators/arista.md
@@ -1,16 +1,26 @@
 # Arista
 
-The arista header designation has the following format:
+## Header Format
 
+The Arista header designation has the following format:
+
+```yaml
+targets:
+    arista: [filter name] {standard|extended|object-group|inet6}
 ```
+
+<!--
+```text
 target:: arista [filter name] {standard|extended|object-group|inet6}
 ```
-
+-->
 * _filter name_: defines the name of the arista filter.
 * _standard_: specifies that the output should be a standard access list
 * _extended_: specifies that the output should be an extended access list
 * _object-group_: specifies this is a arista extended access list, and that object-groups should be used for ports and addresses.
 * _inet6_: specifies the output be for IPv6 only filters.
+* _mixed_: #TODO: does this exist on all Cisco inherited platforms?
+* _enable_dsmo_: #TODO: does this exist on all Cisco inherited platforms?
 
 ## Term Format
 
@@ -21,7 +31,7 @@ target:: arista [filter name] {standard|extended|object-group|inet6}
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ Stop rendering this term after specified date in YYYY-MM-DD format. E.g. 2022-06-30
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
@@ -35,6 +45,7 @@ target:: arista [filter name] {standard|extended|object-group|inet6}
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.
+* _verbose::_ adds additional remark statements with the term name, owner (if set) and the comment (if set) (default: True)
 
 ## Sub Tokens
 
@@ -48,7 +59,15 @@ target:: arista [filter name] {standard|extended|object-group|inet6}
 
 ### Option
 
-* _established::_ Only match established connections, implements tcp-established for tcp and sets destination port to 1024- 65535 for udp if destination port is not defined.
-* _is-fragment::_ Matches on if a packet is a fragment.
-* _tcp-established::_ Only match established tcp connections, based on statefull match or TCP flags. Not supported for other protocols.
-* _tcp-initial::_ Only match initial packet for TCP protocol.
+```yaml
+option: {established|is-fragment|tcp-established}
+```
+<!--
+```text
+option:: {established|is-fragment|tcp-established}
+```
+-->
+* _established_: Only match established connections, implements tcp-established for tcp and sets destination port to 1024-65535 for udp if destination port is not defined.
+* _is-fragment_: Matches on if a packet is a fragment.
+* _tcp-established_: Only match established tcp connections, based on statefull match or TCP flags. Not supported for other protocols.
+* _tcp-initial_: Only match initial packet for TCP protocol. #FIXME: there is no tcp-initial flag implemented in the inherited cisco.py

--- a/docs/user/generators/arista.md
+++ b/docs/user/generators/arista.md
@@ -24,24 +24,16 @@ target:: arista [filter name] {standard|extended|object-group|inet6}
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ Stop rendering this term after specified date in YYYY-MM-DD format. E.g. 2022-06-30
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/arista_tp.md
+++ b/docs/user/generators/arista_tp.md
@@ -15,11 +15,11 @@ The following tokens are supported:
 - `icmp-type`
 - `logging`
 - `option`
-    - `established`
-    - `tcp-established`
-    - `initial`
-    - `rst`
-    - `first-fragment` - this  will be rendered as a `fragment` match.`
+  - `established`
+  - `tcp-established`
+  - `initial`
+  - `rst`
+  - `first-fragment` - this  will be rendered as a `fragment` match.
 - `packet-length`
 - `source-address`
 - `source-exclude`
@@ -31,7 +31,7 @@ The following tokens are supported:
 
 The official documentation for traffic-policies can be found at the following URL.
 
- - <https://eos.arista.com/eos-4-25-0f/support-for-traffic-policy-on-interfaces/>
+- <https://eos.arista.com/eos-4-25-0f/support-for-traffic-policy-on-interfaces/>
 
 ## filter types
 

--- a/docs/user/generators/arista_tp.md
+++ b/docs/user/generators/arista_tp.md
@@ -4,10 +4,9 @@
 
 The following tokens are supported:
 
-- `action`
-- `comment`
+- for common keys see [common.md](common.md)
+
 - `counter`
-- `destination-address`
 - `destination-exclude`
 - `destination-port`
 - `destination-prefix` - this should resolve to a configured field-set in traffic-policy format.
@@ -21,7 +20,6 @@ The following tokens are supported:
   - `rst`
   - `first-fragment` - this  will be rendered as a `fragment` match.
 - `packet-length`
-- `source-address`
 - `source-exclude`
 - `source-port`
 - `source-prefix` - this should resolve to a configured field-set in traffic-policy format.

--- a/docs/user/generators/aruba.md
+++ b/docs/user/generators/aruba.md
@@ -2,8 +2,9 @@
 
 The aruba header designation has the following format:
 
-```
-target:: aruba [filter name] {ipv6}
+```yaml
+targets:
+    aruba: [filter name] {ipv6}
 ```
 
 * _filter name_: defines the name of the arista filter.
@@ -15,7 +16,7 @@ target:: aruba [filter name] {ipv6}
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _destination-address::_ One or more destination address tokens
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _name::_ Name of the term.
 * _option::_ See platforms supported Options section.
 * _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.

--- a/docs/user/generators/aruba.md
+++ b/docs/user/generators/aruba.md
@@ -12,15 +12,9 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.
 
 ## Sub Tokens

--- a/docs/user/generators/brocade.md
+++ b/docs/user/generators/brocade.md
@@ -11,7 +11,7 @@ See Cisco
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.

--- a/docs/user/generators/brocade.md
+++ b/docs/user/generators/brocade.md
@@ -4,24 +4,16 @@ See Cisco
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/cisco.md
+++ b/docs/user/generators/cisco.md
@@ -1,16 +1,19 @@
 # Cisco
 
 The cisco header designation has the following format:
+
+```yaml
+targets:
+    cisco: [filter name] {extended|standard|object-group|inet6|mixed} {enable_dsmo}
 ```
-target:: cisco [filter name] {extended|standard|object-group|inet6|mixed} {enable_dsmo}
-```
-  * _filter name_: defines the name or number of the cisco filter.
-  * _extended_: specifies that the output should be an extended access list, and the filter name should be non-numeric.  This is the default option.
-  * _standard_: specifies that the output should be a standard access list, and the filter name should be numeric and in the range of 1-99.
-  * _object-group_: specifies this is a cisco extended access list, and that object-groups should be used for ports and addresses.
-  * _inet6_: specifies the output be for IPv6 only filters.
-  * _mixed_: specifies output will include both IPv6 and IPv4 filters.
-  * _enable_dsmo_: Enable discontinuous subnet mask summarization.
+
+* _filter name_: defines the name or number of the cisco filter.
+* _extended_: specifies that the output should be an extended access list, and the filter name should be non-numeric.  This is the default option.
+* _standard_: specifies that the output should be a standard access list, and the filter name should be numeric and in the range of 1-99.
+* _object-group_: specifies this is a cisco extended access list, and that object-groups should be used for ports and addresses.
+* _inet6_: specifies the output be for IPv6 only filters.
+* _mixed_: specifies output will include both IPv6 and IPv4 filters.
+* _enable_dsmo_: Enable discontinuous subnet mask summarization.
 When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filters will be rendered using only the specified addresses.
 The default format is _inet4_, and is implied if not other argument is given.
 
@@ -24,7 +27,7 @@ The default format is _inet4_, and is implied if not other argument is given.
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.

--- a/docs/user/generators/cisco.md
+++ b/docs/user/generators/cisco.md
@@ -19,25 +19,17 @@ The default format is _inet4_, and is implied if not other argument is given.
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
 * _restrict-address-family::_ Only include the term in the matching address family filter (eg. for mixed filters).
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/ciscoasa.md
+++ b/docs/user/generators/ciscoasa.md
@@ -2,8 +2,9 @@
 
 The ciscoasa header designation has the following format:
 
-```
-target:: ciscoasa [filter name]
+```yaml
+targets:
+    ciscoasa: [filter name]
 ```
 
 ## Term Format
@@ -13,7 +14,7 @@ target:: ciscoasa [filter name]
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _name::_ Name of the term.

--- a/docs/user/generators/ciscoasa.md
+++ b/docs/user/generators/ciscoasa.md
@@ -9,21 +9,13 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/cisconx.md
+++ b/docs/user/generators/cisconx.md
@@ -2,15 +2,17 @@
 
 The cisconx header designation has the following format:
 
+```yaml
+targets:
+    cisconx: [filter name] {extended|object-group|inet6|mixed} {enable_dsmo}
 ```
-target:: cisconx [filter name] {extended|object-group|inet6|mixed} {enable_dsmo}
-```
-  * _filter name_: defines the name or number of the cisconx filter.
-  * _extended_: specifies that the output should be an extended access list, and the filter name should be non-numeric.  This is the default option.
-  * _object-group_: specifies this is a cisconx extended access list, and that object-groups should be used for ports and addresses.
-  * _inet6_: specifies the output be for IPv6 only filters.
-  * _mixed_: specifies output will include both IPv6 and IPv4 filters.
-  * _enable_dsmo_: Enable discontinuous subnet mask summarization.
+
+* _filter name_: defines the name or number of the cisconx filter.
+* _extended_: specifies that the output should be an extended access list, and the filter name should be non-numeric.  This is the default option.
+* _object-group_: specifies this is a cisconx extended access list, and that object-groups should be used for ports and addresses.
+* _inet6_: specifies the output be for IPv6 only filters.
+* _mixed_: specifies output will include both IPv6 and IPv4 filters.
+* _enable_dsmo_: Enable discontinuous subnet mask summarization.
 When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filters will be rendered using only the specified addresses.
 The default format is _inet4_, and is implied if not other argument is given.
 
@@ -23,7 +25,7 @@ The default format is _inet4_, and is implied if not other argument is given.
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.

--- a/docs/user/generators/cisconx.md
+++ b/docs/user/generators/cisconx.md
@@ -18,24 +18,16 @@ The default format is _inet4_, and is implied if not other argument is given.
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/ciscoxr.md
+++ b/docs/user/generators/ciscoxr.md
@@ -11,7 +11,7 @@ See Cisco
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.

--- a/docs/user/generators/ciscoxr.md
+++ b/docs/user/generators/ciscoxr.md
@@ -4,24 +4,16 @@ See Cisco
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _dscp_match::_ Match a DSCP number.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/common.md
+++ b/docs/user/generators/common.md
@@ -1,0 +1,38 @@
+# Common
+
+This lists contains all the common keys that are used across all generators (with a few highlighted exceptions).
+
+## Term Format
+
+* _action::_ The action to take when matched. See Actions section for valid options.
+* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
+* _destination-address::_ One or more destination address tokens
+* _expiration::_ Stop rendering this term after specified date in YYYY-MM-DD format. E.g. 2022-06-30
+* _name::_ Name of the term.
+* _option::_ See platforms supported Options section. (**Not** supported on: **k8s**, **gce**)
+* _platform::_ one or more target platforms for which this term should ONLY be rendered. (**Not** supported on: **aruba**)
+* _platform-exclude::_ one or more target platforms for which this term should NEVER be rendered. (**Not** supported on: **aruba**)
+* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
+* _source-address::_ one or more source address tokens.
+
+<!--
+build_in tokens:
+            #'action',
+            #'comment',
+            'destination_address',
+            'destination_address_exclude',
+            'destination_port',
+            #'expiration',
+            'icmp_type',
+            'stateless_reply',
+            #'name',  # obj attribute, not token
+            #'option',
+            #'protocol',
+            #'platform',
+            #'platform_exclude',
+            'source_address',
+            'source_address_exclude',
+            'source_port',
+            'translated',  # obj attribute, not token
+            'verbatim',
+-->

--- a/docs/user/generators/gce.md
+++ b/docs/user/generators/gce.md
@@ -2,8 +2,9 @@
 
 The GCE header designation has the following format:
 
-```
-target:: gce [filter name] [direction]
+```yaml
+targets:
+    gce: [filter name] [direction]
 ```
 
 * _filter name_: defines the name of the gce filter.
@@ -17,7 +18,7 @@ target:: gce [filter name] [direction]
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination_tag::_ Tag name to be used for destination filtering.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _name::_ Name of the term.
 * _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.

--- a/docs/user/generators/gce.md
+++ b/docs/user/generators/gce.md
@@ -12,19 +12,13 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination_tag::_ Tag name to be used for destination filtering.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _priority_ Relative priority of rules when evaluated on the platform.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _source-tag::_ Tag name used for source filtering.

--- a/docs/user/generators/ipset.md
+++ b/docs/user/generators/ipset.md
@@ -3,8 +3,9 @@
 Ipset is a system inside the Linux kernel, which can very efficiently store and match IPv4 and IPv6 addresses. This can be used to dramatically increase performance of iptables firewall.
 The Ipset header designation follows the Iptables format above, but uses the target platform of 'ipset':
 
-```
-target:: ipset [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
+```yaml
+targets:
+    ipset: [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
 ```
 
 ## Term Format
@@ -17,7 +18,7 @@ target:: ipset [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nost
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
@@ -40,6 +41,7 @@ target:: ipset [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nost
 ## Sub Tokens
 
 ### Actions
+
 * _accept_
 * _deny_
 * _next_
@@ -47,6 +49,7 @@ target:: ipset [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nost
 * _reject-with-tcp-rst_
 
 ### Option
+
 * _ack::_ Match on ACK flag being present.
 * _all::_ Matches all protocols.
 * _established::_ Only match established connections, implements tcp-established for tcp and sets destination port to 1024- 65535 for udp if destination port is not defined.
@@ -62,4 +65,3 @@ target:: ipset [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nost
 * _tcp-established::_ Only match established tcp connections, based on statefull match or TCP flags. Not supported for other protocols.
 * _tcp-initial::_ Only match initial packet for TCP protocol.
 * _urg::_ Match on URG flag being present.
-

--- a/docs/user/generators/ipset.md
+++ b/docs/user/generators/ipset.md
@@ -10,28 +10,20 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
+* for common keys see [common.md](common.md)
+
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-interface::_ specify specific interface a term should apply to (e.g. source-interface:: eth3).
 * _source-port::_ one or more service definition tokens.

--- a/docs/user/generators/iptables.md
+++ b/docs/user/generators/iptables.md
@@ -1,31 +1,12 @@
 # iptables
 
-> NOTE: Iptables produces output that must be passed, line by line, to the 'iptables/ip6tables' command line. For 'iptables-restore' compatible output, please use the Speedway generator.
-
-The Iptables header designation has the following format:
-
-```
-target:: iptables [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
-INPUT: apply the terms to the input filter.
-OUTPUT: apply the terms to the output filter.
-FORWARD: apply the terms to the forwarding filter.
-custom: create the terms under a custom filter name, which must then be linked/jumped to from one of the default filters (e.g. iptables -A input -j custom)
-ACCEPT: specifies that the default policy on the filter should be 'accept'.
-DROP: specifies that the default policy on the filter should be to 'drop'.
-inet: specifies that the resulting filter should only render IPv4 addresses.
-inet6: specifies that the resulting filter should only render IPv6 addresses.
-truncatenames: specifies to abbreviate term names if necessary (see lib/iptables.py:CheckTerMLength for abbreviation table)
-nostate: specifies to produce 'stateless' filter output (e.g. no connection tracking)
-```
-
-## Iptables
-
 > NOTE: Iptables produces output that must be passed, line by line, to the 'iptables/ip6tables' command line.  For 'iptables-restore' compatible output, please use the [Speedway](PolicyFormat#Speedway.md) generator.
 
 The Iptables header designation has the following format:
 
-```
-target:: iptables [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
+```yaml
+targets:
+    iptables: [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
 ```
 
 * _INPUT_: apply the terms to the input filter.
@@ -37,7 +18,7 @@ target:: iptables [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {n
 * _inet_: specifies that the resulting filter should only render IPv4 addresses.
 * _inet6_: specifies that the resulting filter should only render IPv6 addresses.
 * _truncatenames_: specifies to abbreviate term names if necessary (see lib/iptables.py:_CheckTerMLength for abbreviation table)
-*_nostate_: specifies to produce 'stateless' filter output (e.g. no connection tracking)_
+* _nostate_: specifies to produce 'stateless' filter output (e.g. no connection tracking)
 
 ## Term Format
 
@@ -49,7 +30,7 @@ target:: iptables [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {n
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments

--- a/docs/user/generators/iptables.md
+++ b/docs/user/generators/iptables.md
@@ -22,28 +22,20 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
+* for common keys see [common.md](common.md)
+
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-interface::_ specify specific interface a term should apply to (e.g. source-interface:: eth3).
 * _source-port::_ one or more service definition tokens.

--- a/docs/user/generators/juniper.md
+++ b/docs/user/generators/juniper.md
@@ -2,26 +2,9 @@
 
 The juniper header designation has the following format:
 
-```
-target:: juniper [filter name] {inet|inet6|bridge}
-filter name: defines the name of the juniper filter.
-inet: specifies the output should be for IPv4 only filters. This is the default format.
-inet6: specifies the output be for IPv6 only filters.
-bridge: specifies the output should render a Juniper bridge filter.
-```
-
-When inet4 or inet6 is specified, naming tokens with both IPv4 and IPv6 filters
-will be rendered using only the specified addresses.
-
-The default format is `inet4`, and is implied if not other argument is given.
-
-
-## Juniper
-
-The juniper header designation has the following format:
-
-```
-target:: juniper [filter name] {inet|inet6|bridge} {dsmo} {not-interface-specific}
+```yaml
+targets:
+    juniper: [filter name] {inet|inet6|bridge} {dsmo} {not-interface-specific}
 ```
 
 * _filter name_: defines the name of the juniper filter.
@@ -51,7 +34,7 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _filter-term::_ Include another filter
 * _flexible-match-range Filter based on flexible match options.
 * _forwarding-class::_ Specify the forwarding class to match.

--- a/docs/user/generators/juniper.md
+++ b/docs/user/generators/juniper.md
@@ -20,12 +20,11 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
 * _restrict-address-family::_ Only include the term in the matching address family filter (eg. for mixed filters).
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
@@ -34,7 +33,6 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _filter-term::_ Include another filter
 * _flexible-match-range Filter based on flexible match options.
 * _forwarding-class::_ Specify the forwarding class to match.
@@ -45,22 +43,16 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _loss-priority::_ Specify loss priority.
-* _name::_ Name of the term.
 * _next-ip::_ Used in filter based forwarding.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
 * _policer::_ specify which policer to apply to matching packets.
 * _port::_ Matches on source or destination ports. Takes a service token.
 * _port-mirror::_ Sends copies of the packets to a remote port, boolean value is used to render this config.
 * _precedence::_ specify precedence of range 0-7.  May be a single integer, or a space separated list.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _protocol\_except::_ allow all protocol "except" specified.
 * _qos::_ apply quality of service classification to matching packets (e.g. qos:: af4)
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _source-prefix::_ specify source-prefix matching (e.g. source-prefix:: configured-neighbors-only).

--- a/docs/user/generators/juniperevo.md
+++ b/docs/user/generators/juniperevo.md
@@ -2,25 +2,9 @@
 
 The Juniper EVO header designation has the following format:
 
-```
-target:: juniperevo [filter name] {inet|inet6|bridge}
-filter name: defines the name of the Juniper EVO filter.
-inet: specifies the output should be for IPv4 only filters. This is the default format.
-inet6: specifies the output be for IPv6 only filters.
-bridge: specifies the output should render a Juniper EVO bridge filter.
-```
-
-When inet4 or inet6 is specified, naming tokens with both IPv4 and IPv6 filters
-will be rendered using only the specified addresses.
-
-The default format is `inet4`, and is implied if not other argument is given.
-
-## Juniper EVO
-
-The Juniper EVO header designation has the following format:
-
-```
-target:: juniperevo [filter name] {inet|inet6|bridge} {dsmo} {not-interface-specific} {direction} {interface}
+```yaml
+targets:
+    juniperevo: [filter name] {inet|inet6|bridge} {dsmo} {not-interface-specific} {direction} {interface}
 ```
 
 * _filter name_: defines the name of the Juniper EVO filter.
@@ -49,7 +33,7 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _filter-term::_ Include another filter
 * _flexible-match-range Filter based on flexible match options.
 * _forwarding-class::_ Specify the forwarding class to match.

--- a/docs/user/generators/juniperevo.md
+++ b/docs/user/generators/juniperevo.md
@@ -19,12 +19,11 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
 * _restrict-address-family::_ Only include the term in the matching address family filter (eg. for mixed filters).
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
@@ -33,7 +32,6 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _filter-term::_ Include another filter
 * _flexible-match-range Filter based on flexible match options.
 * _forwarding-class::_ Specify the forwarding class to match.
@@ -44,22 +42,16 @@ When _inet4_ or _inet6_ is specified, naming tokens with both IPv4 and IPv6 filt
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _loss-priority::_ Specify loss priority.
-* _name::_ Name of the term.
 * _next-ip::_ Used in filter based forwarding.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
 * _policer::_ specify which policer to apply to matching packets.
 * _port::_ Matches on source or destination ports. Takes a service token.
 * _port-mirror::_ Sends copies of the packets to a remote port, boolean value is used to render this config.
 * _precedence::_ specify precedence of range 0-7.  May be a single integer, or a space separated list.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _protocol\_except::_ allow all protocol "except" specified.
 * _qos::_ apply quality of service classification to matching packets (e.g. qos:: af4)
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _source-prefix::_ specify source-prefix matching (e.g. source-prefix:: configured-neighbors-only).

--- a/docs/user/generators/junipermsmpc.md
+++ b/docs/user/generators/junipermsmpc.md
@@ -2,15 +2,17 @@
 
 The juniper header designation has the following format:
 
+```yaml
+targets:
+    juniper: [filter name] {inet|inet6|mixed} {noverbose} {ingress|egress}
 ```
-target:: juniper [filter name] {inet|inet6|mixed} {noverbose} {ingress|egress}
-filter name: defines the name of the juniper msmpc filter.
-inet6: specifies the output be for IPv6 only filters.
-mixed: specifies the output be for IPv4 and IPv6 filters. This is the default format.
-noverbose: omit additional term and address comments.
-ingress: filter will be applied in the input direction.
-egress: filter will be appliced in the output direction.
-```
+
+* _filter name_: defines the name of the juniper msmpc filter.
+* _inet6_: specifies the output be for IPv6 only filters.
+* _mixed_: specifies the output be for IPv4 and IPv6 filters. This is the default format.
+* _noverbose_: omit additional term and address comments.
+* _ingress_: filter will be applied in the input direction.
+* _egress_: filter will be appliced in the output direction.
 
 When inet4 or inet6 is specified, naming tokens with both IPv4 and IPv6 filters will be rendered using only the specified addresses.
 

--- a/docs/user/generators/junipersrx.md
+++ b/docs/user/generators/junipersrx.md
@@ -1,16 +1,18 @@
 
-## JuniperSRX
+# JuniperSRX
 
 > Note: The Juniper SRX generator is currently in beta testing.
 
+```yaml
+targets:
+    srx: from-zone [zone name] to-zone [zone name] {inet}
 ```
-target:: srx from-zone [zone name] to-zone [zone name] {inet}
-```
+
 * _from-zone_: static keyword, followed by user specified zone
 * _to-zone_: static keyword, followed by user specified zone
 * _inet_: Address family (only IPv4 tested at this time)
 
-### Term Format
+## Term Format
 
 * _action::_ The action to take when matched. See Actions section for valid options.
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
@@ -21,17 +23,17 @@ target:: srx from-zone [zone name] to-zone [zone name] {inet}
 * _dscp_except::_ Do not match the DSCP number.
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that these packets should be logged.
-    * Based on the input value the resulting logging actions will follow this logic:
-        * _action_ is 'accept':
-            * _logging_ is 'true': resulting SRX output will be 'log { session-close; }'
-            * _logging_ is 'log-both': resulting SRX output will be 'log { session-init; session-close; }'
-        * _action_ is 'deny':
-            * _logging_ is 'true': resulting SRX output will be 'log { session-init; }'
-            * _logging_ is 'log-both': resulting SRX output will be 'log { session-init; session-close; }'
-        * See [here](https://kb.juniper.net/InfoCenter/index?page=content&id=KB16506) for explanation.
+  * Based on the input value the resulting logging actions will follow this logic:
+    * _action_ is 'accept':
+      * _logging_ is 'true': resulting SRX output will be 'log { session-close; }'
+      * _logging_ is 'log-both': resulting SRX output will be 'log { session-init; session-close; }'
+    * _action_ is 'deny':
+      * _logging_ is 'true': resulting SRX output will be 'log { session-init; }'
+      * _logging_ is 'log-both': resulting SRX output will be 'log { session-init; session-close; }'
+    * See [here](https://kb.juniper.net/InfoCenter/index?page=content&id=KB16506) for explanation.
 * _name::_ Name of the term.
 * _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
@@ -46,9 +48,9 @@ target:: srx from-zone [zone name] to-zone [zone name] {inet}
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.
 * _vpn::_ Encapsulate outgoing IP packets and decapsulate incomfing IP packets.
 
-### Sub Tokens
+## Sub Tokens
 
-#### Actions
+### Actions
 
 * _accept_
 * _count_

--- a/docs/user/generators/junipersrx.md
+++ b/docs/user/generators/junipersrx.md
@@ -14,16 +14,14 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination-zone::_ one or more destination zones tokens. Only supported by global policy
 * _dscp_except::_ Do not match the DSCP number.
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that these packets should be logged.
   * Based on the input value the resulting logging actions will follow this logic:
@@ -34,13 +32,7 @@ targets:
       * _logging_ is 'true': resulting SRX output will be 'log { session-init; }'
       * _logging_ is 'log-both': resulting SRX output will be 'log { session-init; session-close; }'
     * See [here](https://kb.juniper.net/InfoCenter/index?page=content&id=KB16506) for explanation.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _source-zone::_ one or more source zones tokens. Only supported by global policy

--- a/docs/user/generators/k8s.md
+++ b/docs/user/generators/k8s.md
@@ -2,8 +2,9 @@
 
 The K8s header designation has the following format:
 
-```
-target:: k8s [direction]
+```yaml
+targets:
+    k8s: [direction]
 ```
 
 * _direction_: defines the direction, valid inputs are INGRESS and EGRESS (default:INGRESS)
@@ -15,7 +16,7 @@ target:: k8s [direction]
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _name::_ Name of the term.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _protocol::_ the network protocols this term will match, such as tcp, udp, or sctp.

--- a/docs/user/generators/k8s.md
+++ b/docs/user/generators/k8s.md
@@ -11,16 +11,11 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
-* _name::_ Name of the term.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, or sctp.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 
 ## Sub Tokens

--- a/docs/user/generators/nftables.md
+++ b/docs/user/generators/nftables.md
@@ -2,8 +2,9 @@
 
 The NFTables header designation has the following format:
 
-```
-target:: newnftables [nf_address_family] [nf_hook] {default_policy_override} {int: base chain priority} {noverbose}
+```yaml
+targets:
+    newnftables: [nf_address_family] [nf_hook] {default_policy_override} {int: base chain priority} {noverbose}
 ```
 
 Unless otherwise stated, all fields are required unless they're marked optional.
@@ -26,9 +27,9 @@ An implementation design for this generator is that terms with options 'establis
 
 When reporting bugs about this generator ensure to include:
 
-1.  Example policy (.pol file)
-1.  Observed output (.nft file)
-1.  Expected (correct) output in Nftables syntax (.nft syntax)
+1. Example policy (.pol file)
+1. Observed output (.nft file)
+1. Expected (correct) output in Nftables syntax (.nft syntax)
 
 ## Term Format
 
@@ -36,7 +37,7 @@ When reporting bugs about this generator ensure to include:
 - _comment::_ A text comment enclosed in double-quotes. The comment can extend over multiple lines if desired, until a closing quote is encountered.
 - _destination-address::_ One or more destination address tokens.
 - _destination-port::_ One or more service definition tokens.
-- _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+- _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 - _icmp-type::_ Specify icmp-type code to match.
 - _source-address::_ One or more source address tokens.
 - _source-port::_ One or more service definition tokens.

--- a/docs/user/generators/nftables.md
+++ b/docs/user/generators/nftables.md
@@ -9,11 +9,11 @@ targets:
 
 Unless otherwise stated, all fields are required unless they're marked optional.
 
-- nf_address_family: defines the IP address family for the policies. (inet, inet6, mixed)
-- nf_hook: defines the traffic direction and the nftables hook for the rules. (input, output)
-- default_policy_override: **OPTIONAL** defines the default action (ACCEPT, DROP) for non-matching packets. Default behavior is DROP.
-- priority: **OPTIONAL** By default, this generator creates base chains with a starting priority of 0. Defining an integer value will override this behavior.
-- noverbose: **OPTIONAL** Disable header and term comments in final ACL output. Default behavior is verbose.
+* nf_address_family: defines the IP address family for the policies. (inet, inet6, mixed)
+* nf_hook: defines the traffic direction and the nftables hook for the rules. (input, output)
+* default_policy_override: **OPTIONAL** defines the default action (ACCEPT, DROP) for non-matching packets. Default behavior is DROP.
+* priority: **OPTIONAL** By default, this generator creates base chains with a starting priority of 0. Defining an integer value will override this behavior.
+* noverbose: **OPTIONAL** Disable header and term comments in final ACL output. Default behavior is verbose.
 
 #### Important: stateful firewall only
 
@@ -33,34 +33,30 @@ When reporting bugs about this generator ensure to include:
 
 ## Term Format
 
-- _action::_ The action to take when matched. Refer to Sub-tokens -> Actions for valid options.
-- _comment::_ A text comment enclosed in double-quotes. The comment can extend over multiple lines if desired, until a closing quote is encountered.
-- _destination-address::_ One or more destination address tokens.
-- _destination-port::_ One or more service definition tokens.
-- _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
-- _icmp-type::_ Specify icmp-type code to match.
-- _source-address::_ One or more source address tokens.
-- _source-port::_ One or more service definition tokens.
-- _protocol::_ The network protocol(s) this term will match.
-- _logging::_ NFTables system logging (host-based).
-- _counter::_ NFTables counter for specific term.
+* for common keys see [common.md](common.md)
+
+* _destination-port::_ One or more service definition tokens.
+* _icmp-type::_ Specify icmp-type code to match.
+* _source-port::_ One or more service definition tokens.
+* _logging::_ NFTables system logging (host-based).
+* _counter::_ NFTables counter for specific term.
 
 ## Sub-tokens
 
 ### Actions
 
-- _accept_
-- _drop_
+* _accept_
+* _drop_
 
 ### Logging
 
-- _disable_ no packets will be logged on syslog.
+* _disable_ no packets will be logged on syslog.
 
 All of the below values are accepted, but outcome is exactly the same.
 
-- _true_
-- _syslog_
-- _local_
+* _true_
+* _syslog_
+* _local_
 
 ### Counter
 
@@ -72,6 +68,7 @@ This generator normalizes certain capirca policy.py string types to NFTables sem
 
 #### IPv4
 
+```text
 | ICMPv4 type code | Capirca (policy.py)  | NFtables manual         |
 |------------------|----------------------|-------------------------|
 | 0                | echo-reply           | echo-reply              |
@@ -92,9 +89,11 @@ This generator normalizes certain capirca policy.py string types to NFTables sem
 | 18               | mask-reply           | address-mask-reply      |
 | 31               | conversion-error     |                         |
 | 32               | mobile-redirect      |                         |
+```
 
 #### IPv6
 
+```text
 | ICMPv6 type code | Capirca (policy.py)                      | NFtables manual                             |
 |------------------|------------------------------------------|---------------------------------------------|
 | 1                | destination-unreachable                  | destination-unreachable                     |
@@ -126,9 +125,9 @@ This generator normalizes certain capirca policy.py string types to NFTables sem
 | 151              | multicast-router-advertisement           |                                             |
 | 152              | multicast-router-solicitation            |                                             |
 | 153              | multicast-router-termination             |                                             |
-
+```
 _source:_ https://www.netfilter.org/projects/nftables/manpage.html
 
 ### Option
 
-- _tcp-established_ and _established_ will cause the term to not be rendered in the final NFT configuration. See 'Important' section above.
+* _tcp-established_ and _established_ will cause the term to not be rendered in the final NFT configuration. See 'Important' section above.

--- a/docs/user/generators/nsxv.md
+++ b/docs/user/generators/nsxv.md
@@ -1,35 +1,19 @@
-# NSX
+# NSXv
 
 The nsx header designation has the following format:
 
-```
-target:: nsxv {section_name} {inet|inet6|mixed} section-id securitygroup securitygroupId
-section_name: specifies the name of the section all terms in this header apply to.
-inet: specifies that the resulting filter should only render IPv4 addresses.
-inet6: specifies that the resulting filter should only render IPv6 addresses.
-mixed: specifies that the resulting filter should render both IPv4 and IPv6 addresses.
-sectionId: specifies the Id for the section [optional]
-securitygroup: specifies that the appliedTo should be security group [optional]
-securitygroupId: specifies the Id of the security group [mandatory if securitygroup is given]
-(Required keywords option and verbatim are not supported in NSX)
+```yaml
+targets:
+    nsxv: {section_name} {inet|inet6|mixed} section-id securitygroup securitygroupId
 ```
 
-
-## Nsxv
-
-The nsxv header designation has the following format:
-
-```
-target:: nsxv {section_name} {inet|inet6|mixed} section-id securitygroup securitygroupId
-```
-
-* _section_name_: specifies the name of the section all terms in this header apply to. [mandatory field]
-* _inet_: specifies the output should be for IPv4 only filters. This is the default format.
-* _inet6_: specifies the output be for IPv6 only filters.
+* _section_name_: specifies the name of the section all terms in this header apply to.
+* _inet_: specifies that the resulting filter should only render IPv4 addresses.
+* _inet6_: specifies that the resulting filter should only render IPv6 addresses.
 * _mixed_: specifies that the resulting filter should render both IPv4 and IPv6 addresses.
-* _sectionId_: specifies the Id for the section [optional]
-* _securitygroup_: specifies that the appliedTo should be security group [optional]
-* _securitygroupId_: specifies the Id of the security group [mandatory if securitygroup is given]
+* _sectionId_: specifies the Id for the section (optional)
+* _securitygroup_: specifies that the appliedTo should be security group (optional)
+* _securitygroupId_: specifies the Id of the security group (mandatory if securitygroup is given)
 
 (Required keywords option and verbatim are not supported in NSX)
 
@@ -40,7 +24,7 @@ target:: nsxv {section_name} {inet|inet6|mixed} section-id securitygroup securit
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _name::_ Name of the term.
@@ -61,4 +45,3 @@ target:: nsxv {section_name} {inet|inet6|mixed} section-id securitygroup securit
 * _deny_
 * _reject_
 * _reject-with-tcp-rst_
-

--- a/docs/user/generators/nsxv.md
+++ b/docs/user/generators/nsxv.md
@@ -19,20 +19,12 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/packetfilter.md
+++ b/docs/user/generators/packetfilter.md
@@ -2,8 +2,9 @@
 
 > Note: The PF generator is currently in alpha testing. The output should be compatible with OpenBSD v4.7 PF and later.
 
-```
-target:: packetfilter filter-name {inet|inet6|mixed} {in|out} {nostate}
+```yaml
+targets:
+    packetfilter: filter-name {inet|inet6|mixed} {in|out} {nostate}
 ```
 
 * _filter-name_: a short, descriptive policy identifier
@@ -20,10 +21,10 @@ target:: packetfilter filter-name {inet|inet6|mixed} {in|out} {nostate}
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
-* _destination-interface::_ Specify the destination interface. Implicitly changes the term direction to *out* for this term. Mutually exclusive with _source-interface::_.
-* _source-interface::_ Specify the source interface. Implicitly changes the term direction to *in* for this term. Mutually exclusive with _destination-interface::_.
+* _destination-interface::_ Specify the destination interface. Implicitly changes the term direction to **out** for this term. Mutually exclusive with _source-interface::_.
+* _source-interface::_ Specify the source interface. Implicitly changes the term direction to **in** for this term. Mutually exclusive with _destination-interface::_.
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _name::_ Name of the term.

--- a/docs/user/generators/packetfilter.md
+++ b/docs/user/generators/packetfilter.md
@@ -17,22 +17,14 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-interface::_ Specify the destination interface. Implicitly changes the term direction to **out** for this term. Mutually exclusive with _source-interface::_.
 * _source-interface::_ Specify the source interface. Implicitly changes the term direction to **in** for this term. Mutually exclusive with _destination-interface::_.
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _verbatim::_ this specifies that the text enclosed within quotes should be rendered into the output without interpretation or modification.  This is sometimes used as a temporary workaround while new required features are being added.

--- a/docs/user/generators/paloaltofw.md
+++ b/docs/user/generators/paloaltofw.md
@@ -2,33 +2,31 @@
 
 The paloalto header designation has the following format:
 
-```
-target:: paloalto from-zone [zone name] to-zone [zone name] [address family] [address objects]
+```yaml
+targets:
+    paloalto: from-zone [zone name] to-zone [zone name] [address family] [address objects]
 ```
 
 * _from-zone_: static keyword, followed by the source zone
 * _to-zone_: static keyword, followed by the destination zone
 * _address family_: specifies the address family for the resulting filter
-    * _inet_: the filter should only render IPv4 addresses (default)
-    * _inet6_: the filter should only render IPv6 addresses
-    * _mixed_: the filter should render IPv4 and IPv6 addresses
-* _address objects_: specifies whether custom address objects or
-     network/mask definitions are used in security policy source and
-     destination fields
-    * _addr-obj_: specifies address groups are used in the security policy
+  * _inet_: the filter should only render IPv4 addresses (default)
+  * _inet6_: the filter should only render IPv6 addresses
+  * _mixed_: the filter should render IPv4 and IPv6 addresses
+* _address objects_: specifies whether custom address objects or network/mask definitions are used in security policy source and destination fields
+  * _addr-obj_: specifies address groups are used in the security policy
       source and destination fields (default)
-    * _no-addr-obj_: specifies network/mask definitions are used in the
+  * _no-addr-obj_: specifies network/mask definitions are used in the
        security policy source and destination fields
-* _unique-term-prefixes_: specifies whether each term name should be generated
-     with unique prefixes. The unique prefix is a hexdigest of from_zone and
-     to_zone fields.
+* _unique-term-prefixes_: specifies whether each term name should be generated with unique prefixes. The unique prefix is a hexdigest of from_zone and to_zone fields.
 
 ## Term Format
+
 * _action::_ The action to take when matched. See Actions section for valid options.
 * _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _destination-address::_ One or more destination address tokens.
 * _destination-port::_ One or more service definition tokens.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _name::_ Name of the term.
@@ -55,15 +53,12 @@ target:: paloalto from-zone [zone name] to-zone [zone name] [address family] [ad
 
 * _pan-application_:: paloalto target only.
     Specify applications for the security policy which can be predefined
-    applications (https://applipedia.paloaltonetworks.com/)
+    applications (<https://applipedia.paloaltonetworks.com/>)
     and custom application objects.
 
-    * _Security Policy Service Setting_
+  * _Security Policy Service Setting_
 
-        * When no _protocol_ is specified in the term, the service will be _application-default_.
-
-        * When _protocol_ is tcp or udp, and no _source-port_ or _destination-port_ is specified, the service will be custom service objects for the protocols and all ports (0-65535).
-
-        * When _protocol_ is tcp or udp, and a _source-port_ or _destination-port_ is specified, the service will be custom service objects for the protocols and ports.
-
-        * _pan-application_ can only be used when no _protocol_ is specified in the term, or the protocols tcp and udp.
+    * When no _protocol_ is specified in the term, the service will be _application-default_.
+    * When _protocol_ is tcp or udp, and no _source-port_ or _destination-port_ is specified, the service will be custom service objects for the protocols and all ports (0-65535).
+    * When _protocol_ is tcp or udp, and a _source-port_ or _destination-port_ is specified, the service will be custom service objects for the protocols and ports.
+    * _pan-application_ can only be used when no _protocol_ is specified in the term, or the protocols tcp and udp.

--- a/docs/user/generators/paloaltofw.md
+++ b/docs/user/generators/paloaltofw.md
@@ -22,18 +22,12 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens.
+* for common keys see [common.md](common.md)
+
 * _destination-port::_ One or more service definition tokens.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
 * _owner::_ Owner of the term, used for organizational purposes.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-port::_ one or more service definition tokens.
 * _timeout::_ specify application timeout. (default 60)
 

--- a/docs/user/generators/pcap.md
+++ b/docs/user/generators/pcap.md
@@ -9,7 +9,7 @@ FILL ME IN
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.

--- a/docs/user/generators/pcap.md
+++ b/docs/user/generators/pcap.md
@@ -4,21 +4,13 @@ FILL ME IN
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 

--- a/docs/user/generators/speedway.md
+++ b/docs/user/generators/speedway.md
@@ -4,28 +4,9 @@
 
 The Speedway header designation has the following format:
 
-```
-target:: speedway [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
-INPUT: apply the terms to the input filter.
-OUTPUT: apply the terms to the output filter.
-FORWARD: apply the terms to the forwarding filter.
-custom: create the terms under a custom filter name, which must then be linked/jumped to from one of the default filters (e.g. iptables -A input -j custom)
-ACCEPT: specifies that the default policy on the filter should be 'accept'.
-DROP: specifies that the default policy on the filter should be to 'drop'.
-inet: specifies that the resulting filter should only render IPv4 addresses.
-inet6: specifies that the resulting filter should only render IPv6 addresses.
-truncatenames: specifies to abbreviate term names if necessary (see lib/iptables.py: CheckTermLength? for abbreviation table)
-nostate: specifies to produce 'stateless' filter output (e.g. no connection tracking)
-```
-
-# Speedway
-
-> NOTE: Speedway produces Iptables filtering output that is suitable for passing to the 'iptables-restore' command.
-
-The Speedway header designation has the following format:
-
-```
-target:: speedway [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
+```yaml
+targets:
+    speedway: [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {nostate} {inet|inet6}
 ```
 
 * _INPUT_: apply the terms to the input filter.
@@ -49,7 +30,7 @@ target:: speedway [INPUT|OUTPUT|FORWARD|custom] {ACCEPT|DROP} {truncatenames} {n
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments

--- a/docs/user/generators/speedway.md
+++ b/docs/user/generators/speedway.md
@@ -22,28 +22,20 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
+* for common keys see [common.md](common.md)
+
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-interface::_ Specify specific interface a term should apply to (e.g. destination-interface:: eth3)
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
 * _icmp-code::_ Specifies the ICMP code to filter on.
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-interface::_ specify specific interface a term should apply to (e.g. source-interface:: eth3).
 * _source-port::_ one or more service definition tokens.

--- a/docs/user/generators/srxlo.md
+++ b/docs/user/generators/srxlo.md
@@ -17,7 +17,7 @@ SRX Loopback is a stateless Juniper ACL with minor changes. Please see code for 
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _forwarding-class::_ Specify the forwarding class to match.
 * _forwarding-class_except::_ Do not match the specified forwarding classes.
 * _fragement-offset::_ specify a fragment offset of a fragmented packet

--- a/docs/user/generators/srxlo.md
+++ b/docs/user/generators/srxlo.md
@@ -4,11 +4,10 @@ SRX Loopback is a stateless Juniper ACL with minor changes. Please see code for 
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
+* for common keys see [common.md](common.md)
+
 * _address::_ One or more network address tokens, matches source or destination.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
 * _counter::_ Update a counter for matching packets
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
 * _destination-prefix::_ Specify destination-prefix matching (e.g. source-prefix:: configured-neighbors-only)
@@ -17,7 +16,6 @@ SRX Loopback is a stateless Juniper ACL with minor changes. Please see code for 
 * _dscp_match::_ Match a DSCP number.
 * _dscp_set::_ Match a DSCP set.
 * _ether_type::_ Match EtherType field.
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _forwarding-class::_ Specify the forwarding class to match.
 * _forwarding-class_except::_ Do not match the specified forwarding classes.
 * _fragement-offset::_ specify a fragment offset of a fragmented packet
@@ -26,21 +24,15 @@ SRX Loopback is a stateless Juniper ACL with minor changes. Please see code for 
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _logging::_ Specify that this packet should be logged via syslog.
 * _loss-priority::_ Specify loss priority.
-* _name::_ Name of the term.
 * _next-ip::_ Used in filter based forwarding.
-* _option::_ See platforms supported Options section.
 * _owner::_ Owner of the term, used for organizational purposes.
 * _packet-length::_ specify packet length.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
 * _policer::_ specify which policer to apply to matching packets.
 * _port::_ Matches on source or destination ports. Takes a service token.
 * _precedence::_ specify precedence of range 0-7.  May be a single integer, or a space separated list.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
 * _protocol\_except::_ allow all protocol "except" specified.
 * _qos::_ apply quality of service classification to matching packets (e.g. qos:: af4)
 * _routing-instance::_ specify routing instance for matching packets.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 * _source-prefix::_ specify source-prefix matching (e.g. source-prefix:: configured-neighbors-only).

--- a/docs/user/generators/windows_advfirewall.md
+++ b/docs/user/generators/windows_advfirewall.md
@@ -2,8 +2,9 @@
 
 The Windows Advanced Firewall header designation has the following format:
 
-```
-target:: windows_advfirewall {out|in} {inet|inet6|mixed}
+```yaml
+targets:
+    windows_advfirewall: {out|in} {inet|inet6|mixed}
 ```
 
 * _out_: Specifies that the direction of packet flow is out. (default)
@@ -18,7 +19,7 @@ target:: windows_advfirewall {out|in} {inet|inet6|mixed}
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
 * _name::_ Name of the term.
 * _option::_ See platforms supported Options section.
@@ -40,8 +41,9 @@ target:: windows_advfirewall {out|in} {inet|inet6|mixed}
 
 The Windows IPSec header designation has the following format:
 
-```
-target:: windows_advfirewall [filter_name]
+```yaml
+targets:
+    windows_advfirewall: [filter_name]
 ```
 
 * _filter name_: defines the name of the Windows IPSec filter.
@@ -53,7 +55,7 @@ target:: windows_advfirewall [filter_name]
 * _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. [YYYY](YYYY.md)-[MM](MM.md)-[DD](DD.md)
+* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _name::_ Name of the term.
 * _option::_ See platforms supported Options section.
 * _platform::_ one or more target platforms for which this term should ONLY be rendered.

--- a/docs/user/generators/windows_advfirewall.md
+++ b/docs/user/generators/windows_advfirewall.md
@@ -14,19 +14,11 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
+* for common keys see [common.md](common.md)
+
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
 * _icmp-type::_ Specify icmp-type code to match, see section [ICMP TYPES](PolicyFormat#ICMP_TYPES.md) for list of valid arguments
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 
@@ -50,18 +42,8 @@ targets:
 
 ## Term Format
 
-* _action::_ The action to take when matched. See Actions section for valid options.
-* _comment::_ A text comment enclosed in double-quotes.  The comment can extend over multiple lines if desired, until a closing quote is encountered.
-* _destination-address::_ One or more destination address tokens
 * _destination-exclude::_ Exclude one or more address tokens from the specified destination-address
 * _destination-port::_ One or more service definition tokens
-* _expiration::_ stop rendering this term after specified date. YYYY-MM-DD
-* _name::_ Name of the term.
-* _option::_ See platforms supported Options section.
-* _platform::_ one or more target platforms for which this term should ONLY be rendered.
-* _platform-exclude:: one or more target platforms for which this term should NEVER be rendered.
-* _protocol::_ the network protocols this term will match, such as tcp, udp, icmp, or a numeric value.
-* _source-address::_ one or more source address tokens.
 * _source-exclude::_ exclude one or more address tokens from the specified source-address.
 * _source-port::_ one or more service definition tokens.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Policy Files: user/lib_policy.md
       - Platforms: user/lib_platforms.md
   - Generators:
+      - common: user/generators/common.md
       - arista: user/generators/arista.md
       - arista_tp: user/generators/arista_tp.md
       - aruba: user/generators/aruba.md


### PR DESCRIPTION
* inherited from `cisco.py`:
  * header options: * `mixed` -> missing * `enable_dsmo` -> missing * are they applicable for arista too?
  * term options:
    * `tcp-initial` is not listed in `cisco.py'
    * `verbose` is missing but default true -> also noverbose available but missing
    * expiration: removed dead links for date format