### PR TITLE
(re)format all code with black/isort

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: test
+name: validate
 on:
   pull_request:
     paths-ignore:
@@ -83,3 +83,10 @@ jobs:
           flags: tests
           name: codecov-umbrella
           verbose: true
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+      - uses: isort/isort-action@v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ Writing code can include adding new features or fixing issues that have been rep
 ## Code Style and Formatting
 We have adopted [Black](https://github.com/ambv/black) as our code formatter. This takes a lot of guesswork out of formatting our code. The code we forked from adopted the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) which we still adopt where it does not conflict with Black. Generally this means following the [Language Rules](https://google.github.io/styleguide/pyguide.html#s2-python-language-rules) while ignoring the [Style Rules](https://google.github.io/styleguide/pyguide.html#s3-python-style-rules)
 
+In additiona to Black [isort](https://pycqa.github.io/isort/) as been added to sort and format import lines.
+
+It is a good idea to configure auto formatting on save in your editor:
+
+* black: https://black.readthedocs.io/en/stable/integrations/editors.html
+* isort: https://github.com/pycqa/isort/wiki/isort-Plugins
+
 ## Testing
 ```
 poetry run pytest

--- a/aclcheck_cmdline.py
+++ b/aclcheck_cmdline.py
@@ -18,37 +18,53 @@
 
 from optparse import OptionParser
 
-from aerleon.lib import aclcheck
-from aerleon.lib import naming
-from aerleon.lib import policy
+from aerleon.lib import aclcheck, naming, policy
 
 
 def main():
-  # TODO(robankeny): Lets move this to gflags
-  usage = 'usage: %prog [options] arg'
-  _parser = OptionParser(usage)
-  _parser.add_option('--definitions-directory', dest='definitions',
-                     help='definitions directory', default='./def')
-  _parser.add_option('-p', '--policy-file', dest='pol',
-                     help='policy file', default='./policies/sample.pol')
-  _parser.add_option('-d', '--destination', dest='dst',
-                     help='destination IP', default='200.1.1.1')
-  _parser.add_option('-s', '--source', dest='src',
-                     help='source IP', default='any')
-  _parser.add_option('--proto', '--protocol', dest='proto',
-                     help='Protocol (tcp, udp, icmp, etc.)', default='tcp')
-  _parser.add_option('--dport', '--destination-port', dest='dport',
-                     help='destination port', default='80')
-  _parser.add_option('--sport', '--source-port', dest='sport',
-                     help='source port', default='1025')
-  (FLAGS, unused_args) = _parser.parse_args()
+    # TODO(robankeny): Lets move this to gflags
+    usage = 'usage: %prog [options] arg'
+    _parser = OptionParser(usage)
+    _parser.add_option(
+        '--definitions-directory',
+        dest='definitions',
+        help='definitions directory',
+        default='./def',
+    )
+    _parser.add_option(
+        '-p', '--policy-file', dest='pol', help='policy file', default='./policies/sample.pol'
+    )
+    _parser.add_option(
+        '-d', '--destination', dest='dst', help='destination IP', default='200.1.1.1'
+    )
+    _parser.add_option('-s', '--source', dest='src', help='source IP', default='any')
+    _parser.add_option(
+        '--proto',
+        '--protocol',
+        dest='proto',
+        help='Protocol (tcp, udp, icmp, etc.)',
+        default='tcp',
+    )
+    _parser.add_option(
+        '--dport', '--destination-port', dest='dport', help='destination port', default='80'
+    )
+    _parser.add_option(
+        '--sport', '--source-port', dest='sport', help='source port', default='1025'
+    )
+    (FLAGS, unused_args) = _parser.parse_args()
 
-  defs = naming.Naming(FLAGS.definitions)
-  policy_obj = policy.ParsePolicy(open(FLAGS.pol).read(), defs)
-  check = aclcheck.AclCheck(policy_obj, src=FLAGS.src, dst=FLAGS.dst,
-                            sport=FLAGS.sport, dport=FLAGS.dport,
-                            proto=FLAGS.proto)
-  print(str(check))
+    defs = naming.Naming(FLAGS.definitions)
+    policy_obj = policy.ParsePolicy(open(FLAGS.pol).read(), defs)
+    check = aclcheck.AclCheck(
+        policy_obj,
+        src=FLAGS.src,
+        dst=FLAGS.dst,
+        sport=FLAGS.sport,
+        dport=FLAGS.dport,
+        proto=FLAGS.proto,
+    )
+    print(str(check))
+
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -21,14 +21,9 @@ import pathlib
 import sys
 from typing import Iterator, List, Tuple
 
-from absl import app
-from absl import flags
-from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import naming
-from aerleon.lib import plugin_supervisor
-from aerleon.lib import policy
-from aerleon.lib import yaml
+from absl import app, flags, logging
+
+from aerleon.lib import aclgenerator, naming, plugin_supervisor, policy, yaml
 from aerleon.utils import config
 
 FLAGS = flags.FLAGS
@@ -352,6 +347,7 @@ def DescendDirectory(input_dirname: str, ignore_directories: List[str]) -> List[
         lambda path: path.is_dir(), input_dir.glob('**/pol')
     )
     for ignored_directory in ignore_directories:
+
         def Filtering(path, ignored=ignored_directory):
             return not path.match('%s/**/pol' % ignored) and not path.match('%s/pol' % ignored)
 

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -179,13 +179,14 @@ import typing
 
 from absl import logging
 
-from aerleon.aclgen import ACLParserError, ACLGeneratorError, RenderACL, WriteFiles, WriteList
-
-from aerleon.lib import aclgenerator
-from aerleon.lib import naming
-from aerleon.lib import plugin_supervisor
-from aerleon.lib import policy
-from aerleon.lib import policy_builder
+from aerleon.aclgen import (
+    ACLGeneratorError,
+    ACLParserError,
+    RenderACL,
+    WriteFiles,
+    WriteList,
+)
+from aerleon.lib import aclgenerator, naming, plugin_supervisor, policy, policy_builder
 
 
 def Generate(

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -26,258 +26,285 @@
 __author__ = 'watson@google.com (Tony Watson)'
 
 import sys
-from aerleon.lib import nacaddr
-from aerleon.lib import policy
-from aerleon.lib import port
+
+from aerleon.lib import nacaddr, policy, port
 
 
 class Error(Exception):
-  """Base error class."""
+    """Base error class."""
 
 
 class AddressError(Error):
-  """Incorrect IP address or format."""
+    """Incorrect IP address or format."""
 
 
 class BadPolicy(Error):
-  """Item is not a valid policy object."""
+    """Item is not a valid policy object."""
 
 
 class NoTargetError(Error):
-  """Specified target platform not available in specified policy."""
+    """Specified target platform not available in specified policy."""
 
 
 class AclCheck(object):
-  """Check where hosts, ports and protocols match in a NAC policy.
-
-  Args:
-    pol:
-      policy.Policy object
-    src:
-      string, the source address
-    dst:
-      string: the destination address.
-    dport:
-      string, the destination port.
-    sport:
-      string, the source port.
-    proto:
-      string, the protocol.
-
-  Returns:
-    An AclCheck Object
-
-  Raises:
-    port.BarPortValue: An invalid source port is used
-    port.BadPortRange: A port is outside of the acceptable range 0-65535
-    AddressError: Incorrect ip address or format
-
-  """
-
-  def __init__(self,
-               pol,
-               src='any',
-               dst='any',
-               sport='any',
-               dport='any',
-               proto='any',
-              ):
-
-    self.pol_obj = pol
-    self.proto = proto
-
-    # validate source port
-    if sport == 'any':
-      self.sport = sport
-    else:
-      self.sport = port.Port(sport)
-
-    # validate destination port
-    if dport == 'any':
-      self.dport = sport
-    else:
-      self.dport = port.Port(dport)
-
-    # validate source address
-    if src == 'any':
-      self.src = src
-    else:
-      try:
-        self.src = nacaddr.IP(src)
-      except ValueError:
-        raise AddressError('bad source address: %s\n' % src)
-
-    # validate destination address
-    if dst == 'any':
-      self.dst = dst
-    else:
-      try:
-        self.dst = nacaddr.IP(dst)
-      except ValueError:
-        raise AddressError('bad destination address: %s\n' % dst)
-
-    if type(self.pol_obj) is not policy.Policy:
-      raise BadPolicy('Policy object is not valid.')
-
-    self.matches = []
-    self.exact_matches = []
-    for header, terms in self.pol_obj.filters:
-      filtername = header.target[0].options[0]
-      for term in terms:
-        possible = []
-
-        if self._AddrInside(self.src, term.source_address):
-          if self._AddrInside(self.dst, term.destination_address):
-            if (self.sport == 'any' or not term.source_port or
-                self._PortInside(self.sport, term.source_port)):
-              if (self.dport == 'any' or not term.destination_port or
-                  self._PortInside(self.dport, term.destination_port)):
-                if (self.proto == 'any' or not term.protocol or
-                    self.proto in term.protocol):
-
-                  possible = self._PossibleMatch(term)
-                  if term.action:  # avoid any verbatim
-                    self.matches.append(Match(filtername, term.name, possible,
-                                              term.action, term.qos))
-
-                    # so if we get here then we have a match, and if the action
-                    # isn't next and there are no possibles, then this is a
-                    # "definite" match and we needn't look for any further
-                    # matches (i.e. later terms may match, but since we'll never
-                    # get there we shouldn't report them)
-                    if 'next' not in term.action and not possible:
-                      self.exact_matches.append(Match(filtername, term.name, [],
-                                                      term.action, term.qos))
-                      break
-
-  def Matches(self):
-    """Return list of matched terms."""
-    return self.matches
-
-  def ExactMatches(self):
-    """Return matched terms, but not terms with possibles or action next."""
-    return self.exact_matches
-
-  def ActionMatch(self, action='any'):
-    """Return list of matched terms with specified actions."""
-    match_list = []
-    for next in self.matches:
-      if next.action:
-        if not next.possibles:
-          if action is 'any' or action in next.action:
-            match_list.append(next)
-    return match_list
-
-  def DescribeMatches(self):
-    """Provide sentence descriptions of matches.
-
-    Returns:
-      ret_str: text sentences describing matches
-    """
-    ret_str = []
-    for next in self.matches:
-      text = str(next)
-      ret_str.append(text)
-    return '\n'.join(ret_str)
-
-  def __str__(self):
-    text = []
-    last_filter = ''
-    for next in self.matches:
-      if next.filter != last_filter:
-        last_filter = next.filter
-        text.append('  filter: ' + next.filter)
-      if next.possibles:
-        text.append(' ' * 10 + 'term: ' + next.term + ' (possible match)')
-      else:
-        text.append(' ' * 10 + 'term: ' + next.term)
-      if next.possibles:
-        text.append(' ' * 16 + next.action + ' if ' + str(next.possibles))
-      else:
-        text.append(' ' * 16 + next.action)
-    return '\n'.join(text)
-
-  def _PossibleMatch(self, term):
-    """Ignore some options and keywords that are edge cases.
+    """Check where hosts, ports and protocols match in a NAC policy.
 
     Args:
-      term: term object to examine for edge-cases
+      pol:
+        policy.Policy object
+      src:
+        string, the source address
+      dst:
+        string: the destination address.
+      dport:
+        string, the destination port.
+      sport:
+        string, the source port.
+      proto:
+        string, the protocol.
 
     Returns:
-      ret_str: a list of reasons this term may possible match
+      An AclCheck Object
+
+    Raises:
+      port.BarPortValue: An invalid source port is used
+      port.BadPortRange: A port is outside of the acceptable range 0-65535
+      AddressError: Incorrect ip address or format
+
     """
-    ret_str = []
-    if 'first-fragment' in term.option:
-      ret_str.append('first-frag')
-    if term.fragment_offset:
-      ret_str.append('frag-offset')
-    if term.packet_length:
-      ret_str.append('packet-length')
-    if 'established' in term.option:
-      ret_str.append('est')
-    if 'tcp-established' in term.option and 'tcp' in term.protocol:
-      ret_str.append('tcp-est')
-    return ret_str
 
-  def _AddrInside(self, addr, addresses):
-    """Check if address is matched in another address or group of addresses.
+    def __init__(
+        self,
+        pol,
+        src='any',
+        dst='any',
+        sport='any',
+        dport='any',
+        proto='any',
+    ):
 
-    Args:
-      addr: An ipaddr network or host address or text 'any'
-      addresses: A list of ipaddr network or host addresses
+        self.pol_obj = pol
+        self.proto = proto
 
-    Returns:
-      bool: True of false
-    """
-    if addr is 'any': return True   # always true if we match for any addr
-    if not addresses: return True   # always true if term has nothing to match
-    for next in addresses:
-      # ipaddr can incorrectly report ipv4 as contained with ipv6 addrs
-      if type(addr) is type(next):
-        if addr in next:
-          return True
-    return False
+        # validate source port
+        if sport == 'any':
+            self.sport = sport
+        else:
+            self.sport = port.Port(sport)
 
-  def _PortInside(self, myport, port_list):
-    """Check if port matches in a port or group of ports.
+        # validate destination port
+        if dport == 'any':
+            self.dport = sport
+        else:
+            self.dport = port.Port(dport)
 
-    Args:
-      myport: port number
-      port_list: list of ports
+        # validate source address
+        if src == 'any':
+            self.src = src
+        else:
+            try:
+                self.src = nacaddr.IP(src)
+            except ValueError:
+                raise AddressError('bad source address: %s\n' % src)
 
-    Returns:
-      bool: True of false
-    """
-    if myport == 'any': return True
-    if [x for x in port_list if x[0] <= myport <= x[1]]:
-      return True
-    return False
+        # validate destination address
+        if dst == 'any':
+            self.dst = dst
+        else:
+            try:
+                self.dst = nacaddr.IP(dst)
+            except ValueError:
+                raise AddressError('bad destination address: %s\n' % dst)
+
+        if type(self.pol_obj) is not policy.Policy:
+            raise BadPolicy('Policy object is not valid.')
+
+        self.matches = []
+        self.exact_matches = []
+        for header, terms in self.pol_obj.filters:
+            filtername = header.target[0].options[0]
+            for term in terms:
+                possible = []
+
+                if self._AddrInside(self.src, term.source_address):
+                    if self._AddrInside(self.dst, term.destination_address):
+                        if (
+                            self.sport == 'any'
+                            or not term.source_port
+                            or self._PortInside(self.sport, term.source_port)
+                        ):
+                            if (
+                                self.dport == 'any'
+                                or not term.destination_port
+                                or self._PortInside(self.dport, term.destination_port)
+                            ):
+                                if (
+                                    self.proto == 'any'
+                                    or not term.protocol
+                                    or self.proto in term.protocol
+                                ):
+
+                                    possible = self._PossibleMatch(term)
+                                    if term.action:  # avoid any verbatim
+                                        self.matches.append(
+                                            Match(
+                                                filtername,
+                                                term.name,
+                                                possible,
+                                                term.action,
+                                                term.qos,
+                                            )
+                                        )
+
+                                        # so if we get here then we have a match, and if the action
+                                        # isn't next and there are no possibles, then this is a
+                                        # "definite" match and we needn't look for any further
+                                        # matches (i.e. later terms may match, but since we'll never
+                                        # get there we shouldn't report them)
+                                        if 'next' not in term.action and not possible:
+                                            self.exact_matches.append(
+                                                Match(
+                                                    filtername,
+                                                    term.name,
+                                                    [],
+                                                    term.action,
+                                                    term.qos,
+                                                )
+                                            )
+                                            break
+
+    def Matches(self):
+        """Return list of matched terms."""
+        return self.matches
+
+    def ExactMatches(self):
+        """Return matched terms, but not terms with possibles or action next."""
+        return self.exact_matches
+
+    def ActionMatch(self, action='any'):
+        """Return list of matched terms with specified actions."""
+        match_list = []
+        for next in self.matches:
+            if next.action:
+                if not next.possibles:
+                    if action is 'any' or action in next.action:
+                        match_list.append(next)
+        return match_list
+
+    def DescribeMatches(self):
+        """Provide sentence descriptions of matches.
+
+        Returns:
+          ret_str: text sentences describing matches
+        """
+        ret_str = []
+        for next in self.matches:
+            text = str(next)
+            ret_str.append(text)
+        return '\n'.join(ret_str)
+
+    def __str__(self):
+        text = []
+        last_filter = ''
+        for next in self.matches:
+            if next.filter != last_filter:
+                last_filter = next.filter
+                text.append('  filter: ' + next.filter)
+            if next.possibles:
+                text.append(' ' * 10 + 'term: ' + next.term + ' (possible match)')
+            else:
+                text.append(' ' * 10 + 'term: ' + next.term)
+            if next.possibles:
+                text.append(' ' * 16 + next.action + ' if ' + str(next.possibles))
+            else:
+                text.append(' ' * 16 + next.action)
+        return '\n'.join(text)
+
+    def _PossibleMatch(self, term):
+        """Ignore some options and keywords that are edge cases.
+
+        Args:
+          term: term object to examine for edge-cases
+
+        Returns:
+          ret_str: a list of reasons this term may possible match
+        """
+        ret_str = []
+        if 'first-fragment' in term.option:
+            ret_str.append('first-frag')
+        if term.fragment_offset:
+            ret_str.append('frag-offset')
+        if term.packet_length:
+            ret_str.append('packet-length')
+        if 'established' in term.option:
+            ret_str.append('est')
+        if 'tcp-established' in term.option and 'tcp' in term.protocol:
+            ret_str.append('tcp-est')
+        return ret_str
+
+    def _AddrInside(self, addr, addresses):
+        """Check if address is matched in another address or group of addresses.
+
+        Args:
+          addr: An ipaddr network or host address or text 'any'
+          addresses: A list of ipaddr network or host addresses
+
+        Returns:
+          bool: True of false
+        """
+        if addr is 'any':
+            return True  # always true if we match for any addr
+        if not addresses:
+            return True  # always true if term has nothing to match
+        for next in addresses:
+            # ipaddr can incorrectly report ipv4 as contained with ipv6 addrs
+            if type(addr) is type(next):
+                if addr in next:
+                    return True
+        return False
+
+    def _PortInside(self, myport, port_list):
+        """Check if port matches in a port or group of ports.
+
+        Args:
+          myport: port number
+          port_list: list of ports
+
+        Returns:
+          bool: True of false
+        """
+        if myport == 'any':
+            return True
+        if [x for x in port_list if x[0] <= myport <= x[1]]:
+            return True
+        return False
 
 
 class Match(object):
-  """A matching term and its associate values."""
+    """A matching term and its associate values."""
 
-  def __init__(self, filtername, term, possibles, action, qos=None):
-    self.filter = filtername
-    self.term = term
-    self.possibles = possibles
-    self.action = action[0]
-    self.qos = qos
+    def __init__(self, filtername, term, possibles, action, qos=None):
+        self.filter = filtername
+        self.term = term
+        self.possibles = possibles
+        self.action = action[0]
+        self.qos = qos
 
-  def __str__(self):
-    text = ''
-    if self.possibles:
-      text += 'possible ' + self.action
-    else:
-      text += self.action
-    text += ' in term ' + self.term + ' of filter ' + self.filter
-    if self.possibles:
-      text += ' with factors: ' + str(', '.join(self.possibles))
-    return text
+    def __str__(self):
+        text = ''
+        if self.possibles:
+            text += 'possible ' + self.action
+        else:
+            text += self.action
+        text += ' in term ' + self.term + ' of filter ' + self.filter
+        if self.possibles:
+            text += ' with factors: ' + str(', '.join(self.possibles))
+        return text
 
 
 def main(_):
-  pass
+    pass
+
 
 if __name__ == '__main__':
-  main(sys.argv)
+    main(sys.argv)

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -17,12 +17,12 @@
 """ACL Generator base class."""
 
 import copy
+import hashlib
 import logging
 import re
 import string
 
 from aerleon.lib import policy
-import hashlib
 
 
 # generic error class

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -5,10 +5,10 @@ import itertools
 
 
 class Addressbook:
-  def __init__(self):
-    self.addressbook = collections.OrderedDict()
+    def __init__(self):
+        self.addressbook = collections.OrderedDict()
 
-  def AddAddresses(self, zone, address_list):
+    def AddAddresses(self, zone, address_list):
         """Create the address book configuration entries.
 
         Args:

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -20,6 +20,7 @@ import datetime
 import re
 
 from absl import logging
+
 from aerleon.lib import aclgenerator
 
 #          1         2         3
@@ -923,7 +924,14 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                     new_terms.append(self._TERM(term, ft, noverbose))
 
             self.arista_traffic_policies.append(
-                (header, filter_name, filter_type, new_terms, sorted(policy_counters), policy_field_sets)
+                (
+                    header,
+                    filter_name,
+                    filter_type,
+                    new_terms,
+                    sorted(policy_counters),
+                    policy_field_sets,
+                )
             )
 
     def __str__(self):

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -18,7 +18,6 @@
 
 import datetime
 import logging
-
 from typing import List, Tuple
 
 from aerleon.lib import aclgenerator
@@ -197,7 +196,7 @@ class Term(aclgenerator.Term):
 
         return '%s %s %s' % (self._NETWORK_STRING, address.network_address, address.netmask)
 
-    def _GeneratePortTokens(self, protocols:List[str], ports:List[Tuple[int, int]]):
+    def _GeneratePortTokens(self, protocols: List[str], ports: List[Tuple[int, int]]):
         """Generates string tokens for ports.
 
         Args:
@@ -212,7 +211,9 @@ class Term(aclgenerator.Term):
             if protocol in self._PROTOCOL_MAP:
                 return [str(self._PROTOCOL_MAP[protocol])]
             for start_port, end_port in sorted(ports):
-                ret_ports.append(f'{protocol.lower()} {start_port}{" " + str(end_port) if start_port != end_port else ""}')
+                ret_ports.append(
+                    f'{protocol.lower()} {start_port}{" " + str(end_port) if start_port != end_port else ""}'
+                )
         return ret_ports
 
 

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -18,14 +18,11 @@
 
 import datetime
 import ipaddress
-from typing import cast, Union
+from typing import Union, cast
 
 from absl import logging
-from aerleon.lib import addressbook
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import summarizer
 
+from aerleon.lib import aclgenerator, addressbook, nacaddr, summarizer
 
 _ACTION_TABLE = {
     'accept': 'permit',
@@ -254,16 +251,16 @@ class ObjectGroup:
         netgroups = set()
         ports = {}
 
-            # I don't have an easy way get the token name used in the pol file
-            # w/o reading the pol file twice (with some other library) or doing
-            # some other ugly hackery. Instead, the entire block of source and dest
-            # addresses for a given term is given a unique, computable name which
-            # is not related to the NETWORK.net token name.  that's what you get
-            # for using cisco, which has decided to implement its own meta language.
+        # I don't have an easy way get the token name used in the pol file
+        # w/o reading the pol file twice (with some other library) or doing
+        # some other ugly hackery. Instead, the entire block of source and dest
+        # addresses for a given term is given a unique, computable name which
+        # is not related to the NETWORK.net token name.  that's what you get
+        # for using cisco, which has decided to implement its own meta language.
 
-            # Create network object-groups
+        # Create network object-groups
         for name, ips in self.addressbook.addressbook[''].items():
-            for version in (4,6):
+            for version in (4, 6):
                 vips = [i for i in ips if i.version == version]
                 if vips:
 
@@ -322,7 +319,7 @@ class PortMap:
         110: 'pop3',
         1723: 'pptp',
         554: 'rtsp',
-        5060:'sip',
+        5060: 'sip',
         25: 'smtp',
         22: 'ssh',
         111: 'sunrpc',
@@ -350,7 +347,7 @@ class PortMap:
         123: 'ntp',
         496: 'pim-auto-rp',
         520: 'rip',
-        5060:'sip',
+        5060: 'sip',
         161: 'snmp',
         162: 'snmptrap',
         111: 'sunrpc',

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -22,11 +22,7 @@ import logging
 import re
 from typing import cast
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import cisco
-from aerleon.lib import nacaddr
-from aerleon.lib import summarizer
-
+from aerleon.lib import aclgenerator, cisco, nacaddr, summarizer
 
 _ACTION_TABLE = {
     'accept': 'permit',

--- a/aerleon/lib/cisconx.py
+++ b/aerleon/lib/cisconx.py
@@ -15,8 +15,7 @@
 #
 """CiscoNX generator."""
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import cisco
+from aerleon.lib import aclgenerator, cisco
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -27,11 +27,9 @@ import ipaddress
 import json
 import logging
 import re
+from typing import Any, Dict
 
-from typing import Dict, Any
-
-from aerleon.lib import gcp
-from aerleon.lib import nacaddr
+from aerleon.lib import gcp, nacaddr
 
 
 class Error(gcp.Error):

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -7,12 +7,11 @@ Hierarchical Firewalls (HF) are represented in a SecurityPolicy GCP resouce.
 
 import copy
 import re
-
-from typing import Dict, Any
+from typing import Any, Dict
 
 from absl import logging
-from aerleon.lib import gcp
-from aerleon.lib import nacaddr
+
+from aerleon.lib import gcp, nacaddr
 
 
 class ExceededCostError(gcp.Error):

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -23,8 +23,7 @@ performace of iptables firewall.
 
 import string
 
-from aerleon.lib import iptables
-from aerleon.lib import nacaddr
+from aerleon.lib import iptables, nacaddr
 
 
 class Error(iptables.Error):

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -21,8 +21,8 @@ import re
 from string import Template  # pylint: disable=g-importing-member
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
+
+from aerleon.lib import aclgenerator, nacaddr
 
 
 class Term(aclgenerator.Term):
@@ -231,7 +231,7 @@ class Term(aclgenerator.Term):
         # icmp-types
         icmp_types = ['']
         if self.term.icmp_type:
-            
+
             icmp_types = self.NormalizeIcmpTypes(self.term.icmp_type, protocol, self.af)
 
         source_interface = ''

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -17,10 +17,10 @@
 """Juniper JCL generator."""
 
 import datetime
+
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import summarizer
+
+from aerleon.lib import aclgenerator, nacaddr, summarizer
 
 
 # generic error class

--- a/aerleon/lib/juniperevo.py
+++ b/aerleon/lib/juniperevo.py
@@ -20,8 +20,7 @@ uses the same syntax as regular Juniper (Junos) ACLs, with minor differences.
 This subclass effects those differences.
 """
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import juniper
+from aerleon.lib import aclgenerator, juniper
 
 
 class Term(juniper.Term):

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -18,9 +18,7 @@
 import datetime
 import logging
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import juniper
-from aerleon.lib import nacaddr
+from aerleon.lib import aclgenerator, juniper, nacaddr
 
 MAX_IDENTIFIER_LEN = 55  # It is really 63, but leaving room for added chars
 

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -26,10 +26,8 @@ import ipaddress
 import itertools
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import addressbook
 
+from aerleon.lib import aclgenerator, addressbook, nacaddr
 
 ICMP_TERM_LIMIT = 8
 

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -25,8 +25,9 @@ import datetime
 import logging
 import re
 
-from aerleon.lib import aclgenerator
 import yaml
+
+from aerleon.lib import aclgenerator
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -46,18 +46,17 @@ DNS = 53/tcp
 """
 
 
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Tuple
-import yaml
-from yaml import YAMLError
 
+import yaml
 from absl import logging
+from yaml import YAMLError
 
 from aerleon.lib import nacaddr
 from aerleon.lib import port as portlib
 from aerleon.lib.yaml_loader import SpanSafeYamlLoader
-
 
 DEF_TYPE_SERVICES = 'services'
 DEF_TYPE_NETWORKS = 'networks'

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -20,8 +20,7 @@ import copy
 import datetime
 import logging
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
+from aerleon.lib import aclgenerator, nacaddr
 
 # NFTables and Aerleon have conflicting definitions of 'address family'
 # In Aerleon:

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -21,9 +21,8 @@ import re
 import xml
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
 
+from aerleon.lib import aclgenerator, nacaddr
 
 _ACTION_TABLE = {
     'accept': 'allow',

--- a/aerleon/lib/openconfig.py
+++ b/aerleon/lib/openconfig.py
@@ -26,11 +26,10 @@ import ipaddress
 import json
 import logging
 import re
-
-from typing import Dict, Any
+from collections import defaultdict
+from typing import Any, Dict
 
 from aerleon.lib import aclgenerator
-from collections import defaultdict
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -22,8 +22,8 @@ import datetime
 from typing import cast
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
+
+from aerleon.lib import aclgenerator, nacaddr
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -19,12 +19,10 @@ import copy
 import datetime
 import logging
 import re
-from xml.dom import minidom
 import xml.etree.ElementTree as etree
-from aerleon.lib import aclgenerator
-from aerleon.lib import addressbook
-from aerleon.lib import nacaddr
-from aerleon.lib import policy
+from xml.dom import minidom
+
+from aerleon.lib import aclgenerator, addressbook, nacaddr, policy
 
 
 class Error(aclgenerator.Error):
@@ -889,7 +887,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         address_book_names_dict = {}
         address_book_groups_dict = {}
         try:
-          groups = sorted(self.addressbook.addressbook[''].keys())
+            groups = sorted(self.addressbook.addressbook[''].keys())
         except:
             groups = []
         for group in groups:
@@ -906,7 +904,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
             # building individual address-group dictionary
             for nested_group in groups:
                 group_names = [i for i in address_book_names_dict.keys() if nested_group in i]
-                
+
                 address_book_groups_dict[nested_group] = group_names
 
         # sort address books and address sets
@@ -916,7 +914,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         address_book_keys = sorted(
             list(address_book_names_dict.keys()), key=self._SortAddressBookNumCheck
         )
-        
+
         # INITAL CONFIG
         config = etree.Element("config", {"urldb": "paloaltonetworks", "version": "8.1.0"})
         devices = etree.SubElement(config, "devices")
@@ -1173,7 +1171,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
 
         vsys_entry.append(etree.Comment(" Addresses "))
         addr = etree.SubElement(vsys_entry, "address")
-        
+
         for name in address_book_keys:
             entry = etree.SubElement(addr, "entry", {"name": name})
             desc = etree.SubElement(entry, "description")

--- a/aerleon/lib/pcap.py
+++ b/aerleon/lib/pcap.py
@@ -31,6 +31,7 @@ Stolen liberally from packetfilter.py.
 import datetime
 
 from absl import logging
+
 from aerleon.lib import aclgenerator
 
 

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -41,11 +41,11 @@ undocumented and subject to change.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from importlib import import_module
 import importlib.util
 import pathlib
 import sys
+from dataclasses import dataclass
+from importlib import import_module
 from typing import Tuple
 
 if sys.version_info < (3, 10):
@@ -174,7 +174,7 @@ class _PluginSetup:
     disable_plugin: list[str] = None
     disable_builtin: list[str] = None
     include_path: list[list[str]] = None
-    
+
     def __init__(self, config: PluginSupervisorConfiguration = None):
         """Initialize self.generators, self.plugins."""
 
@@ -284,7 +284,9 @@ class _PluginSetup:
         """Import built-in modules by name."""
         loaded_generators = []
         for target, module_name, class_or_func in builtin_generators:
-            if self.disable_builtin and (module_name in self.disable_builtin or target in self.disable_builtin):
+            if self.disable_builtin and (
+                module_name in self.disable_builtin or target in self.disable_builtin
+            ):
                 continue
             try:
                 module = import_module(module_name)

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -24,11 +24,9 @@ import sys
 from typing import TYPE_CHECKING
 
 from absl import logging
-from ply import lex
-from ply import yacc
+from ply import lex, yacc
 
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
+from aerleon.lib import nacaddr, naming
 
 if TYPE_CHECKING:
     from aerleon.lib.policy_builder import PolicyBuilder

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -1,32 +1,32 @@
 """Builds Policy objects from a plain Python object representation."""
 
-from dataclasses import dataclass, field
 import enum
-import typing
 import sys
+import typing
+from dataclasses import dataclass, field
 
 from absl import logging
 
 from aerleon.lib.policy import (
-    Policy,
+    FLEXIBLE_MATCH_RANGE_ATTRIBUTES,
+    FLEXIBLE_MATCH_START_OPTIONS,
     Header,
+    Policy,
     Target,
     Term,
     VarType,
-    FLEXIBLE_MATCH_RANGE_ATTRIBUTES,
-    FLEXIBLE_MATCH_START_OPTIONS,
 )
 from aerleon.lib.recognizers import (
     RecognizerContext,
     RecognizerKeywordResult,
     RecognizerValueResult,
-    TValue,
     TComposition,
     TList,
-    TSection,
-    TUnion,
     TListStr,
     TListStrCollapsible,
+    TSection,
+    TUnion,
+    TValue,
 )
 
 if sys.version_info < (3, 9):

--- a/aerleon/lib/recognizers.py
+++ b/aerleon/lib/recognizers.py
@@ -18,11 +18,11 @@ This class uses recognizers to parse, validate and normalize all built-in fields
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 import datetime
 import enum
 import re
 import typing
+from dataclasses import dataclass
 
 if typing.TYPE_CHECKING:
     from aerleon.lib.policy_builder import (

--- a/aerleon/lib/speedway.py
+++ b/aerleon/lib/speedway.py
@@ -18,6 +18,7 @@
 """Speedway iptables generator.  This is a subclass of Iptables lib."""
 
 from string import Template
+
 from aerleon.lib import iptables
 
 

--- a/aerleon/lib/windows.py
+++ b/aerleon/lib/windows.py
@@ -20,9 +20,8 @@ import datetime
 import string
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
 
+from aerleon.lib import aclgenerator, nacaddr
 
 CMD_PREFIX = 'netsh ipsec static add '
 

--- a/aerleon/lib/windows_ipsec.py
+++ b/aerleon/lib/windows_ipsec.py
@@ -20,8 +20,8 @@
 from string import Template
 
 from absl import logging
-from aerleon.lib import aclgenerator
-from aerleon.lib import windows
+
+from aerleon.lib import aclgenerator, windows
 
 
 class Term(windows.Term):

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -2,10 +2,10 @@
 
 import pathlib
 from typing import Tuple
-import yaml
-from yaml.error import YAMLError
 
+import yaml
 from absl import logging
+from yaml.error import YAMLError
 
 from aerleon.lib import policy
 from aerleon.lib.policy_builder import (

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,10 @@
 """ Define nox sessions for Aerleon """
 
-from datetime import datetime
 import os
+from datetime import datetime
 
 import nox
-from nox_poetry import session, Session
-
+from nox_poetry import Session, session
 
 nox.options.error_on_missing_interpreters = False
 nox.options.reuse_existing_virtualenvs = True
@@ -67,7 +66,7 @@ def benchmark(session):
         session.run(
             "python",
             "-c",
-            f"with open('{os.path.join(benchmark_result_path, result_meta_filename)}', 'x') as file: print('file={result_filename} suite_name={suite_name} tune_system={tune_system} start_time={start_time} end_time={end_time} posargs={session.posargs}', file=file)", # noqa E501
+            f"with open('{os.path.join(benchmark_result_path, result_meta_filename)}', 'x') as file: print('file={result_filename} suite_name={suite_name} tune_system={tune_system} start_time={start_time} end_time={end_time} posargs={session.posargs}', file=file)",  # noqa E501
         )
 
     if tune_system:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ exclude = '''
 )
 '''
 
+[tool.isort]
+profile = "black"
+
 [tool.flake8]
 max-complexity = 10
 max-line-length = 99

--- a/tests/api/api_test.py
+++ b/tests/api/api_test.py
@@ -1,4 +1,5 @@
 import re
+
 from absl.testing import absltest
 
 from aerleon import api

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -15,13 +15,11 @@
 
 """Unittest for ACL rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, naming, policy
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/lib/builtins_test.py
+++ b/tests/lib/builtins_test.py
@@ -2,12 +2,7 @@ import datetime
 
 from absl.testing import absltest, parameterized
 
-from aerleon.lib.recognizers import (
-    TValue,
-    TList,
-    TUnion,
-    TSection,
-)
+from aerleon.lib.recognizers import TList, TSection, TUnion, TValue
 
 
 class PrebuiltRecognizerTest(parameterized.TestCase):

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -17,8 +17,7 @@
 
 from absl.testing import absltest
 
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
+from aerleon.lib import nacaddr, naming
 
 
 class NamingUnitTest(absltest.TestCase):

--- a/tests/lib/plugin_test.py
+++ b/tests/lib/plugin_test.py
@@ -5,8 +5,8 @@ from absl.testing import absltest
 from aerleon.lib.cisco import Cisco
 from aerleon.lib.juniper import Juniper
 from aerleon.lib.plugin_supervisor import (
-    _PluginSupervisor,
     PluginSupervisorConfiguration,
+    _PluginSupervisor,
 )
 
 
@@ -56,6 +56,7 @@ class PluginSupervisorTest(absltest.TestCase):
         self.assertEqual(pluginSupervisor.plugins, [])
         self.assertEqual(pluginSupervisor.generators.get("cisco", None), None)
         self.assertEqual(pluginSupervisor.generators["juniper"], Juniper)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/lib/policy_builder_test.py
+++ b/tests/lib/policy_builder_test.py
@@ -11,7 +11,6 @@ from aerleon.lib.policy_builder import (
     RawTerm,
 )
 
-
 RAW_POLICY_ALL_BUILTIN = RawPolicy(
     filename="raw_policy_all_builtin",
     filters=[

--- a/tests/lib/policy_simple_test.py
+++ b/tests/lib/policy_simple_test.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 
+from absl import logging
 from absl.testing import absltest
 
-from absl import logging
 from aerleon.lib import policy_simple
 
 

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -15,14 +15,12 @@
 
 """Unit tests for policy.py library."""
 
-from absl.testing import absltest, parameterized
 from unittest import mock
 
 from absl import logging
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import nacaddr, naming, policy
 
 HEADER = """
 header {

--- a/tests/lib/summarizer_test.py
+++ b/tests/lib/summarizer_test.py
@@ -16,14 +16,13 @@
 """Tests for discontinuous subnet mask summarizer."""
 
 import os
-
 import random
 import time
-from absl.testing import absltest
 
 from absl import logging
-from aerleon.lib import nacaddr
-from aerleon.lib import summarizer
+from absl.testing import absltest
+
+from aerleon.lib import nacaddr, summarizer
 
 
 class SummarizerTest(absltest.TestCase):

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -1,8 +1,11 @@
 """Unittest for YAML front-end."""
 
-from absl.testing import absltest
 from unittest import mock
-from aerleon.lib import nacaddr, naming, yaml as yaml_frontend
+
+from absl.testing import absltest
+
+from aerleon.lib import nacaddr, naming
+from aerleon.lib import yaml as yaml_frontend
 
 GOOD_YAML_POLICY_BASIC = """
 filters:

--- a/tests/regression/arista/arista_test.py
+++ b/tests/regression/arista/arista_test.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 """Tests for arista acl rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import arista
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import arista, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -17,15 +17,11 @@
 
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import arista_tp
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, arista_tp, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/aruba/aruba_test.py
+++ b/tests/regression/aruba/aruba_test.py
@@ -18,14 +18,11 @@
 import datetime
 import logging
 import textwrap
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aruba
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aruba, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER_V4 = """

--- a/tests/regression/brocade/brocade_test.py
+++ b/tests/regression/brocade/brocade_test.py
@@ -15,13 +15,11 @@
 """Tests for brocade acl rendering module."""
 
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import brocade
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import brocade, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -17,17 +17,12 @@
 
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import cisco
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, cisco, nacaddr, naming, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -15,14 +15,11 @@
 
 """Unittest for ciscoasa acl rendering module."""
 
-from absl.testing import absltest, parameterized
 from unittest import mock
 
-from aerleon.lib import ciscoasa
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import ciscoasa, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 """Tests for cisconx acl rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import cisconx
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import cisconx, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/ciscoxr/ciscoxr_test.py
+++ b/tests/regression/ciscoxr/ciscoxr_test.py
@@ -14,16 +14,12 @@
 # limitations under the License.
 """Unittest for Cisco XR acl rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import ciscoxr
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import ciscoxr, nacaddr, naming, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/regression/cloudarmor/cloudarmor_test.py
+++ b/tests/regression/cloudarmor/cloudarmor_test.py
@@ -4,14 +4,11 @@
 
 import json
 import random
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import cloudarmor
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import cloudarmor, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 SUPPORTED_TOKENS = {'action', 'comment', 'priority', 'source_address'}

--- a/tests/regression/demo/demo_test.py
+++ b/tests/regression/demo/demo_test.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 from absl import app
 from absl.testing import absltest
+
 from aerleon import aclgen
 from tests.regression_utils import capture
 

--- a/tests/regression/gce/gce_test.py
+++ b/tests/regression/gce/gce_test.py
@@ -16,18 +16,12 @@
 """Unittest for GCE firewall rendering module."""
 
 import json
-from absl.testing import absltest
 from unittest import mock
 
-from absl.testing import parameterized
-from aerleon.lib import aclgenerator
-from aerleon.lib import gce
-from aerleon.lib import gcp
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import yaml as yaml_frontend
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import aclgenerator, gce, gcp, nacaddr, naming, policy
+from aerleon.lib import yaml as yaml_frontend
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/gcp/gcp_test.py
+++ b/tests/regression/gcp/gcp_test.py
@@ -2,9 +2,7 @@
 # Modifications Copyright 2022-2023 Aerleon Project Authors.
 """Unittest for GCP Firewall Generator module."""
 
-from absl.testing import absltest
-
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 
 from aerleon.lib import gcp
 

--- a/tests/regression/gcp_hf/gcp_hf_test.py
+++ b/tests/regression/gcp_hf/gcp_hf_test.py
@@ -3,16 +3,11 @@
 """Tests for google3.third_party.py.aerleon.lib.gcp_hf.py."""
 
 import json
-from absl.testing import absltest
 from unittest import mock
 
-from absl.testing import parameterized
-from aerleon.lib import gcp
-from aerleon.lib import gcp_hf
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import gcp, gcp_hf, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 HEADER_NO_OPTIONS = """

--- a/tests/regression/ipset/ipset_test.py
+++ b/tests/regression/ipset/ipset_test.py
@@ -15,16 +15,12 @@
 
 """Unittest for Ipset rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import ipset
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import ipset, nacaddr, naming, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -17,18 +17,13 @@
 
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import iptables
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
+
+from aerleon.lib import aclgenerator, iptables, nacaddr, naming, policy
 from aerleon.lib import yaml as yaml_frontend
-
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {
@@ -1830,11 +1825,12 @@ YAML_GOOD_WARNING_TERM = """
     policer: batman
     action: accept
 """
-YAML_BAD_ICMP_TERM= """
+YAML_BAD_ICMP_TERM = """
   - name: permit-icmp
     protocol: icmp icmpv6
     action: accept
 """
+
 
 def _YamlParsePolicy(
     data, definitions=None, optimize=True, base_dir='', shade_check=False, filename=''

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -17,18 +17,13 @@
 
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
 from absl import logging
-from absl.testing import parameterized
-from aerleon.lib import aclgenerator
-from aerleon.lib import juniper
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import yaml as yaml_frontend
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import aclgenerator, juniper, nacaddr, naming, policy
+from aerleon.lib import yaml as yaml_frontend
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/juniperevo/juniperevo_test.py
+++ b/tests/regression/juniperevo/juniperevo_test.py
@@ -17,14 +17,10 @@
 
 from unittest import mock
 
-from absl.testing import absltest
-from absl.testing import parameterized
-from aerleon.lib import juniperevo
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import juniperevo, naming, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/regression/junipermsmpc/junipermsmpc_test.py
+++ b/tests/regression/junipermsmpc/junipermsmpc_test.py
@@ -17,15 +17,11 @@
 
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from absl.testing import parameterized
-from aerleon.lib import junipermsmpc
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import junipermsmpc, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/junipersrx/junipersrx_test.py
+++ b/tests/regression/junipersrx/junipersrx_test.py
@@ -18,18 +18,13 @@
 import copy
 import datetime
 import re
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import junipersrx
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest
+
+from aerleon.lib import aclgenerator, junipersrx, nacaddr, naming, policy
 from aerleon.lib import yaml as yaml_frontend
-
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {
@@ -2627,7 +2622,7 @@ def _YamlParsePolicy(
     # Erase any subsequent copies of "filters:". Multi-filter tests must not
     # contain copies of the "filters:" key
     data = "filters:" + ''.join(data.split("filters:\n"))
-    
+
     return yaml_frontend.ParsePolicy(
         data,
         filename=filename,

--- a/tests/regression/k8s/k8s_test.py
+++ b/tests/regression/k8s/k8s_test.py
@@ -15,16 +15,11 @@
 """Unittest for K8s NetworkPolicy rendering module."""
 
 from unittest import mock
-from absl.testing import absltest
-from absl.testing import parameterized
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import k8s
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
 import yaml
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import aclgenerator, k8s, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/nftables/nftables_test.py
+++ b/tests/regression/nftables/nftables_test.py
@@ -16,15 +16,11 @@
 
 import datetime
 from unittest import mock
-from absl import logging
-from absl.testing import absltest
-from absl.testing import parameterized
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import nftables
-from aerleon.lib import policy
 
+from absl import logging
+from absl.testing import absltest, parameterized
+
+from aerleon.lib import aclgenerator, nacaddr, naming, nftables, policy
 from tests.regression_utils import capture
 
 

--- a/tests/regression/nsxv/nsxv_test.py
+++ b/tests/regression/nsxv/nsxv_test.py
@@ -15,15 +15,12 @@
 """UnitTest class for nsxv.py."""
 
 import copy
-from absl.testing import absltest
 from unittest import mock
 from xml.etree import ElementTree as ET
 
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import nsxv
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import nacaddr, naming, nsxv, policy
 from tests.regression_utils import capture
 
 INET_TERM = """\

--- a/tests/regression/openconfig/openconfig_test.py
+++ b/tests/regression/openconfig/openconfig_test.py
@@ -16,17 +16,11 @@
 """Unittest for OpenConfig rendering module."""
 
 import json
-from absl.testing import absltest
 from unittest import mock
 
-from absl.testing import parameterized
-from aerleon.lib import aclgenerator
-from aerleon.lib import openconfig
-from aerleon.lib import gcp
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
+from absl.testing import absltest, parameterized
 
+from aerleon.lib import aclgenerator, gcp, nacaddr, naming, openconfig, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER = """

--- a/tests/regression/packetfilter/packetfilter_test.py
+++ b/tests/regression/packetfilter/packetfilter_test.py
@@ -16,17 +16,12 @@
 """Unittest for packetfilter rendering module."""
 
 import datetime
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import packetfilter
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, nacaddr, naming, packetfilter, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -14,15 +14,11 @@
 # limitations under the License.
 """Unit test for Palo Alto Firewalls acl rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import paloaltofw
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, nacaddr, naming, paloaltofw, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER_1 = """

--- a/tests/regression/pcap/pcap_test.py
+++ b/tests/regression/pcap/pcap_test.py
@@ -15,17 +15,12 @@
 """Unittest for pcap rendering module."""
 
 import datetime
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import pcap
-from aerleon.lib import policy
+from absl.testing import absltest
 
+from aerleon.lib import aclgenerator, nacaddr, naming, pcap, policy
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {

--- a/tests/regression/speedway/speedway_test.py
+++ b/tests/regression/speedway/speedway_test.py
@@ -15,15 +15,12 @@
 
 """Unittest for Speedway rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import speedway
+from absl.testing import absltest
 
+from aerleon.lib import naming, policy, speedway
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/regression/srxlo/srxlo_test.py
+++ b/tests/regression/srxlo/srxlo_test.py
@@ -15,15 +15,12 @@
 
 """Unittest for Srxlo rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import srxlo
+from absl.testing import absltest
 
+from aerleon.lib import naming, policy, srxlo
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_1 = """
 header {

--- a/tests/regression/windows/windows_test.py
+++ b/tests/regression/windows/windows_test.py
@@ -15,15 +15,12 @@
 
 """Unittest for windows acl rendering module."""
 
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import windows
+from absl.testing import absltest
 
+from aerleon.lib import naming, policy, windows
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {

--- a/tests/regression/windows_advfirewall/windows_advfirewall_test.py
+++ b/tests/regression/windows_advfirewall/windows_advfirewall_test.py
@@ -15,18 +15,19 @@
 """Unittest for windows_advfirewall rendering module."""
 
 import datetime
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import aclgenerator
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import windows
-from aerleon.lib import windows_advfirewall
+from absl.testing import absltest
 
+from aerleon.lib import (
+    aclgenerator,
+    nacaddr,
+    naming,
+    policy,
+    windows,
+    windows_advfirewall,
+)
 from tests.regression_utils import capture
-
 
 GOOD_HEADER_OUT = """
 header {

--- a/tests/regression/windows_ipsec/windows_ipsec_test.py
+++ b/tests/regression/windows_ipsec/windows_ipsec_test.py
@@ -15,16 +15,12 @@
 """Unittest for windows_ipsec rendering module."""
 
 import datetime
-from absl.testing import absltest
 from unittest import mock
 
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-from aerleon.lib import policy
-from aerleon.lib import windows_ipsec
+from absl.testing import absltest
 
+from aerleon.lib import nacaddr, naming, policy, windows_ipsec
 from tests.regression_utils import capture
-
 
 GOOD_HEADER = """
 header {

--- a/tests/regression/yaml/yaml_regression_test.py
+++ b/tests/regression/yaml/yaml_regression_test.py
@@ -4,13 +4,13 @@ import os
 import pathlib
 import shutil
 import tempfile
-
 from unittest import mock
 
 from absl.testing import absltest
 
 from aerleon import aclgen
-from aerleon.lib import nacaddr, naming, policy, yaml as yaml_frontend
+from aerleon.lib import nacaddr, naming, policy
+from aerleon.lib import yaml as yaml_frontend
 from tests.regression_utils import capture
 
 EXP_INFO = 2

--- a/tests/regression_utils/capture.py
+++ b/tests/regression_utils/capture.py
@@ -25,10 +25,10 @@ Users may wish to place each test file in its own folder to avoid having an
 excessive number of reference files in the same folder.
 """
 
-from collections import defaultdict
-from io import StringIO
 import os
+from collections import defaultdict
 from functools import wraps
+from io import StringIO
 from unittest import mock
 
 __all__ = ("files", "stdout", "stderr")

--- a/tests/unit/wrapwords_test.py
+++ b/tests/unit/wrapwords_test.py
@@ -1,7 +1,8 @@
 # Copyright 2018-2021 Google Inc. All Rights Reserved.
 # Modifications Copyright 2022-2023 Aerleon Project Authors.
-from aerleon.lib.aclgenerator import WrapWords
 import pytest
+
+from aerleon.lib.aclgenerator import WrapWords
 
 SINGLE_LINE_OVERFLOW_TEXT_LONG = (
     "http://github.com/google/aerleon/commit/c5"

--- a/tests/utils/iputils_test.py
+++ b/tests/utils/iputils_test.py
@@ -1,12 +1,11 @@
 # Copyright 2018-2021 Google Inc. All Rights Reserved.
 # Modifications Copyright 2022-2023 Aerleon Project Authors.
-import pytest
-
 import pathlib
 
-from aerleon.utils import iputils
-from aerleon.lib import nacaddr
+import pytest
 
+from aerleon.lib import nacaddr
+from aerleon.utils import iputils
 
 file_directory = pathlib.Path(__file__).parent.absolute()
 exclude_address_testcases = []

--- a/tools/cgrep.py
+++ b/tools/cgrep.py
@@ -38,452 +38,483 @@ Examples:
   $ cgrep.py -p 22 tcp
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
-import pprint
-from aerleon.lib import nacaddr
-from aerleon.lib import naming
-
 import logging
+import pprint
+
+from aerleon.lib import nacaddr, naming
 
 
 def is_valid_ip(arg):
-  """Validates a value to be an IP or not.
+    """Validates a value to be an IP or not.
 
-  Args:
-    arg: potential IP address as a string.
+    Args:
+      arg: potential IP address as a string.
 
-  Returns:
-    arg as IP object (if arg is an IP)
+    Returns:
+      arg as IP object (if arg is an IP)
 
-  Raises:
-    Error (if arg is not an IP)
-  """
-  try:
-    nacaddr.IP(arg)
-  except:
-    raise argparse.ArgumentTypeError('%s is an invalid ip address' % arg)
-  return arg
+    Raises:
+      Error (if arg is not an IP)
+    """
+    try:
+        nacaddr.IP(arg)
+    except:
+        raise argparse.ArgumentTypeError('%s is an invalid ip address' % arg)
+    return arg
 
 
 def cli_options():
-  """Builds the argparse options for cgrep.
+    """Builds the argparse options for cgrep.
 
-  TODO(robankeny): Move this to flags.
+    TODO(robankeny): Move this to flags.
 
-  Returns:
-    parser: the arguments, ready to be parsed.
-  """
+    Returns:
+      parser: the arguments, ready to be parsed.
+    """
 
-  parser = argparse.ArgumentParser(
-      description='c[apirca]grep',
-      formatter_class=argparse.RawTextHelpFormatter
-  )
+    parser = argparse.ArgumentParser(
+        description='c[apirca]grep', formatter_class=argparse.RawTextHelpFormatter
+    )
 
-  parser.add_argument('-d', '--def', dest='defs',
-                      help='Network Definitions directory location. \n',
-                      default='./def')
+    parser.add_argument(
+        '-d',
+        '--def',
+        dest='defs',
+        help='Network Definitions directory location. \n',
+        default='./def',
+    )
 
-  # -i and -t can be used together, but not with any other option.
-  ip_group = parser.add_argument_group()
-  # take 1 or more IPs
-  ip_group.add_argument('-i', '--ip', dest='ip', nargs='+', type=is_valid_ip,
-                        help='Return list of definitions containing the '
-                        'IP(s).\nMultiple IPs permitted.')
+    # -i and -t can be used together, but not with any other option.
+    ip_group = parser.add_argument_group()
+    # take 1 or more IPs
+    ip_group.add_argument(
+        '-i',
+        '--ip',
+        dest='ip',
+        nargs='+',
+        type=is_valid_ip,
+        help='Return list of definitions containing the ' 'IP(s).\nMultiple IPs permitted.',
+    )
 
-  ip_group.add_argument('-t', '--token', dest='token',
-                        help=('See if an IP is contained within the given '
-                              'token.\nMust be used in conjunction with '
-                              '-i/--ip [addr].'))
+    ip_group.add_argument(
+        '-t',
+        '--token',
+        dest='token',
+        help=(
+            'See if an IP is contained within the given '
+            'token.\nMust be used in conjunction with '
+            '-i/--ip [addr].'
+        ),
+    )
 
-  exclusive_group = parser.add_mutually_exclusive_group()
-  # the rest of the arguments are mutually exclusive with each other,
-  # and -i / -t
-  exclusive_group.add_argument('-c', '--cmp', dest='cmp', nargs=2,
-                               metavar=('OBJ', 'OBJ'),
-                               help=('Compare the two given network '
-                                     'definition tokens'))
+    exclusive_group = parser.add_mutually_exclusive_group()
+    # the rest of the arguments are mutually exclusive with each other,
+    # and -i / -t
+    exclusive_group.add_argument(
+        '-c',
+        '--cmp',
+        dest='cmp',
+        nargs=2,
+        metavar=('OBJ', 'OBJ'),
+        help=('Compare the two given network ' 'definition tokens'),
+    )
 
-  exclusive_group.add_argument('-g', '--gmp', dest='gmp', nargs=2,
-                               type=is_valid_ip, metavar=('IP', 'IP'),
-                               help=('Diff the network objects to'
-                                     ' which the given IP(s) belong'))
+    exclusive_group.add_argument(
+        '-g',
+        '--gmp',
+        dest='gmp',
+        nargs=2,
+        type=is_valid_ip,
+        metavar=('IP', 'IP'),
+        help=('Diff the network objects to' ' which the given IP(s) belong'),
+    )
 
-  exclusive_group.add_argument('-o', '--obj', dest='obj', nargs='+',
-                               help=('Return list of IP(s) contained within '
-                                     'the given token(s)'))
+    exclusive_group.add_argument(
+        '-o',
+        '--obj',
+        dest='obj',
+        nargs='+',
+        help=('Return list of IP(s) contained within ' 'the given token(s)'),
+    )
 
-  exclusive_group.add_argument('-s', '--svc', dest='svc', nargs='+',
-                               help=('Return list of port(s) contained '
-                                     'within given token(s)'))
+    exclusive_group.add_argument(
+        '-s',
+        '--svc',
+        dest='svc',
+        nargs='+',
+        help=('Return list of port(s) contained ' 'within given token(s)'),
+    )
 
-  exclusive_group.add_argument('-p', '--port', dest='port', nargs=2,
-                               metavar=('PORT', 'PROTO'),
-                               help=('Returns a list of tokens containing '
-                                     'the given port and protocol'))
+    exclusive_group.add_argument(
+        '-p',
+        '--port',
+        dest='port',
+        nargs=2,
+        metavar=('PORT', 'PROTO'),
+        help=('Returns a list of tokens containing ' 'the given port and protocol'),
+    )
 
-  return parser
+    return parser
 
 
 def main(parser):
-  """Determines the code path based on the arguments passed.
+    """Determines the code path based on the arguments passed.
 
-  Args:
-    parser: the argument parser, but not parsed yet.
-  """
-  options = parser.parse_args()
-  db = naming.Naming(options.defs)
-  p = pprint.PrettyPrinter(indent=1, depth=4, width=1).pprint
+    Args:
+      parser: the argument parser, but not parsed yet.
+    """
+    options = parser.parse_args()
+    db = naming.Naming(options.defs)
+    p = pprint.PrettyPrinter(indent=1, depth=4, width=1).pprint
 
-  # if -i and any other option:
-  if options.ip and any([options.gmp, options.cmp, options.obj, options.svc,
-                         options.port]):
-    logging.info('You can only use -i with -t or by itself')
+    # if -i and any other option:
+    if options.ip and any([options.gmp, options.cmp, options.obj, options.svc, options.port]):
+        logging.info('You can only use -i with -t or by itself')
 
-  # if -i and -t
-  elif options.token and options.ip:
-    try:
-      get_nets([options.token], db)
-    except naming.UndefinedAddressError:
-      logging.info("Network group '%s' is not defined!", options.token)
-    else:
-      results = compare_ip_token(options, db)
-      logging.info(results)
+    # if -i and -t
+    elif options.token and options.ip:
+        try:
+            get_nets([options.token], db)
+        except naming.UndefinedAddressError:
+            logging.info("Network group '%s' is not defined!", options.token)
+        else:
+            results = compare_ip_token(options, db)
+            logging.info(results)
 
-  # if -t, but not -i; invalid!
-  elif options.token and not options.ip:
-    logging.info('You must specify an IP Address with -i [addr]')
+    # if -t, but not -i; invalid!
+    elif options.token and not options.ip:
+        logging.info('You must specify an IP Address with -i [addr]')
 
-  # if -i
-  elif options.ip:
-    for ip in options.ip:
-      groups = get_ip_parents(ip, db)
-      logging.info('Results for IP: %s', ip)
-      # iterate and print the tokens we found.
-      for name, networks in groups:
-        # print the group name [0], and the networks it was in [1]
-        logging.info('%s  %s', name, networks)
+    # if -i
+    elif options.ip:
+        for ip in options.ip:
+            groups = get_ip_parents(ip, db)
+            logging.info('Results for IP: %s', ip)
+            # iterate and print the tokens we found.
+            for name, networks in groups:
+                # print the group name [0], and the networks it was in [1]
+                logging.info('%s  %s', name, networks)
 
-  elif options.gmp:
-    common, diff1, diff2 = group_diff(options, db)
-    print_diff(options.gmp[0], common, diff1, diff2)
+    elif options.gmp:
+        common, diff1, diff2 = group_diff(options, db)
+        print_diff(options.gmp[0], common, diff1, diff2)
+        logging.info('')
+        print_diff(options.gmp[1], common, diff2, diff1)
+
+    # if -c
+    elif options.cmp:
+        meta, results = compare_tokens(options, db)
+        first_name = meta[0]
+        second_name = meta[1]
+        union = meta[2]
+        logging.info('Union of %s and %s:\n %s\n', first_name, second_name, union)
+        logging.info('Diff of %s and %s:', first_name, second_name)
+        for i in results:
+            logging.info(' ' + i)
+        logging.info('')
+        first_obj, sec_obj = options.cmp
+        if check_encapsulated('network', first_obj, sec_obj, db):
+            logging.info('%s fully encapsulates %s', sec_obj, first_obj)
+        else:
+            logging.info('%s does _not_ fully encapsulate %s', sec_obj, first_obj)
+        # check the other way around.
+        if check_encapsulated('network', sec_obj, first_obj, db):
+            logging.info('%s fully encapsulates %s', first_obj, sec_obj)
+        else:
+            logging.info('%s does _not_ fully encapsulate %s', first_obj, sec_obj)
+
+    # if -o
+    elif options.obj:
+        for obj in options.obj:
+            try:
+                token, ips = get_nets([obj], db)[0]
+            except naming.UndefinedAddressError:
+                logging.info('%s is an invalid object', obj)
+            else:
+                logging.info(token + ':')
+                # convert list of ip objects to strings and sort them
+                ips.sort(key=lambda x: int(x.ip))
+                p([str(x) for x in ips])
+
+    # if -s
+    elif options.svc:
+        try:
+            results = get_ports(options.svc, db)
+        except naming.UndefinedServiceError:
+            logging.info('%s contains an invalid service object', str(options.svc))
+        else:
+            for result in get_ports(options.svc, db):
+                svc, port = result
+                logging.info(svc + ':')
+                p(port)
+
+    # if -p
+    elif options.port:
+        port, protocol, result = get_services(options, db)
+        logging.info('%s/%s:', port, protocol)
+        p(result)
+
+    # if nothing is passed
+    elif not any((options.cmp, options.ip, options.token, options.obj, options.svc, options.port)):
+        parser.print_help()
     logging.info('')
-    print_diff(options.gmp[1], common, diff2, diff1)
-
-  # if -c
-  elif options.cmp:
-    meta, results = compare_tokens(options, db)
-    first_name = meta[0]
-    second_name = meta[1]
-    union = meta[2]
-    logging.info('Union of %s and %s:\n %s\n', first_name, second_name, union)
-    logging.info('Diff of %s and %s:', first_name, second_name)
-    for i in results:
-      logging.info(' ' + i)
-    logging.info('')
-    first_obj, sec_obj = options.cmp
-    if check_encapsulated('network', first_obj, sec_obj, db):
-      logging.info('%s fully encapsulates %s', sec_obj, first_obj)
-    else:
-      logging.info('%s does _not_ fully encapsulate %s', sec_obj, first_obj)
-    # check the other way around.
-    if check_encapsulated('network', sec_obj, first_obj, db):
-      logging.info('%s fully encapsulates %s', first_obj, sec_obj)
-    else:
-      logging.info('%s does _not_ fully encapsulate %s', first_obj, sec_obj)
-
-  # if -o
-  elif options.obj:
-    for obj in options.obj:
-      try:
-        token, ips = get_nets([obj], db)[0]
-      except naming.UndefinedAddressError:
-        logging.info('%s is an invalid object', obj)
-      else:
-        logging.info(token + ':')
-        # convert list of ip objects to strings and sort them
-        ips.sort(key=lambda x: int(x.ip))
-        p([str(x) for x in ips])
-
-  # if -s
-  elif options.svc:
-    try:
-      results = get_ports(options.svc, db)
-    except naming.UndefinedServiceError:
-      logging.info('%s contains an invalid service object', str(options.svc))
-    else:
-      for result in get_ports(options.svc, db):
-        svc, port = result
-        logging.info(svc + ':')
-        p(port)
-
-  # if -p
-  elif options.port:
-    port, protocol, result = get_services(options, db)
-    logging.info('%s/%s:', port, protocol)
-    p(result)
-
-  # if nothing is passed
-  elif not any((options.cmp, options.ip, options.token, options.obj,
-                options.svc, options.port)):
-    parser.print_help()
-  logging.info('')
 
 
 def check_encapsulated(obj_type, first_obj, second_obj, db):
-  """Checks if a network/service object is entirely contained within another.
+    """Checks if a network/service object is entirely contained within another.
 
-  Args:
-    obj_type: "network" or "service"
-    first_obj: The name of the first network/service object
-    second_obj: The name of the secondnetwork/service object
-    db: The network and service definitions
+    Args:
+      obj_type: "network" or "service"
+      first_obj: The name of the first network/service object
+      second_obj: The name of the secondnetwork/service object
+      db: The network and service definitions
 
-  Returns:
-    Error or bool:
-      ValueError if an invalid object type is passed
-      True if the first_obj is entirely within second_obj, otherwise False
+    Returns:
+      Error or bool:
+        ValueError if an invalid object type is passed
+        True if the first_obj is entirely within second_obj, otherwise False
 
-  Raises:
-    ValueError: When value is not a network or service.
-  """
-  if obj_type == 'network':
-    # the indexing is to get the list of networks out of the tuple[1] and
-    # list[0] returned by get_nets
-    first = get_nets([first_obj], db)[0][1]
-    second = get_nets([second_obj], db)[0][1]
+    Raises:
+      ValueError: When value is not a network or service.
+    """
+    if obj_type == 'network':
+        # the indexing is to get the list of networks out of the tuple[1] and
+        # list[0] returned by get_nets
+        first = get_nets([first_obj], db)[0][1]
+        second = get_nets([second_obj], db)[0][1]
 
-  elif obj_type == 'service':
-    first = get_ports([first_obj], db)[0][1]
-    second = get_ports([second_obj], db)[0][1]
-  else:
-    raise ValueError("check_encapsulated() currently only supports "
-                     "'network' and 'service' for the obj_type parameter")
-  # iterates over each object in the first group, and then each obj in the
-  # second group, making sure each one in the first is contained
-  # somewhere in the second.
-  for obj in first:
-    for sec_obj in second:
-      if obj in sec_obj:
-        break
-    # if we got through every object in the second group, and didn't have
-    # a match, then the first group is not entirely contained.
+    elif obj_type == 'service':
+        first = get_ports([first_obj], db)[0][1]
+        second = get_ports([second_obj], db)[0][1]
     else:
-      return False
-  # if we got here, then the group was fully contained.
-  return True
+        raise ValueError(
+            "check_encapsulated() currently only supports "
+            "'network' and 'service' for the obj_type parameter"
+        )
+    # iterates over each object in the first group, and then each obj in the
+    # second group, making sure each one in the first is contained
+    # somewhere in the second.
+    for obj in first:
+        for sec_obj in second:
+            if obj in sec_obj:
+                break
+        # if we got through every object in the second group, and didn't have
+        # a match, then the first group is not entirely contained.
+        else:
+            return False
+    # if we got here, then the group was fully contained.
+    return True
 
 
 def print_diff(ip, common, diff1, diff2):
-  """Print out the common, added, and removed network objects between 2 IPs.
+    """Print out the common, added, and removed network objects between 2 IPs.
 
-  Args:
-    ip: the IP being compared against
-    common: the network objects shared between the two IPs
-                    ('ip' and the other passed into options.cmp)
-    diff1: the network objects present in 'ip' but not in the other IP
-                   passed into options.cmp
-    diff2: the network objects not present in 'ip' but are present in
-                   the other IP passed into options.cmp
-  """
-  logging.info('IP: %s', ip)
-  if common:
-    common = ['  {0}'.format(elem) for elem in common]
-    logging.info('\n'.join(common))
-  if diff1:
-    diff = ['+ {0}'.format(elem) for elem in diff1]
-    logging.info('\n'.join(diff))
-  if diff2:
-    diff = ['- {0}'.format(elem) for elem in diff2]
-    logging.info('\n'.join(diff))
+    Args:
+      ip: the IP being compared against
+      common: the network objects shared between the two IPs
+                      ('ip' and the other passed into options.cmp)
+      diff1: the network objects present in 'ip' but not in the other IP
+                     passed into options.cmp
+      diff2: the network objects not present in 'ip' but are present in
+                     the other IP passed into options.cmp
+    """
+    logging.info('IP: %s', ip)
+    if common:
+        common = ['  {0}'.format(elem) for elem in common]
+        logging.info('\n'.join(common))
+    if diff1:
+        diff = ['+ {0}'.format(elem) for elem in diff1]
+        logging.info('\n'.join(diff))
+    if diff2:
+        diff = ['- {0}'.format(elem) for elem in diff2]
+        logging.info('\n'.join(diff))
 
 
 def group_diff(options, db):
-  """Diffs two different group objects.
+    """Diffs two different group objects.
 
-  Args:
-    options: the options sent to the script
-    db : network and service definitions
+    Args:
+      options: the options sent to the script
+      db : network and service definitions
 
-  Returns:
-    tuple: the common lines, the differences from 1 to 2,
-                          and the differences from 2 to 1
-  """
-  nested_rvals = []
-  for ip in options.gmp:
-    nested_rvals.append(get_ip_parents(ip, db))
-  # get just the list of groups, stripping out the networks.
-  group1 = [x[0] for x in nested_rvals[0]]
-  group2 = [x[0] for x in nested_rvals[1]]
-  common = list(set(group1) & set(group2))
-  diff1 = list(set(group1) - set(group2))
-  diff2 = list(set(group2) - set(group1))
-  return common, diff1, diff2
+    Returns:
+      tuple: the common lines, the differences from 1 to 2,
+                            and the differences from 2 to 1
+    """
+    nested_rvals = []
+    for ip in options.gmp:
+        nested_rvals.append(get_ip_parents(ip, db))
+    # get just the list of groups, stripping out the networks.
+    group1 = [x[0] for x in nested_rvals[0]]
+    group2 = [x[0] for x in nested_rvals[1]]
+    common = list(set(group1) & set(group2))
+    diff1 = list(set(group1) - set(group2))
+    diff2 = list(set(group2) - set(group1))
+    return common, diff1, diff2
 
 
 def get_ip_parents(ip, db):
-  """Gets a list of all network objects that include an IP.
+    """Gets a list of all network objects that include an IP.
 
-  Args:
-    ip: the IP we're looking for the parents of
-    db: network and service definitions
+    Args:
+      ip: the IP we're looking for the parents of
+      db: network and service definitions
 
-  Returns:
-    results: a list of all groups that include the IP, in the format:
-                     [("Group", ["networks", "matched"]), (etc)]
-  """
-  results = []
-  rval = db.GetIpParents(ip)
-  for v in rval:
-    nested = db.GetNetParents(v)
-    prefix_and_nets = get_nets_and_highest_prefix(ip, v, db)
-    if nested:
-      for n in nested:
-        results.append(('%s -> %s' % (n, v), prefix_and_nets))
-    else:
-      results.append((v, prefix_and_nets))
-  # sort the results by prefix length descending
-  results = sorted(results, key=lambda x: x[1][0], reverse=True)
-  # strip out the no longer needed prefix lengths before handing off
-  for index, group in enumerate(results):
-    results[index] = (group[0], group[1][1])
-  return results
+    Returns:
+      results: a list of all groups that include the IP, in the format:
+                       [("Group", ["networks", "matched"]), (etc)]
+    """
+    results = []
+    rval = db.GetIpParents(ip)
+    for v in rval:
+        nested = db.GetNetParents(v)
+        prefix_and_nets = get_nets_and_highest_prefix(ip, v, db)
+        if nested:
+            for n in nested:
+                results.append(('%s -> %s' % (n, v), prefix_and_nets))
+        else:
+            results.append((v, prefix_and_nets))
+    # sort the results by prefix length descending
+    results = sorted(results, key=lambda x: x[1][0], reverse=True)
+    # strip out the no longer needed prefix lengths before handing off
+    for index, group in enumerate(results):
+        results[index] = (group[0], group[1][1])
+    return results
 
 
 def get_nets_and_highest_prefix(ip, net_group, db):
-  """Find the highest prefix length in all networks given it contains the IP.
+    """Find the highest prefix length in all networks given it contains the IP.
 
-  Args:
-    ip: the IP address contained in net_group
-    net_group: the name of the network object we'll be looking through
-    db: network and service definitions
+    Args:
+      ip: the IP address contained in net_group
+      net_group: the name of the network object we'll be looking through
+      db: network and service definitions
 
-  Returns:
-    highest_prefix_length, networks as tuple
-      highest_prefix_length : the longest prefix length found,
-      networks : network objects
-  """
-  highest_prefix_length = 0
-  networks = []
-  ip = nacaddr.IP(ip)
-  # loop through all the networks in the net_group
-  for net in get_nets([net_group], db)[0][1]:
-    # find the highest prefix length for the networks that contain the IP
-    if ip in net:
-      networks.append(str(net))
-      if net.prefixlen > highest_prefix_length:
-        highest_prefix_length = net.prefixlen
-  return highest_prefix_length, networks
+    Returns:
+      highest_prefix_length, networks as tuple
+        highest_prefix_length : the longest prefix length found,
+        networks : network objects
+    """
+    highest_prefix_length = 0
+    networks = []
+    ip = nacaddr.IP(ip)
+    # loop through all the networks in the net_group
+    for net in get_nets([net_group], db)[0][1]:
+        # find the highest prefix length for the networks that contain the IP
+        if ip in net:
+            networks.append(str(net))
+            if net.prefixlen > highest_prefix_length:
+                highest_prefix_length = net.prefixlen
+    return highest_prefix_length, networks
 
 
 def get_nets(objects, db):
-  """Gets a list of all networks that are inside of a network object.
+    """Gets a list of all networks that are inside of a network object.
 
-  Args:
-    objects: network objects
-    db: network and service definitions
+    Args:
+      objects: network objects
+      db: network and service definitions
 
-  Returns:
-    results : all networks inside a network object
-  """
-  results = []
-  for obj in objects:
-    net = db.GetNet(obj)
-    results.append((obj, net))
-  return results
+    Returns:
+      results : all networks inside a network object
+    """
+    results = []
+    for obj in objects:
+        net = db.GetNet(obj)
+        results.append((obj, net))
+    return results
 
 
 def compare_tokens(options, db):
-  """Compares to network objects against each other.
+    """Compares to network objects against each other.
 
-  Args:
-    options: the options sent to the script
-    db: network and service definitions
+    Args:
+      options: the options sent to the script
+      db: network and service definitions
 
-  Returns:
-    meta, results :
-      ((first object, second object, union of those two),
-       diff of those two network objects)
-  """
-  t1, t2 = options.cmp
-  d1 = db.GetNet(t1)
-  d2 = db.GetNet(t2)
-  union = list(set(d1 + d2))
-  meta = (t1, t2, union)
-  results = []
-  for el in set(d1 + d2):
-    el = nacaddr.IP(el)
-    if el in d1 and el in d2:
-      results.append(str(el))
-    elif el in d1:
-      results.append(str(el))
-    elif el in d2:
-      results.append(str(el))
-  return meta, results
+    Returns:
+      meta, results :
+        ((first object, second object, union of those two),
+         diff of those two network objects)
+    """
+    t1, t2 = options.cmp
+    d1 = db.GetNet(t1)
+    d2 = db.GetNet(t2)
+    union = list(set(d1 + d2))
+    meta = (t1, t2, union)
+    results = []
+    for el in set(d1 + d2):
+        el = nacaddr.IP(el)
+        if el in d1 and el in d2:
+            results.append(str(el))
+        elif el in d1:
+            results.append(str(el))
+        elif el in d2:
+            results.append(str(el))
+    return meta, results
 
 
 def compare_ip_token(options, db):
-  """Looks to see if a network IP is contained in a network object.
+    """Looks to see if a network IP is contained in a network object.
 
-  Args:
-    options: the options sent to the script
-    db: network and service definitions
+    Args:
+      options: the options sent to the script
+      db: network and service definitions
 
-  Returns:
-    results : end-user string stating the results
-  """
-  token = options.token
-  results = []
-  for ip in options.ip:
-    rval = db.GetIpParents(ip)
-    if token in rval:
-      results = '%s is in %s' % (ip, token)
-    else:
-      results = '%s is _not_ in %s' % (ip, token)
-  return results
+    Returns:
+      results : end-user string stating the results
+    """
+    token = options.token
+    results = []
+    for ip in options.ip:
+        rval = db.GetIpParents(ip)
+        if token in rval:
+            results = '%s is in %s' % (ip, token)
+        else:
+            results = '%s is _not_ in %s' % (ip, token)
+    return results
 
 
 def get_ports(svc_group, db):
-  """Gets the ports and protocols defined in a service group.
+    """Gets the ports and protocols defined in a service group.
 
-  Args:
-    svc_group: a list of strings for each service group
-    db: network and service definitions
+    Args:
+      svc_group: a list of strings for each service group
+      db: network and service definitions
 
-  Returns:
-    results: a list of tuples for each service defined, in the format:
-                     (service name, "<port>/<protocol>")
-  """
-  results = []
-  for svc in svc_group:
-    port = db.GetService(svc)
-    results.append((svc, port))
-  return results
+    Returns:
+      results: a list of tuples for each service defined, in the format:
+                       (service name, "<port>/<protocol>")
+    """
+    results = []
+    for svc in svc_group:
+        port = db.GetService(svc)
+        results.append((svc, port))
+    return results
 
 
 def get_services(options, db):
-  """Finds any services with that include a specific port/protocol pair.
+    """Finds any services with that include a specific port/protocol pair.
 
-  Args:
-    options: the options sent to the script
-    db: network and service definitions
+    Args:
+      options: the options sent to the script
+      db: network and service definitions
 
-  Returns:
-    port, protocol, results as tuple in the format:
-    (port, protocol, list of the services containing this pair)
-  """
-  results = []
-  port, protocol = options.port
-  # swap values if they were passed in wrong order
-  if port.isalpha() and protocol.isdigit():
-    port, protocol = protocol, port
-  results = db.GetPortParents(port, protocol)
-  return port, protocol, results
+    Returns:
+      port, protocol, results as tuple in the format:
+      (port, protocol, list of the services containing this pair)
+    """
+    results = []
+    port, protocol = options.port
+    # swap values if they were passed in wrong order
+    if port.isalpha() and protocol.isdigit():
+        port, protocol = protocol, port
+    results = db.GetPortParents(port, protocol)
+    return port, protocol, results
 
 
 if __name__ == '__main__':
-  main(cli_options())
+    main(cli_options())

--- a/tools/iputilstools.py
+++ b/tools/iputilstools.py
@@ -1,6 +1,6 @@
-import random
 import ipaddress
 import itertools as it
+import random
 
 
 def write_excludes_testcase(ipstr, excludelist='', max_prefix_range=8, max_random_subnets=30):
@@ -20,17 +20,9 @@ def write_excludes_testcase(ipstr, excludelist='', max_prefix_range=8, max_rando
     ip = ipaddress.ip_network(ipstr)
     if len(excludelist) == 0:  # empty excludelist, making a random one
         prefixrange = min(max_prefix_range, ip.max_prefixlen - ip.prefixlen)
-        excludelist = it.chain.from_iterable(ip.subnets(i) for i in range(1, prefixrange+1))
+        excludelist = it.chain.from_iterable(ip.subnets(i) for i in range(1, prefixrange + 1))
         total_ips = 2**prefixrange
-        ip_positions = set(
-            random.choices(
-                range(total_ips),
-                k=min(
-                    max_random_subnets,
-                    total_ips
-                )
-            )
-        )
+        ip_positions = set(random.choices(range(total_ips), k=min(max_random_subnets, total_ips)))
         compress_map = (1 if i in ip_positions else 0 for i in range(total_ips))
         excludelist = list(it.compress(excludelist, compress_map))
     else:


### PR DESCRIPTION
> "Any customer can have a car painted any color that he wants so long as it
> is black".

Auto formatting source code is great for working in larger teams and allows
code review to focus on teh code and not formatting issues.

The defacto tool is "black" which is an opinonated formatting tool.  There
already seems to be configuration for black in the pyproject.toml file and
that wasn't modified.

https://black.readthedocs.io/en/stable/

In addition to "black" there is a tool called "isort" that sorts and formats
`import` lines again in the name of having a standard across all files.

https://pycqa.github.io/isort/

This PR is just running `black` and `isort` on the files and then adds a
formatting check to the github actions.
