### PR TITLE
Removing `push` from github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: test
-
 on:
-  - "push"
   - "pull_request"
-
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Push overlaps with `pull_request` and I believe we only need the one for our current needs.