### PR TITLE
Reorganizing object-group and extended term string functions.

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -683,7 +683,6 @@ class Term(aclgenerator.Term):
             if addr.num_addresses > 1:
                 return addr.with_prefixlen
             return 'host %s' % (addr.network_address)
-
         return addr
 
     def _FormatPort(self, port, proto):
@@ -940,7 +939,6 @@ class Cisco(aclgenerator.ACLGenerator):
 
                     # render terms based on filter type
                     if next_filter == 'standard':
-
                         # keep track of sequence numbers across terms
                         new_terms.append(
                             TermStandard(term, filter_name, self._PLATFORM, self.verbose)

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -438,7 +438,7 @@ class PortMap:
 
 
 class Term(aclgenerator.Term):
-    """A single ACL Term."""
+    """This is an general Term object that all other Cisco Terms should inherite from."""
 
     ALLOWED_PROTO_STRINGS = [
         'eigrp',
@@ -455,7 +455,6 @@ class Term(aclgenerator.Term):
         'sctp',
         'ahp',
     ]
-
     IPV4_ADDRESS = Union[nacaddr.IPv4, ipaddress.IPv4Network]
     IPV6_ADDRESS = Union[nacaddr.IPv6, ipaddress.IPv6Network]
 
@@ -469,7 +468,6 @@ class Term(aclgenerator.Term):
         platform='cisco',
         verbose=True,
     ):
-        super().__init__(term)
         self.term = term
         self.proto_int = proto_int
         self.options = []
@@ -506,9 +504,9 @@ class Term(aclgenerator.Term):
         if self.verbose:
             comments = []
             if self.term_remark:
-                    comments.append(self.term.name)
+                comments.append(self.term.name)
             if self.term.owner:
-                     comments.append(f'Owner: {self.term.owner}')
+                comments.append(f'Owner: {self.term.owner}')
             comments.extend(self.term.comment)
 
             comments = aclgenerator.WrapWords(comments, _COMMENT_MAX_WIDTH)
@@ -552,7 +550,6 @@ class Term(aclgenerator.Term):
                 protocol = [x if x != 'ah' else '51' for x in protocol]
 
         # addresses
-
 
         # source address
         if self.term.source_address:
@@ -650,8 +647,6 @@ class Term(aclgenerator.Term):
         # action
         if self.term.action:
             action = _ACTION_TABLE.get(str(self.term.action[0]))
-
-        
 
         # logging
         if self.term.logging:
@@ -834,7 +829,14 @@ class Term(aclgenerator.Term):
         return temporary_port_list
 
 
