### PR TITLE
Fix #211

### DIFF
--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -8,7 +8,7 @@ from absl import logging
 from yaml.error import YAMLError
 
 from aerleon.lib import policy
-from aerleon.lib.policy import _SubpathOf, BadIncludePath
+from aerleon.lib.policy import BadIncludePath, _SubpathOf
 from aerleon.lib.policy_builder import (
     PolicyBuilder,
     RawFilter,

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -8,6 +8,7 @@ from absl import logging
 from yaml.error import YAMLError
 
 from aerleon.lib import policy
+from aerleon.lib.policy import _SubpathOf, BadIncludePath
 from aerleon.lib.policy_builder import (
     PolicyBuilder,
     RawFilter,
@@ -234,17 +235,23 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
         found_terms = []
         max_include_depth = 5
 
-        def process_include(depth, stack, inc_filename):
+        def process_include(depth, stack, include_filename):
+            include_path = pathlib.Path(base_dir).joinpath(include_filename)
+            if not _SubpathOf(base_dir, include_path):
+                raise BadIncludePath(
+                    f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
+                )
+
             try:
-                include_file = _LoadIncludeFile(base_dir, inc_filename)
+                include_file = _LoadIncludeFile(include_path)
                 include_data = yaml.load(
-                    include_file, Loader=SpanSafeYamlLoader(filename=inc_filename)
+                    include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
                 )
             except YAMLError as yaml_error:
                 raise PolicyTypeError(
                     UserMessage(
                         "Unable to read file as YAML.",
-                        filename=inc_filename,
+                        filename=str(include_path),
                         include_chain=stack,
                     )
                 ) from yaml_error
@@ -252,7 +259,7 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
                 logging.warning(
                     UserMessage(
                         "Ignoring empty policy include source.",
-                        filename=inc_filename,
+                        filename=str(include_path),
                         include_chain=stack,
                     )
                 )
@@ -330,10 +337,10 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
     return RawPolicy(filename=filename, filters=filters_model)
 
 
-def _LoadIncludeFile(base_dir, inc_filename):
+def _LoadIncludeFile(include_path):
     """Open an include file."""
 
-    with open(pathlib.Path(base_dir).joinpath(inc_filename), 'r') as include_file:
+    with open(include_path, 'r') as include_file:
         return include_file.read()
 
 

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -56,6 +56,10 @@ BAD_INCLUDE_YAML_INVALID_FILENAME = """
 terms:
 - include: include_1.pol
 """
+BAD_INCLUDE_YAML_INVALID_PATH = """
+terms:
+- include: /tmp/include_2.yaml
+"""
 BAD_INCLUDE_YAML_INVALID_YAML = """
 %INVALID YAML% &unknown
 """
@@ -384,6 +388,16 @@ Include stack:
 > File='policy_with_include.pol.yaml', Line=10 (Top Level)
 > File='include_1.pol-include.yaml', Line=3""",  # noqa: E501
             )
+
+    def testIncludeInvalidPath(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_PATH)):
+            with self.assertRaises(yaml_frontend.BadIncludePath):
+                yaml_frontend.ParsePolicy(
+                    GOOD_YAML_POLICY_INCLUDE,
+                    filename="policy_with_include.pol.yaml",
+                    base_dir=self.base_dir,
+                    definitions=self.naming,
+                )
 
     def testIncludeInvalidYAML(self):
         with mock.patch("builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_YAML)):


### PR DESCRIPTION
This applies the following restrictions to includes in .pol files and YAML policy files:

* Included file paths must be a subpath of base_directory.

This applies the following restrictions to includes in .pol files:

* Included files must end in ".inc".

YAML policy files already required that any included file name end in ".yaml" or ".yml".

Demo:
```
Before:

error encountered in rendering process:
Error parsing policy file policies/pol/sample_msmpc.pol:
<class 'aerleon.lib.policy.ParseError'> ERROR on "ssh-rsa" (type STRING, line 25, Next 'AAAAB3N…………….')

After:

error encountered in rendering process:
Error parsing policy file policies/pol/sample_msmpc.pol:
<class 'aerleon.lib.policy.BadIncludePath'>Include file name must end in ".inc". File=/home/j/.ssh/authorized_keys base_directory=./policies

Also after, with the name restriction removed so we can see the path restriction:

error encountered in rendering process:
Error parsing policy file policies/pol/sample_msmpc.pol:
<class 'aerleon.lib.policy.BadIncludePath'>Include file cannot be loaded from outside the base directory. File=/etc/passwd base_directory=./policies

```