### PR TITLE
Remove AllContributors usage link

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -28,6 +28,5 @@
       ]
     }
   ],
-  "contributorsPerLine": 7,
-  "linkToUsage": true
+  "contributorsPerLine": 7
 }

--- a/README.md
+++ b/README.md
@@ -76,15 +76,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center"><a href="https://github.com/fischa"><img src="https://avatars.githubusercontent.com/u/11302991?v=4?s=100" width="100px;" alt="Axel F"/><br /><sub><b>Axel F</b></sub></a><br /><a href="https://github.com/aerleon/aerleon/commits?author=fischa" title="Documentation">📖</a></td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td align="center" size="13px" colspan="7">
-        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
-          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
-        </img>
-      </td>
-    </tr>
-  </tfoot>
 </table>
 
 <!-- markdownlint-restore -->


### PR DESCRIPTION
The 'tfoot' tag is not rendered correctly in the PyPI README renderer.


<img width="623" alt="image" src="https://user-images.githubusercontent.com/212901/213312713-5c450754-7393-4f73-a80a-4f446d7e51b0.png">

Removing the 'tfoot' tag (and the usage link) should resolve the issue.