### PR TITLE
subnet comparison in aclcheck.py not working as expected

### DIFF
--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -257,10 +257,8 @@ class AclCheck(object):
         if not addresses:
             return True  # always true if term has nothing to match
         for next in addresses:
-            # ipaddr can incorrectly report ipv4 as contained with ipv6 addrs
-            if type(addr) is type(next):
-                if addr in next:
-                    return True
+            if addr.subnet_of(next):
+                return True
         return False
 
     def _PortInside(self, myport, port_list):


### PR DESCRIPTION
possible fix addressing problem described in https://github.com/aerleon/aerleon/issues/226

tests run clean with one seemingly unrelated warning-
====== 1882 passed, 1 warning in 40.79s 

 in tests/utils/iputils_test.py:28- Unknown pytest.mark.unit