-class ObjectGroupTerm(Term):
+class ExtendedTerm(Term):
+    """A single ACL Term."""
+
+
+pass
+
+
+class ObjectGroupTerm(ExtendedTerm):
     """An individual term of an object-group'd acl.
 
     Object Group acls are very similar to extended acls in their
@@ -882,9 +884,9 @@ class ObjectGroupTerm(Term):
         if self.verbose:
             comments = []
             if self.term_remark:
-                    comments.append(self.term.name)
+                comments.append(self.term.name)
             if self.term.owner:
-                     comments.append(f'Owner: {self.term.owner}')
+                comments.append(f'Owner: {self.term.owner}')
             comments.extend(self.term.comment)
 
             comments = aclgenerator.WrapWords(comments, _COMMENT_MAX_WIDTH)
@@ -928,7 +930,6 @@ class ObjectGroupTerm(Term):
                 protocol = [x if x != 'ah' else '51' for x in protocol]
 
         # addresses
-
 
         # source address
         if self.term.source_address:
@@ -1028,8 +1029,6 @@ class ObjectGroupTerm(Term):
         if self.term.action:
             action = _ACTION_TABLE.get(str(self.term.action[0]))
 
-        
-
         # logging
         if self.term.logging:
             self.options.append('log')
@@ -1110,13 +1109,12 @@ class ObjectGroupTerm(Term):
         # str(icmp_type) is needed to ensure 0 maps to '0' instead of FALSE
         icmp_type = str(icmp_type)
         icmp_code = str(icmp_code)
-        import ipdb;ipdb.set_trace()
         all_elements = [
             action,
             str(proto),
-            saddr,
+            str(saddr),
             sport,
-            daddr,
+            str(daddr),
             dport,
             icmp_type,
             icmp_code,
@@ -1242,7 +1240,7 @@ class Cisco(aclgenerator.ACLGenerator):
                             len(filter_options) > 2 and filter_options[2] == 'enable_dsmo'
                         )
                         new_terms.append(
-                            Term(
+                            ExtendedTerm(
                                 term,
                                 proto_int=self._PROTO_INT,
                                 enable_dsmo=enable_dsmo,
@@ -1258,7 +1256,7 @@ class Cisco(aclgenerator.ACLGenerator):
                         )
                     elif next_filter == 'inet6':
                         new_terms.append(
-                            Term(
+                            ExtendedTerm(
                                 term,
                                 6,
                                 proto_int=self._PROTO_INT,

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -504,13 +504,17 @@ class Term(aclgenerator.Term):
 
         # verbose
         if self.verbose:
+            comments = []
             if self.term_remark:
-                ret_str.append(' remark ' + self.term.name)
+                    comments.append(self.term.name)
             if self.term.owner:
-                self.term.comment.append('Owner: %s' % self.term.owner)
-            for comment in self.term.comment:
-                for line in comment.split('\n'):
-                    ret_str.append(' remark ' + str(line)[:100].rstrip())
+                     comments.append(f'Owner: {self.term.owner}')
+            comments.extend(self.term.comment)
+
+            comments = aclgenerator.WrapWords(comments, _COMMENT_MAX_WIDTH)
+            if comments and comments[0]:
+                for comment in comments:
+                    ret_str.append(' remark %s' % str(comment))
 
         # Term verbatim output - this will skip over normal term creation
         # code by returning early.  Warnings provided in policy.py.
@@ -860,14 +864,33 @@ class ObjectGroupTerm(Term):
         source_address_set = set()
         destination_address_set = set()
 
+        # Don't render icmpv6 protocol terms under inet, or icmp under inet6
+        if (
+            (self.af == 6 and 'icmp' in self.term.protocol)
+            or (self.af == 6 and self.PROTO_MAP['icmp'] in self.term.protocol)
+            or (self.af == 4 and 'icmpv6' in self.term.protocol)
+            or (self.af == 4 and self.PROTO_MAP['icmpv6'] in self.term.protocol)
+        ):
+            logging.warning(
+                self.NO_AF_LOG_PROTO.substitute(
+                    term=self.term.name, proto=', '.join(self.term.protocol), af=self.text_af
+                )
+            )
+            return ''
+
+        # verbose
         if self.verbose:
-            ret_str.append(' remark %s' % self.term.name)
-            comments = aclgenerator.WrapWords(self.term.comment, _COMMENT_MAX_WIDTH)
+            comments = []
+            if self.term_remark:
+                    comments.append(self.term.name)
+            if self.term.owner:
+                     comments.append(f'Owner: {self.term.owner}')
+            comments.extend(self.term.comment)
+
+            comments = aclgenerator.WrapWords(comments, _COMMENT_MAX_WIDTH)
             if comments and comments[0]:
                 for comment in comments:
                     ret_str.append(' remark %s' % str(comment))
-
-        # verbose
 
         # Term verbatim output - this will skip over normal term creation
         # code by returning early.  Warnings provided in policy.py.
@@ -879,30 +902,78 @@ class ObjectGroupTerm(Term):
 
         # protocol
         if not self.term.protocol:
-            protocol = ['ip']
+            if self.af == 6:
+                protocol = ['ipv6']
+            elif self.platform == 'ciscoxr':
+                protocol = ['ipv4']
+            else:
+                protocol = ['ip']
+        elif self.term.protocol == ['hopopt'] or self.term.protocol == self.PROTO_MAP['hopopt']:
+            protocol = ['hbh']
+        elif self.proto_int:
 
-        else:
             protocol = [
                 proto
                 if proto in self.ALLOWED_PROTO_STRINGS or proto.isnumeric()
                 else self.PROTO_MAP.get(proto)
                 for proto in self.term.protocol
             ]
+        else:
+            protocol = self.term.protocol
+        # Arista can not process acls with esp/ah, these must appear as integers.
+        if self.platform == 'arista':
+            if 'esp' in protocol:
+                protocol = [x if x != 'esp' else '50' for x in protocol]
+            if 'ah' in protocol:
+                protocol = [x if x != 'ah' else '51' for x in protocol]
 
         # addresses
 
 
         # source address
-        source_address = self.term.source_address
-        if not self.term.source_address:
-            source_address = [nacaddr.IPv4('0.0.0.0/0', token='any')]
-        source_address_set.add(source_address[0].parent_token)
-
+        if self.term.source_address:
+            source_address = self.term.GetAddressOfVersion('source_address', self.af)
+            source_address_exclude = self.term.GetAddressOfVersion(
+                'source_address_exclude', self.af
+            )
+            if source_address_exclude:
+                source_address = nacaddr.ExcludeAddrs(source_address, source_address_exclude)
+            if not source_address:
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='source', af=self.text_af
+                    )
+                )
+                return ''
+            if self.enable_dsmo:
+                source_address = summarizer.Summarize(source_address)
+        else:
+            # source address not set
+            source_address = ['any']
+        source_address_set = set(source_address)
         # destination address
-        destination_address = self.term.destination_address
-        if not self.term.destination_address:
-            destination_address = [nacaddr.IPv4('0.0.0.0/0', token='any')]
-        destination_address_set.add(destination_address[0].parent_token)
+        if self.term.destination_address:
+            destination_address = self.term.GetAddressOfVersion('destination_address', self.af)
+            destination_address_exclude = self.term.GetAddressOfVersion(
+                'destination_address_exclude', self.af
+            )
+            if destination_address_exclude:
+                destination_address = nacaddr.ExcludeAddrs(
+                    destination_address, destination_address_exclude
+                )
+            if not destination_address:
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='destination', af=self.text_af
+                    )
+                )
+                return ''
+            if self.enable_dsmo:
+                destination_address = summarizer.Summarize(destination_address)
+        else:
+            # destination address not set
+            destination_address = ['any']
+        destination_address_set = set(destination_address)
 
         # ports
         source_port = [()]
@@ -910,23 +981,80 @@ class ObjectGroupTerm(Term):
 
         # source port
         if self.term.source_port:
-            source_port = self.term.source_port
+            source_port = self._FixConsecutivePorts(self.term.source_port)
 
         # destination port
         if self.term.destination_port:
-            destination_port = self.term.destination_port
+            destination_port = self._FixConsecutivePorts(self.term.destination_port)
 
         # options
-
+        opts = [str(x) for x in self.term.option]
+        if (self.PROTO_MAP['tcp'] in protocol or 'tcp' in protocol) and (
+            'tcp-established' in opts or 'established' in opts
+        ):
+            if 'established' not in self.options:
+                self.options.append('established')
+        # Using both 'fragments' and 'is-fragment', ref Github Issue #187
+        if ('ip' in protocol) and (('fragments' in opts) or ('is-fragment' in opts)):
+            if 'fragments' not in self.options:
+                self.options.append('fragments')
         # ACL-based Forwarding
+        if (
+            (self.platform == 'ciscoxr')
+            and not self.term.action
+            and self.term.next_ip
+            and ('nexthop1' not in opts)
+        ):
+            if len(self.term.next_ip) > 1:
+                raise CiscoNextIpError(
+                    'The following term has more than one next IP ' 'value: %s' % self.term.name
+                )
+            if not isinstance(self.term.next_ip[0], nacaddr.IPv4) and not isinstance(
+                self.term.next_ip[0], nacaddr.IPv6
+            ):
+                raise CiscoNextIpError(
+                    'Next IP value must be an IP address. ' 'Invalid term: %s' % self.term.name
+                )
+            if self.term.next_ip[0].num_addresses > 1:
+                raise CiscoNextIpError(
+                    'The following term has a subnet instead of a ' 'host: %s' % self.term.name
+                )
+            nexthop = self.term.next_ip[0].network_address
+            nexthop_protocol = 'ipv4' if nexthop.version == 4 else 'ipv6'
+            self.options.append('nexthop1 %s %s' % (nexthop_protocol, nexthop))
+            action = _ACTION_TABLE.get('accept')
 
         # action
+        if self.term.action:
+            action = _ACTION_TABLE.get(str(self.term.action[0]))
+
+        
 
         # logging
+        if self.term.logging:
+            self.options.append('log')
 
         # dscp; unlike srx, cisco only supports single, non-except values
+        if self.term.dscp_match:
+            if len(self.term.dscp_match) > 1:
+                raise ExtendedACLTermError(
+                    'Extended ACLs cannot specify more than one dscp match value'
+                )
+            else:
+                self.options.append('dscp %s' % ' '.join(self.term.dscp_match))
 
         # icmp-types
+        icmp_types = ['']
+        if self.term.icmp_type:
+            icmp_types = self.NormalizeIcmpTypes(self.term.icmp_type, self.term.protocol, self.af)
+        icmp_codes = ['']
+        if self.term.icmp_code:
+            icmp_codes = self.term.icmp_code
+        fixed_src_addresses = [self._GetIpString(x) for x in source_address]
+        fixed_dst_addresses = [self._GetIpString(x) for x in destination_address]
+        fixed_opts = {}
+        for p in protocol:
+            fixed_opts[p] = self._FixOptions(p, self.options)
 
         # temlet constructor
         for saddr in source_address_set:
@@ -934,36 +1062,68 @@ class ObjectGroupTerm(Term):
                 for sport in source_port:
                     for dport in destination_port:
                         for proto in protocol:
-                            ret_str.append(
-                                self._TermletToStr(
-                                    _ACTION_TABLE.get(str(self.term.action[0])),
-                                    proto,
-                                    saddr,
-                                    sport,
-                                    daddr,
-                                    dport,
-                                )
-                            )
+                            opts = fixed_opts[proto]
+                            # cisconx uses icmp for both ipv4 and ipv6
+                            if self.platform == 'cisconx':
+                                if self.af == 6:
+                                    proto = 'icmp' if proto == 'icmpv6' else proto
+                            for icmp_type in icmp_types:
+                                for icmp_code in icmp_codes:
+                                    ret_str.extend(
+                                        self._TermletToStr(
+                                            action,
+                                            proto,
+                                            saddr,
+                                            self._FormatPort(sport, proto),
+                                            daddr,
+                                            self._FormatPort(dport, proto),
+                                            icmp_type,
+                                            icmp_code,
+                                            opts,
+                                        )
+                                    )
+
         return '\n'.join(ret_str)
 
-    def _TermletToStr(self, action, proto, saddr, sport, daddr, dport):
-        """Output a portion of a cisco term/filter only, based on the 5-tuple."""
-        # Empty addr/port destinations should emit 'any'
-        if saddr and saddr != 'any':
-            saddr = 'net-group %s' % saddr
-        if daddr and daddr != 'any':
-            daddr = 'net-group %s' % daddr
-        # fix ports
-        if sport:
-            sport = ' port-group %d-%d' % (sport[0], sport[1])
-        else:
-            sport = ''
-        if dport:
-            dport = ' port-group %d-%d' % (dport[0], dport[1])
-        else:
-            dport = ''
+    def _TermletToStr(
+        self, action, proto, saddr, sport, daddr, dport, icmp_type, icmp_code, option
+    ):
+        """Take the various compenents and turn them into a cisco acl line.
 
