### PR TITLE
aclcheck should have the ability to specific base directory

### DIFF
--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -33,6 +33,12 @@ def main():
         default='./def',
     )
     _parser.add_option(
+        '--base-directory',
+        dest='basedir',
+        help='directory policies files are located in, sometimes necessary for resolving referenced includes',
+        default='',
+    )
+    _parser.add_option(
         '-p',
         '--policy-file',
         dest='pol',
@@ -64,14 +70,12 @@ def main():
     if pathlib.Path(FLAGS.pol).suffix in ['.yaml', '.yml']:
         policy_obj = yaml.ParsePolicy(
             conf,
+            base_dir=FLAGS.basedir,
             filename=FLAGS.pol,
             definitions=defs,
         )
     else:
-        policy_obj = policy.ParsePolicy(
-            conf,
-            defs,
-        )
+        policy_obj = policy.ParsePolicy(conf, defs, base_dir=FLAGS.basedir)
     check = aclcheck.AclCheck(
         policy_obj,
         src=FLAGS.src,

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -33,7 +33,7 @@ def main():
         default='./def',
     )
     _parser.add_option(
-        '--base_directory',
+        '--base-directory',
         dest='basedir',
         help='The base directory to look for include files.',
         default='',

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -33,9 +33,9 @@ def main():
         default='./def',
     )
     _parser.add_option(
-        '--base-directory',
+        '--base_directory',
         dest='basedir',
-        help='directory policies files are located in, sometimes necessary for resolving referenced includes',
+        help='The base directory to look for include files.',
         default='',
     )
     _parser.add_option(


### PR DESCRIPTION
proposing this as a fix for this issue https://github.com/aerleon/aerleon/issues/227

Leaving the default as blank to match current behavior, in case changing it would break any existing implementations. However, I think having the default base directory for aclgen and aclcheck_cmdline may make more sense.