### PR TITLE
Use 'address' key for IP/CIDR values

### DIFF
--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -847,10 +847,10 @@ class Naming:
                 # 'item' can be:
                 # 1. A string, understood as a network name reference
                 # 2. A dictionary, with these fields:
-                #    'ip': A specific IP address or CIDR range
+                #    'address': A specific IP address or CIDR range
                 #    'name': A network name reference
                 #    'comment': An optional comment
-                # 'ip' or 'name' must be present in any dictionary item
+                # 'address' or 'name' must be present in any dictionary item
                 value = None
                 network_ref = None
                 ip = None
@@ -860,8 +860,8 @@ class Naming:
                 elif isinstance(item, dict):
                     if 'name' in item and isinstance(item['name'], str):
                         value = network_ref = item['name']
-                    elif 'ip' in item and isinstance(item['ip'], str):
-                        value = ip = item['ip']
+                    elif 'address' in item and isinstance(item['address'], str):
+                        value = ip = item['address']
                     else:
                         logging.info(f'\nNetwork name or CIDR expected for: {symbol}')
                         continue

--- a/def/naming.yaml
+++ b/def/naming.yaml
@@ -1,11 +1,11 @@
 networks:
   RFC1918:
     values:
-      - ip: 10.0.0.0/8
+      - address: 10.0.0.0/8
         comment: "non-public"
-      - ip: 172.16.0.0/12
+      - address: 172.16.0.0/12
         comment: "non-public"
-      - ip: 192.168.0.0/16
+      - address: 192.168.0.0/16
         comment: "non-public"
 
   INTERNAL:
@@ -14,45 +14,45 @@ networks:
 
   LOOPBACK:
     values:
-      - ip: 127.0.0.0/8
+      - address: 127.0.0.0/8
         comment: "loopback"
-      - ip: ::1/128
+      - address: ::1/128
         comment: "ipv6 loopback"
 
   RFC_3330:
     values:
-      - ip: 169.254.0.0/16
+      - address: 169.254.0.0/16
         comment: "special use IPv4 addresses - netdeploy"
 
   RFC_6598:
     values:
-      - ip: 100.64.0.0/10
+      - address: 100.64.0.0/10
         comment: "Shared Address Space"
 
   LINKLOCAL:
     values:
-      - ip: FE80::/10
+      - address: FE80::/10
         comment: "IPv6 link-local"
 
   SITELOCAL:
     values:
-      - ip: FEC0::/10
+      - address: FEC0::/10
         comment: "Ipv6 Site-local"
 
   MULTICAST:
     values:
-      - ip: 224.0.0.0/4
+      - address: 224.0.0.0/4
         comment: "IP multicast"
-      - ip: FF00::/8
+      - address: FF00::/8
         comment: "IPv6 multicast"
 
   CLASS-E:
     values:
-      - ip: 240.0.0.0/4
+      - address: 240.0.0.0/4
 
   RESERVED:
     values:
-      - ip: 0.0.0.0/8
+      - address: 0.0.0.0/8
         comment: "reserved"
       - name: RFC1918
       - name: LOOPBACK
@@ -60,37 +60,37 @@ networks:
       - name: RFC_6598
       - name: MULTICAST
       - name: CLASS-E
-      - ip: 0000::/8
+      - address: 0000::/8
         comment: "reserved by IETF"
-      - ip: 0100::/8
+      - address: 0100::/8
         comment: "reserved by IETF"
-      - ip: 0200::/7
+      - address: 0200::/7
         comment: "reserved by IETF"
-      - ip: 0400::/6
+      - address: 0400::/6
         comment: "reserved by IETF"
-      - ip: 0800::/5
+      - address: 0800::/5
         comment: "reserved by IETF"
-      - ip: 1000::/4
+      - address: 1000::/4
         comment: "reserved by IETF"
-      - ip: 4000::/3
+      - address: 4000::/3
         comment: "reserved by IETF"
-      - ip: 6000::/3
+      - address: 6000::/3
         comment: "reserved by IETF"
-      - ip: 8000::/3
+      - address: 8000::/3
         comment: "reserved by IETF"
-      - ip: A000::/3
+      - address: A000::/3
         comment: "reserved by IETF"
-      - ip: C000::/3
+      - address: C000::/3
         comment: "reserved by IETF"
-      - ip: E000::/4
+      - address: E000::/4
         comment: "reserved by IETF"
-      - ip: F000::/5
+      - address: F000::/5
         comment: "reserved by IETF"
-      - ip: F800::/6
+      - address: F800::/6
         comment: "reserved by IETF"
-      - ip: FC00::/7
+      - address: FC00::/7
         comment: "unique local unicast"
-      - ip: FE00::/9
+      - address: FE00::/9
         comment: "reserved by IETF"
       - name: LINKLOCAL
         comment: "link local unicast"
@@ -99,11 +99,11 @@ networks:
 
   ANY:
     values:
-      - ip: 0.0.0.0/0
+      - address: 0.0.0.0/0
 
   ANY_V6:
     values:
-      - ip: ::/0
+      - address: ::/0
 
   ANY_MIXED:
     values:
@@ -114,30 +114,30 @@ networks:
   # 22-Apr-2011
   BOGON:
     values:
-      - ip: 0.0.0.0/8
-      - ip: 192.0.0.0/24
-      - ip: 192.0.2.0/24
-      - ip: 198.18.0.0/15
-      - ip: 198.51.100.0/24
-      - ip: 203.0.113.0/24
+      - address: 0.0.0.0/8
+      - address: 192.0.0.0/24
+      - address: 192.0.2.0/24
+      - address: 198.18.0.0/15
+      - address: 198.51.100.0/24
+      - address: 203.0.113.0/24
       - name: MULTICAST
       - name: CLASS-E
