### PR TITLE
Fix list in getting_started.md on readthedocs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -65,6 +65,7 @@ services:
 ```
 
 Above we have defined a couple of networks and services.
+
 * `RFC1918` is defined as three IP subnets.
 * `WEB_SERVERS` and `MAIL_SERVERS` are both two IP hosts and include a comment about those IPs.
 * `ALL_SERVERS` is a composite of both `WEB_SERVERS` and `MAIL_SERVERS`.


### PR DESCRIPTION
This fixes markdown formatting so this bullet list will appear correctly on ReadTheDocs.

Before:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/212901/216177940-3a4bc9f0-23e6-40cb-8bbb-709c4db8a8c5.png">

After:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/212901/216177815-22ad5fe4-293e-4101-b752-b688f6bc1491.png">