-        return (' %s %s %s%s %s%s' % (action, proto, saddr, sport, daddr, dport)).rstrip()
+        Args:
+          action: str, action
+          proto: str or int, protocol
+          saddr: str, source address
+          sport: str, the source port
+          daddr: str, the destination address
+          dport: str, the destination port
+          icmp_type: icmp-type numeric specification (if any)
+          icmp_code: icmp-code numeric specification (if any)
+          option: list or none, optional, eg. 'logging' tokens.
+
+        Returns:
+          string of the cisco acl line, suitable for printing.
+
+        Raises:
+          UnsupportedCiscoAccessListError: When unknown icmp-types specified
+        """
+        # str(icmp_type) is needed to ensure 0 maps to '0' instead of FALSE
+        icmp_type = str(icmp_type)
+        icmp_code = str(icmp_code)
+        import ipdb;ipdb.set_trace()
+        all_elements = [
+            action,
+            str(proto),
+            saddr,
+            sport,
+            daddr,
+            dport,
+            icmp_type,
+            icmp_code,
+            ' '.join(option),
+        ]
+        non_empty_elements = [x for x in all_elements if x]
+        return [' ' + ' '.join(non_empty_elements)]
 
 
 class Cisco(aclgenerator.ACLGenerator):

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -120,7 +120,7 @@ class TermStandard:
         prefix = ''
         if self.filter_name.isdigit():
             prefix = f'access-list {self.filter_name}'
-      
+
         if self.verbose:
             ret_str.append(f'{prefix} remark {self.term.name}')
             comments = aclgenerator.WrapWords(self.term.comment, _COMMENT_MAX_WIDTH)
@@ -133,12 +133,12 @@ class TermStandard:
                 if self.platform == 'arista':
                     if addr.prefixlen == 32:
                         ret_str.append(
-                        f'{prefix} {action} host {addr.network_address}{self.logstring}{self.dscpstring}'
+                            f'{prefix} {action} host {addr.network_address}{self.logstring}{self.dscpstring}'
                         )
                     else:
                         ret_str.append(
-                        f'{prefix} {action} {addr.network_address}/{addr.prefixlen}{self.logstring}{self.dscpstring}'
-                    )
+                            f'{prefix} {action} {addr.network_address}/{addr.prefixlen}{self.logstring}{self.dscpstring}'
+                        )
                 elif addr.prefixlen == 32:
                     ret_str.append(
                         f'{prefix} {action} {addr.network_address}{self.logstring}{self.dscpstring}'
@@ -805,6 +805,7 @@ class ObjectGroupTerm(Term):
     where first-term-source-address, ANY and 179-179 are defined elsewhere
     in the acl.
     """
