### PR TITLE
Configure Codecov to fail open

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,5 @@ coverage:
   status:
     project:
       default:
+        if_ci_failed: success
         informational: true
-


### PR DESCRIPTION
If there is a network error between GitHub Actions and Codecov, or if Codecov generates an unexpected error, this configuration change causes the Codecov action to not block the pull request. Our pull request workflow places Codecov in an informational role - we do not rely on Codecov's action to enforce rules.