-      - ip: 3FFE::/16
+      - address: 3FFE::/16
         comment: "6bone"
-      - ip: 5F00::/8
+      - address: 5F00::/8
         comment: "6bone"
-      - ip: 2001:DB8::/32
+      - address: 2001:DB8::/32
         comment: "IPv6 documentation prefix"
 
   GOOGLE_PUBLIC_DNS_ANYCAST:
     values:
-      - ip: 8.8.4.4/32
+      - address: 8.8.4.4/32
         comment: "IPv4 Anycast"
-      - ip: 8.8.8.8/32
+      - address: 8.8.8.8/32
         comment: "IPv4 Anycast"
-      - ip: 2001:4860:4860::8844/128
+      - address: 2001:4860:4860::8844/128
         comment: "IPv6 Anycast"
-      - ip: 2001:4860:4860::8888/128
+      - address: 2001:4860:4860::8888/128
         comment: "IPv6 Anycast"
 
   GOOGLE_DNS:
@@ -146,53 +146,53 @@ networks:
 
   CLOUDFLARE_PUBLIC_DNS:
     values:
-      - ip: 2606:4700:4700::1111/128
-      - ip: 1.1.1.1
+      - address: 2606:4700:4700::1111/128
+      - address: 1.1.1.1
 
   # The following are sample entires intended for us in the included
   # sample policy file.  These should be removed.
 
   WEB_SERVERS:
     values:
-      - ip: 200.1.1.1/32
+      - address: 200.1.1.1/32
         comment: "Example web server 1"
-      - ip: 200.1.1.2/32
+      - address: 200.1.1.2/32
         comment: "Example web server 2"
 
   MAIL_SERVERS:
     values:
-      - ip: 200.1.1.4/32
+      - address: 200.1.1.4/32
         comment: "Example mail server 1"
-      - ip: 200.1.1.5/32
+      - address: 200.1.1.5/32
         comment: "Example mail server 2"
 
   PUBLIC_NAT:
     values:
-      - ip: 200.1.1.3/32
+      - address: 200.1.1.3/32
         comment: "Example company NAT address"
 
   NTP_SERVERS:
     values:
-      - ip: 10.0.0.1/32
+      - address: 10.0.0.1/32
         comment: "Example NTP server"
-      - ip: 10.0.0.2/32
+      - address: 10.0.0.2/32
         comment: "Example NTP server"
 
   TACACS_SERVERS:
     values:
-      - ip: 10.1.0.1/32
+      - address: 10.1.0.1/32
         comment: "Example tacacs server"
-      - ip: 10.1.0.2/32
+      - address: 10.1.0.2/32
         comment: "Example tacacs server"
 
   PUBLIC_IPV6_SERVERS:
     values:
-      - ip: 2606:700:e:550:b01a::b00a
+      - address: 2606:700:e:550:b01a::b00a
         comment: "Example public web server"
 
   WEB_IPV6_SERVERS:
     values:
-      - ip: 2620:15c:2c4:202:b0e7:158f:6a7a:3188/128
+      - address: 2620:15c:2c4:202:b0e7:158f:6a7a:3188/128
         comment: "Example web server"
 
 services:

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -225,26 +225,26 @@ services:
 networks:
   NET1:
     values:
-      - ip: 10.1.0.0/8
+      - address: 10.1.0.0/8
         comment: "network1"
   NET2:
     values:
-      - ip: 10.2.0.0/16
+      - address: 10.2.0.0/16
         comment: "network2.0"
       - NET1
   9OCLOCK:
     values:
-      - ip: 1.2.3.4/32
+      - address: 1.2.3.4/32
         comment: "9 is the time"
   FOOBAR:
     values:
       - 9OCLOCK
   FOO_V6:
     values:
-      - ip: ::FFFF:FFFF:FFFF:FFFF
+      - address: ::FFFF:FFFF:FFFF:FFFF
   BAR_V6:
     values:
-      - ip: ::1/128
+      - address: ::1/128
   BAZ:
     values:
       - FOO_V6
@@ -271,14 +271,14 @@ class DefinitionObjectUnitTest(NamingUnitTest):
         super().setUp()
         defs_obj = {
             'networks': {
-                '9OCLOCK': {'values': [{'comment': '9 is the time', 'ip': '1.2.3.4/32'}]},
-                'BAR_V6': {'values': [{'ip': '::1/128'}]},
+                '9OCLOCK': {'values': [{'comment': '9 is the time', 'address': '1.2.3.4/32'}]},
+                'BAR_V6': {'values': [{'address': '::1/128'}]},
                 'BAZ': {'values': ['FOO_V6', 'BAR_V6']},
                 'BING': {'values': [{'comment': 'foo', 'name': 'NET1'}, 'FOO_V6']},
                 'FOOBAR': {'values': ['9OCLOCK']},
-                'FOO_V6': {'values': [{'ip': '::FFFF:FFFF:FFFF:FFFF'}]},
-                'NET1': {'values': [{'comment': 'network1', 'ip': '10.1.0.0/8'}]},
-                'NET2': {'values': [{'comment': 'network2.0', 'ip': '10.2.0.0/16'}, 'NET1']},
+                'FOO_V6': {'values': [{'address': '::FFFF:FFFF:FFFF:FFFF'}]},
+                'NET1': {'values': [{'comment': 'network1', 'address': '10.1.0.0/8'}]},
+                'NET2': {'values': [{'comment': 'network2.0', 'address': '10.2.0.0/16'}, 'NET1']},
             },
             'services': {
                 'SVC1': [


### PR DESCRIPTION
This change renames the 'ip' key to 'address' for IP/CIDR values in YAML network definition files per discussion.