### PR TITLE
Fixing black version rather than GH Action Version

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,7 +93,9 @@ jobs:
       #----------------------------------------------
       - name: Format project using Black
         if: steps.paths-filter.outputs.run_format == 'true'
-        uses: psf/black@22.12.0
+        uses: psf/black@stable
+        with:
+          version: "22.12.0"
       #----------------------------------------------
       # run isort
       #----------------------------------------------


### PR DESCRIPTION
The `psf/black@22.12.0` was actually the github action version rather than the version of black. This is talked about in  https://github.com/psf/black/issues/3382

We are not pinning the version of black and using stable for the github action version.