### PR TITLE
Fixing release.yml to not upload invalid artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,37 @@ jobs:
       - name: build
         run: python -m build
       - name: sign
-        uses: sigstore/gh-action-sigstore-python@v0.2.0
-        with:
-          inputs: dist/*
+        run: |
+          mkdir -p smoketest-artifacts
+
+          # we smoke-test sigstore by installing each of the distributions
+          # we've built in a fresh environment and using each to sign and
+          # verify for itself, using the ambient OIDC identity
+          for dist in dist/*; do
+            dist_base="$(basename "${dist}")"
+
+            python -m venv smoketest-env
+
+            ./smoketest-env/bin/python -m pip install "${dist}"
+
+            # NOTE: signing artifacts currently go in a separate directory,
+            # to avoid confusing the package uploader (which otherwise tries
+            # to upload them to PyPI and fails). Future versions of twine
+            # and the gh-action-pypi-publish action should support these artifacts.
+            ./smoketest-env/bin/python -m \
+              sigstore sign "${dist}" \
+              --output-signature smoketest-artifacts/"${dist_base}.sig" \
+              --output-certificate smoketest-artifacts/"${dist_base}.crt"
+
+            ./smoketest-env/bin/python -m \
+              sigstore verify identity "${dist}" \
+              --cert "smoketest-artifacts/${dist_base}.crt" \
+              --signature "smoketest-artifacts/${dist_base}.sig" \
+              --cert-oidc-issuer https://token.actions.githubusercontent.com \
+              --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/release.yml@${GITHUB_REF}
+
+            rm -rf smoketest-env
+          done
       - name: Generate hashes for provenance
         shell: bash
         id: hash


### PR DESCRIPTION
Pypi only accepts certain files. crt and sig files are unable to be uploaded. These need to be put into a different directory so they are not accidentally uploaded.