+
     def _FormatPort(self, port, proto):
         """Returns a formatted port string for the range.
 
@@ -818,7 +819,7 @@ class ObjectGroupTerm(Term):
         if not port:
             return ''
         return f'port-group {port[0]}-{port[1]}'
-        
+
     def _GetIpString(self, addr):
         """Formats the address object for printing in the ACL.
 

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -805,7 +805,20 @@ class ObjectGroupTerm(Term):
     where first-term-source-address, ANY and 179-179 are defined elsewhere
     in the acl.
     """
+    def _FormatPort(self, port, proto):
+        """Returns a formatted port string for the range.
 
+        Args:
+          port: str list or none, the port range.
+          proto: str representing proto (tcp, udp, etc).
+
+        Returns:
+          A string suitable for the ACL.
+        """
+        if not port:
+            return ''
+        return f'port-group {port[0]}-{port[1]}'
+        
     def _GetIpString(self, addr):
         """Formats the address object for printing in the ACL.
 
@@ -814,7 +827,9 @@ class ObjectGroupTerm(Term):
         Returns:
           An address string suitable for the ACL.
         """
-        return addr.parent_token
+        if addr.prefixlen == 0:
+            return f'{addr.parent_token}'
+        return f'net-group {addr.parent_token}'
 
 
 class Cisco(aclgenerator.ACLGenerator):

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -50,7 +50,7 @@ class NoCiscoPolicyError(Error):
     """Raised when a policy is errantly passed to this module for rendering."""
 
 
-class Term(cisco.Term):
+class Term(cisco.ExtendedTerm):
     """A single ACL Term."""
 
     def __init__(self, term, filter_name, af=4, enable_dsmo=False):

--- a/aerleon/lib/ciscoxr.py
+++ b/aerleon/lib/ciscoxr.py
@@ -64,4 +64,4 @@ class CiscoXR(cisco.Cisco):
 
 
 class CiscoXRObjectGroupTerm(cisco.ObjectGroupTerm):
-    ALLOWED_PROTO_STRINGS = cisco.Term.ALLOWED_PROTO_STRINGS + ['pcp', 'esp']
+    ALLOWED_PROTO_STRINGS = cisco.ExtendedTerm.ALLOWED_PROTO_STRINGS + ['pcp', 'esp']

--- a/aerleon/lib/ciscoxr.py
+++ b/aerleon/lib/ciscoxr.py
@@ -58,9 +58,9 @@ class CiscoXR(cisco.Cisco):
 
         return supported_tokens, supported_sub_tokens
 
-    def _GetObjectGroupTerm(self, term, filter_name, verbose=True):
+    def _GetObjectGroupTerm(self, term, verbose=True):
         """Returns an ObjectGroupTerm object."""
-        return CiscoXRObjectGroupTerm(term, filter_name, platform=self._PLATFORM, verbose=verbose)
+        return CiscoXRObjectGroupTerm(term, platform=self._PLATFORM, verbose=verbose)
 
 
 class CiscoXRObjectGroupTerm(cisco.ObjectGroupTerm):

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -39,8 +39,9 @@ class DSMNet:
         self.address = address
         self.netmask = netmask
         self.text = text
+
     def __hash__(self):
-        return hash(str(self.address)+str(self.netmask))
+        return hash(str(self.address) + str(self.netmask))
 
     def __eq__(self, other):
         try:

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -39,6 +39,8 @@ class DSMNet:
         self.address = address
         self.netmask = netmask
         self.text = text
+    def __hash__(self):
+        return hash(str(self.address)+str(self.netmask))
 
     def __eq__(self, other):
         try:

--- a/tests/regression/arista/AristaTest.testAHAndESPAreIntegers.stdout.ref
+++ b/tests/regression/arista/AristaTest.testAHAndESPAreIntegers.stdout.ref
@@ -9,8 +9,8 @@ ip access-list test-filter
 
  remark good-term-6
  remark Accept AH from internal sources.
- permit 51 any any
  permit 50 any any
+ permit 51 any any
  permit tcp any any
 
 exit

--- a/tests/regression/cisco/CiscoTest.testIPVersion.stdout.ref
+++ b/tests/regression/cisco/CiscoTest.testIPVersion.stdout.ref
@@ -8,7 +8,7 @@ ip access-list extended test-filter
 
 
  remark good-term-6
- permit ip any 0.0.0.0 255.255.255.255
+ permit ip any any
 
 exit
 

--- a/tests/regression/cisco/CiscoTest.testObjectGroup.stdout.ref
+++ b/tests/regression/cisco/CiscoTest.testObjectGroup.stdout.ref
@@ -22,7 +22,7 @@ ip access-list extended objgroupheader
 
 
  remark good-term-2
- permit tcp any port-group 80-80 net-group SOME_HOST port-group 1024-65535
+ permit tcp any port-group 80-80 net-group SOME_HOST port-group 1024-65535 established
 
 
  remark good-term-18

--- a/tests/regression/cisco/CiscoTest.testOwnerTerm.stdout.ref
+++ b/tests/regression/cisco/CiscoTest.testOwnerTerm.stdout.ref
@@ -9,8 +9,6 @@ ip access-list extended test-filter
 
  remark good-term-13
  remark Owner: foo@google.com
- remark Owner: foo@google.com
- remark Owner: foo@google.com
  permit ip any any
 
 exit

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -631,26 +631,27 @@ class CiscoTest(absltest.TestCase):
 
         pol = policy.ParsePolicy(GOOD_OBJGRP_HEADER + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
+        print(acl)
 
-        #self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
-        #self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
-        #self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % ('\n'.join(port_grp2), str(acl)))
+        self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
+        self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
+        self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % ('\n'.join(port_grp2), str(acl)))
 
         # Object-group terms should use the object groups created.
-        # self.assertIn(
-        #     ' permit tcp any port-group 80-80 net-group SOME_HOST port-group' ' 1024-65535',
-        #     str(acl),
-        #     str(acl),
-        # )
-        # self.assertIn(' permit ip net-group SOME_HOST net-group SOME_HOST', str(acl), str(acl))
+        self.assertIn(
+            ' permit tcp any port-group 80-80 net-group SOME_HOST port-group' ' 1024-65535',
+            str(acl),
+            str(acl),
+        )
+        self.assertIn(' permit ip net-group SOME_HOST net-group SOME_HOST', str(acl), str(acl))
 
         # There should be no addrgroups that look like IP addresses.
-        # for addrgroup in re.findall(r'net-group ([a-f0-9.:/]+)', str(acl)):
-        #     self.assertRaises(ValueError, nacaddr.IP(addrgroup))
+        for addrgroup in re.findall(r'net-group ([a-f0-9.:/]+)', str(acl)):
+            self.assertRaises(ValueError, nacaddr.IP(addrgroup))
 
-        # self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
-        # self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
-        print(acl)
+        self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
+        self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
+        
 
     @capture.stdout
     def testInet6(self):

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -841,7 +841,7 @@ class CiscoTest(absltest.TestCase):
         self.assertIn('permit hbh any any', str(acl), str(acl))
         print(acl)
 
-    @capture.stdout
+    # @capture.stdout
     def testOwnerTerm(self):
         acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_13, self.naming), EXP_INFO)
         self.assertTrue(re.search(' remark Owner: foo@google.com', str(acl)), str(acl))

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -614,7 +614,7 @@ class CiscoTest(absltest.TestCase):
 
         self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
 
-    @capture.stdout
+    # @capture.stdout
     def testObjectGroup(self):
         ip_grp = ['object-group network ipv4 SOME_HOST']
         ip_grp.append(' 10.0.0.0/8')
@@ -632,24 +632,24 @@ class CiscoTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_OBJGRP_HEADER + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
 
-        self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
-        self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
-        self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % ('\n'.join(port_grp2), str(acl)))
+        #self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
+        #self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
+        #self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % ('\n'.join(port_grp2), str(acl)))
 
         # Object-group terms should use the object groups created.
-        self.assertIn(
-            ' permit tcp any port-group 80-80 net-group SOME_HOST port-group' ' 1024-65535',
-            str(acl),
-            str(acl),
-        )
-        self.assertIn(' permit ip net-group SOME_HOST net-group SOME_HOST', str(acl), str(acl))
+        # self.assertIn(
+        #     ' permit tcp any port-group 80-80 net-group SOME_HOST port-group' ' 1024-65535',
+        #     str(acl),
+        #     str(acl),
+        # )
+        # self.assertIn(' permit ip net-group SOME_HOST net-group SOME_HOST', str(acl), str(acl))
 
         # There should be no addrgroups that look like IP addresses.
-        for addrgroup in re.findall(r'net-group ([a-f0-9.:/]+)', str(acl)):
-            self.assertRaises(ValueError, nacaddr.IP(addrgroup))
+        # for addrgroup in re.findall(r'net-group ([a-f0-9.:/]+)', str(acl)):
+        #     self.assertRaises(ValueError, nacaddr.IP(addrgroup))
 
-        self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
-        self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
+        # self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
+        # self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
         print(acl)
 
     @capture.stdout

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -614,7 +614,7 @@ class CiscoTest(absltest.TestCase):
 
         self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
 
-    # @capture.stdout
+    @capture.stdout
     def testObjectGroup(self):
         ip_grp = ['object-group network ipv4 SOME_HOST']
         ip_grp.append(' 10.0.0.0/8')
@@ -631,7 +631,6 @@ class CiscoTest(absltest.TestCase):
 
         pol = policy.ParsePolicy(GOOD_OBJGRP_HEADER + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
-        print(acl)
 
         self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
         self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
@@ -841,7 +840,7 @@ class CiscoTest(absltest.TestCase):
         self.assertIn('permit hbh any any', str(acl), str(acl))
         print(acl)
 
-    # @capture.stdout
+    @capture.stdout
     def testOwnerTerm(self):
         acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_13, self.naming), EXP_INFO)
         self.assertTrue(re.search(' remark Owner: foo@google.com', str(acl)), str(acl))

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -651,7 +651,6 @@ class CiscoTest(absltest.TestCase):
 
         self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
         self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
-        
 
     @capture.stdout
     def testInet6(self):

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -650,6 +650,7 @@ class CiscoTest(absltest.TestCase):
 
         self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST'), mock.call('SOME_HOST')])
         self.naming.GetServiceByProto.assert_called_once_with('HTTP', 'tcp')
+        print(acl)
 
     @capture.stdout
     def testInet6(self):

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.acl.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.acl.ref
@@ -97,16 +97,15 @@ ipv6 access-list ipv6-edge-inbound
 
 
  remark deny-from-reserved
- deny ipv6 ::/8 any
- deny ipv6 host ::1 any
+ deny ipv6 1000::/4 any
  deny ipv6 100::/8 any
  deny ipv6 200::/7 any
- deny ipv6 400::/6 any
- deny ipv6 800::/5 any
- deny ipv6 1000::/4 any
  deny ipv6 4000::/3 any
+ deny ipv6 400::/6 any
  deny ipv6 6000::/3 any
  deny ipv6 8000::/3 any
+ deny ipv6 800::/5 any
+ deny ipv6 ::/8 any
  deny ipv6 a000::/3 any
  deny ipv6 c000::/3 any
  deny ipv6 e000::/4 any
@@ -117,6 +116,7 @@ ipv6 access-list ipv6-edge-inbound
  deny ipv6 fe80::/10 any
  deny ipv6 fec0::/10 any
  deny ipv6 ff00::/8 any
+ deny ipv6 host ::1 any
 
 
  remark default-deny
@@ -132,24 +132,18 @@ ip access-list extended edge-outbound
 
  remark deny-to-bad-destinations
  deny ip any 0.0.0.0 0.255.255.255
- deny ip any 0.0.0.0 0.255.255.255
- deny ip any 10.0.0.0 0.255.255.255
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 100.64.0.0 0.63.255.255
  deny ip any 127.0.0.0 0.255.255.255
  deny ip any 169.254.0.0 0.0.255.255
  deny ip any 172.16.0.0 0.15.255.255
- deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.0.0.0 0.0.0.255
  deny ip any 192.0.2.0 0.0.0.255
- deny ip any 192.168.0.0 0.0.255.255
  deny ip any 192.168.0.0 0.0.255.255
  deny ip any 198.18.0.0 0.1.255.255
  deny ip any 198.51.100.0 0.0.0.255
  deny ip any 203.0.113.0 0.0.0.255
  deny ip any 224.0.0.0 15.255.255.255
- deny ip any 224.0.0.0 15.255.255.255
- deny ip any 240.0.0.0 15.255.255.255
  deny ip any 240.0.0.0 15.255.255.255
 
 
@@ -165,19 +159,18 @@ ipv6 access-list ipv6-edge-outbound
 
 
  remark deny-to-bad-destinations
- deny ipv6 any ::/8
- deny ipv6 any host ::1
- deny ipv6 any 100::/8
- deny ipv6 any 200::/7
- deny ipv6 any 400::/6
- deny ipv6 any 800::/5
  deny ipv6 any 1000::/4
+ deny ipv6 any 100::/8
  deny ipv6 any 2001:db8::/32
+ deny ipv6 any 200::/7
  deny ipv6 any 3ffe::/16
  deny ipv6 any 4000::/3
+ deny ipv6 any 400::/6
  deny ipv6 any 5f00::/8
  deny ipv6 any 6000::/3
  deny ipv6 any 8000::/3
+ deny ipv6 any 800::/5
+ deny ipv6 any ::/8
  deny ipv6 any a000::/3
  deny ipv6 any c000::/3
  deny ipv6 any e000::/4
@@ -188,7 +181,7 @@ ipv6 access-list ipv6-edge-outbound
  deny ipv6 any fe80::/10
  deny ipv6 any fec0::/10
  deny ipv6 any ff00::/8
- deny ipv6 any ff00::/8
+ deny ipv6 any host ::1
 
 
  remark default-accept


### PR DESCRIPTION
This starts the fixes for https://github.com/aerleon/aerleon/issues/40 and https://github.com/aerleon/aerleon/issues/41
We want to consolidate these so that we no longer have to worry about keeping multiple string functions in sync. Where there are differences those should be handled with inheritance or other ways to abstract the differences.

- Created a Term object for Extended and Object terms to inherit from, standard needs more work to inherit.
- StandardTerm now uses a `prefix` string to cut down on multiple if/else conditionals that are same beyond the prefix.
- Consolidated common logic of Extended and Object into the __init__ of `Term`.
- ObjectTerm has its own `_GetIpString` function as it differs from the standard.
- Sorted all lists in term constructor (line 633).
- Summarizer now has a hash function similar to IP objects in the standard library.