### PR TITLE
fix broken `cgrep -o <object>` lookup

### DIFF
--- a/tools/cgrep.py
+++ b/tools/cgrep.py
@@ -238,8 +238,8 @@ def main(parser):
             else:
                 logging.info(token + ':')
                 # convert list of ip objects to strings and sort them
-                ips.sort(key=lambda x: int(x.ip))
-                p([str(x) for x in ips])
+                sorted_ips = nacaddr.SortAddrList(ips)
+                p([str(x) for x in sorted_ips])
 
     # if -s
     elif options.svc:


### PR DESCRIPTION
Lookup of an object with `cgrep -o <object>` did return: 
```text
  File "XXXXX/.venv/lib/python3.9/site-packages/tools/cgrep.py", line 241, in main
    ips.sort(key=lambda x: int(x.ip)) 
  File "XXXXX/.venv/lib/python3.9/site-packages/tools/cgrep.py", line 241, in <lambda> 
    ips.sort(key=lambda x: int(x.ip)) 
AttributeError: 'IPv4' object has no attribute 'ip' 
```
With the suggest fix it works as expected.