### PR TITLE
Fix markdown formatting in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,22 +37,26 @@ All community leaders are obligated to respect the privacy and security of the r
 # Enforcement Guidelines
 Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-1. Correction
+### 1. Correction
+
 **Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 **Consequence:** A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
-2. Warning
+### 2. Warning
+
 **Community Impact:** A violation through a single incident or series of actions.
 
 **Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
-3. Temporary Ban
+### 3. Temporary Ban
+
 **Community Impact:** A serious violation of community standards, including sustained inappropriate behavior.
 
 **Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
-4. Permanent Ban
+### 4. Permanent Ban
+
 **Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence:** A permanent ban from any sort of public interaction within the community.


### PR DESCRIPTION
In "Enforcement Guidelines", the "Community Impact" lines were not appearing on their own lines. The numbered titles in this section were not aligned with the text.