### PR TITLE
JSON Schema support for Policy, Definition YAML files

### DIFF
--- a/policies/includes/untrusted-networks-blocking.yaml
+++ b/policies/includes/untrusted-networks-blocking.yaml
@@ -1,14 +1,15 @@
 terms:
-- name: deny-from-bogons
-  comment: this is a sample edge input filter with a very very very long and
-           multi-line comment that also has multiple entries.
-  source-address: BOGON
-  action: deny
+  - name: deny-from-bogons
+    comment:
+      this is a sample edge input filter with a very very very long and
+      multi-line comment that also has multiple entries.
+    source-address: BOGON
+    action: deny
 
-- name: deny-from-reserved
-  source-address: RESERVED
-  action: deny
+  - name: deny-from-reserved
+    source-address: RESERVED
+    action: deny
 
-- name: deny-to-rfc1918
-  destination-address: RFC1918
-  action: deny
+  - name: deny-to-rfc1918
+    destination-address: RFC1918
+    action: deny

--- a/schemas/aerleon-config.schema.json
+++ b/schemas/aerleon-config.schema.json
@@ -1,0 +1,53 @@
+{
+  "$id": "urn:aerleon:schemas:aerleon-config:1.0.0",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Aerleon CLI",
+  "description": "YAML Schema for Aerleon CLI tools",
+  "type": "object",
+  "properties": {
+    "base_directory": {
+      "type": "string",
+      "description": "When using the aclgen or aclcheck programs, base_directory specifies a root directory expected to contain policy files.\n\nRelative paths used in file includes will be resolved against base_directory.\n\nBy default, aclgen will process all policy files found within base_directory and any subdirectories of base_directory. If configured with --policy_file, aclgen will only process the file or files given by that flag.",
+      "minLength": 1
+    },
+    "definitions_directory": {
+      "type": "string",
+      "description": "When using the aclgen or aclcheck programs, definitions_directory specifies a root directory expected to contain network/service definition files.\n\nBoth aclgen and aclcheck will search this directory and its subdirectories for definition files and load them into memory. These definitions will be used to resolve network and service names referenced by policy files.",
+      "minLength": 1
+    },
+    "output_directory": {
+      "type": "string",
+      "description": "When using the aclgen program, output_directory controls where generated ACL files will be placed.\n\nGenerated ACL files will be placed in the current directory if ouput_directory is not set.",
+      "minLength": 1
+    },
+    "optimize": {
+      "type": "boolean",
+      "description": "When using the aclgen program, setting optimize to true causes the program to produce a more compact address book by collapsing adjacent or overlapping CIDR expressions within the same network.\n\nOn some platforms (Juniper SRX and platforms configured with the 'object-group' option) address book compression is restricted to only collapse addresses that share the same network token (name).\n\nThis flag is not enabled by default, although an secondary address book compression pass is always performed for Juniper SRX and Palo Alto Networks firewalls regardless of this setting."
+    },
+    "recursive": {
+      "type": "boolean",
+      "description": "UNUSED. This field is not used."
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "When using the aclgen program, setting debug to true displays very detailed log messages."
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "UNUSED. This field is not used. To get detailed log messages, use 'debug'."
+    },
+    "max_renderers": {
+      "type": "integer",
+      "description": "When using the aclgen program, max_renderers controls the number of parallel processes used to render ACLs. The aclgen program uses Python's OS process-based multiprocessing, so setting max_renderers to '2' would cause aclgen to spawn two OS processes that will generate ACLs.\n\nSetting max_renderers to '1' will disable multiprocessing.\n\nBy default, max_renderers is set to '10'. Users may wish to set this to the number of available CPUs on the current system."
+    },
+    "shade_check": {
+      "type": "boolean",
+      "description": "When using the aclgen program, setting shade_check to true causes the program to produce a warning if any unreachable term is encountered."
+    },
+    "exp_info": {
+      "type": "integer",
+      "description": "When using the aclgen program, aclgen will produce a warning if it encounters a term set to expire in the near future. Expired terms are ignored. Setting exp_info controls the number of weeks ahead that aclgen will check for soon-to-expire terms.\n\nBy default, exp_info is set to '2' (two weeks)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/aerleon-definition-yaml.schema.json
+++ b/schemas/aerleon-definition-yaml.schema.json
@@ -1,7 +1,8 @@
 {
   "$id": "urn:aerleon:schemas:aerleon-definition-yaml:1.0.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "AerleonDefinitionFile2",
+  "title": "AerleonDefinitionFile",
+  "description": "An Aerleon definition file defines named networks, services, or both.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schemas/aerleon-definition-yaml.schema.json
+++ b/schemas/aerleon-definition-yaml.schema.json
@@ -1,0 +1,95 @@
+{
+  "$id": "urn:aerleon:schemas:aerleon-definition-yaml:1.0.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AerleonDefinitionFile2",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "networks": { "$ref": "#/$defs/networkDefinitionMapping" },
+    "services": { "$ref": "#/$defs/serviceDefinitionMapping" }
+  },
+  "$defs": {
+    "networkDefinitionMapping": {
+      "type": "object",
+      "title": "NetworkDefinitionMapping",
+      "additionalProperties": { "$ref": "#/$defs/networkDefinition" }
+    },
+    "networkDefinition": {
+      "type": "object",
+      "title": "NetworkDefinition",
+      "additionalProperties": false,
+      "required": ["values"],
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "title": "NetworkCompactEntry"
+              },
+              {
+                "type": "object",
+                "title": "NetworkValueEntry",
+                "required": ["address"],
+                "properties": {
+                  "address": { "type": "string" },
+                  "comment": { "type": "string" }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "title": "NetworkReferenceEntry",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "comment": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      }
+    },
+    "serviceDefinitionMapping": {
+      "type": "object",
+      "title": "ServiceDefinitionMapping",
+      "additionalProperties": { "$ref": "#/$defs/serviceDefinition" }
+    },
+    "serviceDefinition": {
+      "type": "array",
+      "title": "ServiceDefinition",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "ServiceValueEntry",
+            "required": ["port", "protocol"],
+            "properties": {
+              "port": {
+                "oneOf": [{ "type": "integer" }, { "type": "string" }]
+              },
+              "protocol": {
+                "oneOf": [{ "type": "integer" }, { "type": "string" }]
+              },
+              "comment": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "title": "ServiceReferenceEntry",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "comment": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schemas/aerleon-definition-yaml.schema.json
+++ b/schemas/aerleon-definition-yaml.schema.json
@@ -6,13 +6,13 @@
   "additionalProperties": false,
   "properties": {
     "networks": {
-      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80).\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
+      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80) and can include port ranges.\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/networkDefinition" },
       "propertyNames": { "$ref": "#/$defs/token" }
     },
     "services": {
-      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80).\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
+      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80) and can include port ranges.\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/serviceDefinition" },
       "propertyNames": { "$ref": "#/$defs/token" }

--- a/schemas/aerleon-definition-yaml.schema.json
+++ b/schemas/aerleon-definition-yaml.schema.json
@@ -1,20 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "https://aerleon.readthedocs.io/en/latest/reference/naming/",
-  "title": "AerleonDefinitionFile",
-  "description": "An Aerleon definition file defines named networks, services, or both.",
+  "title": "Aerleon Definition File",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "networks": {
+      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80).\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
       "type": "object",
-      "title": "NetworkDefinitionMapping",
       "additionalProperties": { "$ref": "#/$defs/networkDefinition" },
       "propertyNames": { "$ref": "#/$defs/token" }
     },
     "services": {
+      "description": "An Aerleon definition file defines named networks and services which can be referenced by Aerleon Policy files. Networks are lists of IP addresses or CIDR IP address ranges. Services are lists of port/protocol pairs (e.g. tcp/80).\nDefinition files must include a \"networks\" section, a \"services\" section, or both.\nNetworks and services may use composition in their definitions. Include another definition by creating an item containing the \"name\" property.",
       "type": "object",
-      "title": "ServiceDefinitionMapping",
       "additionalProperties": { "$ref": "#/$defs/serviceDefinition" },
       "propertyNames": { "$ref": "#/$defs/token" }
     }
@@ -24,42 +23,46 @@
       "type": "string",
       "pattern": "^[-_A-Z0-9]+$"
     },
+    "comment": {
+      "description": "When inserting a network or service value you can attach a comment directly to that value. The comment will be loaded and potentially included in generated output on platforms that support it.",
+      "type": "string"
+    },
+    "address": {
+      "description": "When defining a network you can insert data as a specific IP address or a CIDR IP address range expression.",
+      "type": "string"
+    },
     "networkDefinition": {
       "type": "object",
-      "title": "NetworkDefinition",
-      "description": "Defines a named network, composed of IP addresses, IP address ranges, and references to other networks.",
+      "title": "Network Definition",
+      "description": "Defines a named network, composed of IP addresses, IP address ranges, and references to other networks.\nAn object with the \"address\" property adds that address or address range to the network.\nAn object with the \"name\" property includes the contents of that network into this one.\nA single string also includes the content of that network into this one.",
       "additionalProperties": false,
       "required": ["values"],
       "properties": {
         "values": {
+          "description": "Defines a named network, composed of IP addresses, IP address ranges, and references to other networks.\nAn object with the \"address\" property adds that address or address range to the network.\nAn object with the \"name\" property includes the contents of that network into this one.\nA single string also includes the content of that network into this one.",
           "type": "array",
           "items": {
+            "description": "Defines a named network, composed of IP addresses, IP address ranges, and references to other networks.\nAn object with the \"address\" property adds that address or address range to the network.\nAn object with the \"name\" property includes the contents of that network into this one.\nA single string also includes the content of that network into this one.",
             "oneOf": [
               {
                 "type": "string",
-                "title": "CompactNetworkReference",
-                "description": "References another network.",
                 "$ref": "#/$defs/token"
               },
               {
                 "type": "object",
-                "title": "NetworkValueEntry",
-                "description": "Specifies an IP address or CIDR IP address range.",
                 "required": ["address"],
                 "properties": {
-                  "address": { "type": "string" },
-                  "comment": { "type": "string" }
+                  "address": { "$ref": "#/$defs/address" },
+                  "comment": { "$ref": "#/$defs/comment" }
                 },
                 "additionalProperties": false
               },
               {
                 "type": "object",
-                "title": "NetworkReference",
-                "description": "References another network.",
                 "required": ["name"],
                 "properties": {
                   "name": { "$ref": "#/$defs/token" },
-                  "comment": { "type": "string" }
+                  "comment": { "$ref": "#/$defs/comment" }
                 },
                 "additionalProperties": false
               }

--- a/schemas/aerleon-definition-yaml.schema.json
+++ b/schemas/aerleon-definition-yaml.schema.json
@@ -1,23 +1,33 @@
 {
-  "$id": "urn:aerleon:schemas:aerleon-definition-yaml:1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://aerleon.readthedocs.io/en/latest/reference/naming/",
   "title": "AerleonDefinitionFile",
   "description": "An Aerleon definition file defines named networks, services, or both.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "networks": { "$ref": "#/$defs/networkDefinitionMapping" },
-    "services": { "$ref": "#/$defs/serviceDefinitionMapping" }
-  },
-  "$defs": {
-    "networkDefinitionMapping": {
+    "networks": {
       "type": "object",
       "title": "NetworkDefinitionMapping",
-      "additionalProperties": { "$ref": "#/$defs/networkDefinition" }
+      "additionalProperties": { "$ref": "#/$defs/networkDefinition" },
+      "propertyNames": { "$ref": "#/$defs/token" }
+    },
+    "services": {
+      "type": "object",
+      "title": "ServiceDefinitionMapping",
+      "additionalProperties": { "$ref": "#/$defs/serviceDefinition" },
+      "propertyNames": { "$ref": "#/$defs/token" }
+    }
+  },
+  "$defs": {
+    "token": {
+      "type": "string",
+      "pattern": "^[-_A-Z0-9]+$"
     },
     "networkDefinition": {
       "type": "object",
       "title": "NetworkDefinition",
+      "description": "Defines a named network, composed of IP addresses, IP address ranges, and references to other networks.",
       "additionalProperties": false,
       "required": ["values"],
       "properties": {
@@ -27,11 +37,14 @@
             "oneOf": [
               {
                 "type": "string",
-                "title": "NetworkCompactEntry"
+                "title": "CompactNetworkReference",
+                "description": "References another network.",
+                "$ref": "#/$defs/token"
               },
               {
                 "type": "object",
                 "title": "NetworkValueEntry",
+                "description": "Specifies an IP address or CIDR IP address range.",
                 "required": ["address"],
                 "properties": {
                   "address": { "type": "string" },
@@ -41,10 +54,11 @@
               },
               {
                 "type": "object",
-                "title": "NetworkReferenceEntry",
+                "title": "NetworkReference",
+                "description": "References another network.",
                 "required": ["name"],
                 "properties": {
-                  "name": { "type": "string" },
+                  "name": { "$ref": "#/$defs/token" },
                   "comment": { "type": "string" }
                 },
                 "additionalProperties": false
@@ -54,23 +68,23 @@
         }
       }
     },
-    "serviceDefinitionMapping": {
-      "type": "object",
-      "title": "ServiceDefinitionMapping",
-      "additionalProperties": { "$ref": "#/$defs/serviceDefinition" }
-    },
     "serviceDefinition": {
       "type": "array",
       "title": "ServiceDefinition",
+      "description": "Defines a named service, composed of portocol / port pairs and references to other services.",
       "items": {
         "oneOf": [
           {
             "type": "object",
             "title": "ServiceValueEntry",
+            "description": "Describes a protocol / port pair or protocol / port range pair.",
             "required": ["port", "protocol"],
             "properties": {
               "port": {
-                "oneOf": [{ "type": "integer" }, { "type": "string" }]
+                "oneOf": [
+                  { "type": "string", "pattern": "^\\d+-\\d+|^\\d+$" },
+                  { "type": "integer" }
+                ]
               },
               "protocol": {
                 "oneOf": [{ "type": "integer" }, { "type": "string" }]
@@ -81,10 +95,11 @@
           },
           {
             "type": "object",
-            "title": "ServiceReferenceEntry",
+            "title": "ServiceReference",
+            "description": "References another service.",
             "required": ["name"],
             "properties": {
-              "name": { "type": "string" },
+              "name": { "$ref": "#/$defs/token" },
               "comment": { "type": "string" }
             },
             "additionalProperties": false

--- a/schemas/aerleon-policy-yaml.schema.json
+++ b/schemas/aerleon-policy-yaml.schema.json
@@ -2,6 +2,7 @@
   "$id": "urn:aerleon:schemas:aerleon-policy-yaml:1.0.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AerleonPolicyFile",
+  "description": "An Aerleon policy file represents a platform-agnostic network policy. It must define one or more filter objects.",
   "oneOf": [
     { "$ref": "#/$defs/policyIncludeFile" },
     { "$ref": "#/$defs/policyFile" }
@@ -10,18 +11,19 @@
     "policyFile": {
       "type": "object",
       "title": "PolicyFile",
+      "description": "A policy file contains one or more filters, where each filter has a unique list of target platforms and a unique list of terms.",
       "required": ["filters"],
       "properties": {
         "filters": {
           "type": "array",
-          "items": { "$ref": "#/$defs/filter" },
-          "description": "A policy file contains one or more filters, where each filter has a unique list of target platforms and a unique list of terms."
+          "items": { "$ref": "#/$defs/filter" }
         }
       }
     },
     "policyIncludeFile": {
       "type": "object",
       "title": "PolicyIncludeFile",
+      "description": "A policy include file only defines a list of terms. This file can be inserted into any list of terms.",
       "required": ["terms"],
       "properties": {
         "terms": {

--- a/schemas/aerleon-policy-yaml.schema.json
+++ b/schemas/aerleon-policy-yaml.schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "urn:aerleon:schemas:aerleon-policy-yaml:1.0.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PolicyFile",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/$defs/policyIncludeFile" },
+    { "$ref": "#/$defs/policyFile" }
+  ],
+  "$defs": {
+    "policyFile": {
+      "type": "object",
+      "title": "PolicyFile",
+      "required": ["filters"],
+      "properties": {
+        "filters": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/filter" },
+          "description": "A policy file contains one or more filters, where each filter has a unique list of target platforms and a unique list of terms."
+        }
+      }
+    },
+    "policyIncludeFile": {
+      "type": "object",
+      "title": "PolicyIncludeFile",
+      "required": ["terms"],
+      "properties": {
+        "terms": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/term" }
+        }
+      }
+    },
+    "filter": {
+      "type": "object",
+      "required": ["header", "terms"],
+      "header": {
+        "type": { "$ref": "#/$defs/filterHeader" }
+      },
+      "terms": {
+        "type": "list",
+        "items": { "$ref": "#/$defs/term" }
+      },
+      "additionalProperties": true
+    },
+    "filterHeader": {
+      "type": "object",
+      "title": "FilterHeader",
+      "required": ["targets"],
+      "targets": {
+        "type": "object"
+      }
+    },
+    "term": {
+      "type": "object",
+      "title": "Term",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/aerleon-policy-yaml.schema.json
+++ b/schemas/aerleon-policy-yaml.schema.json
@@ -53,9 +53,29 @@
       }
     },
     "term": {
-      "type": "object",
       "title": "Term",
-      "additionalProperties": true
+      "oneOf": [
+        {
+          "type": "object",
+          "required": "name",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": "include",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/schemas/aerleon-policy-yaml.schema.json
+++ b/schemas/aerleon-policy-yaml.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "urn:aerleon:schemas:aerleon-policy-yaml:1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "AerleonPolicyFile",
   "description": "An Aerleon policy file represents a platform-agnostic network policy. It must define one or more filter objects.",
   "oneOf": [

--- a/schemas/aerleon-policy-yaml.schema.json
+++ b/schemas/aerleon-policy-yaml.schema.json
@@ -1,8 +1,7 @@
 {
   "$id": "urn:aerleon:schemas:aerleon-policy-yaml:1.0.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "PolicyFile",
-  "type": "object",
+  "title": "AerleonPolicyFile",
   "oneOf": [
     { "$ref": "#/$defs/policyIncludeFile" },
     { "$ref": "#/$defs/policyFile" }


### PR DESCRIPTION
This PR adds JSON Schema definition files for Policy, Policy Include, and Definition YAML files.

This first pass targets editor and validation scenarios. We would like users to be able to get immediate inline errors in their editors when viewing non-conforming YAML files. These schema files should also be useful in validation workflows, either for manual validation or CI/CD, git pre-commit, or automation scenario.

This PR does NOT integrate the JSON Schemas into the actual application. This might be an interesting topic of discussion - on one hand using the schema in the application helps ensure the schema never drifts from the application behavior, but a tight clamp on the performance characteristics of the validation code (startup and per-file) would be key.

![image](https://user-images.githubusercontent.com/212901/213630694-e5070c86-1df9-4479-ba65-e4e39191cec6.png)

**Status of this PR**

Seeking input.

I would like to look at providing some kind of editor config files (e.g. settings.json or example.settings.json) that would help users to map these schemas to their input files correctly. The mapping problem might require some discussion - on one hand we could re-introduce multi-part names like ".policy.yaml" so that VSCode (specifically [this YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) can pick up mappings directly from [JSON Schema Store](https://www.schemastore.org/json/) . Alternatively just including the files in the repo with an example file might be pretty good.