### PR TITLE
update .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # Reformat everything using 'black'
 f8937ef224b027ef20bd915f35bdb02312e8d6e5
+# (re)format all code with black/isort (#186)
+186d08e4037717207ae38941f76cb78733f490cd


### PR DESCRIPTION
Updates the .git-blame.ignore-revs to include the formatting commit from

```
$ git blame tools/cgrep.py | grep 186d08e | wc -l
423
$ git blame --ignore-revs-file=.git-blame-ignore-revs tools/cgrep.py | grep 186d08e | wc -l
49
```

Note: there are still lines in git blame after this change?  Because new lines were added they are still included.
