### PR TITLE
Add support for aerleon.yml file

### DIFF
--- a/aerleon.yml
+++ b/aerleon.yml
@@ -1,0 +1,4 @@
+base_directory: ./policies
+definitions_directory: ./def
+exp_info: 2
+max_renderers: 10

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -24,7 +24,6 @@ from aerleon.utils import config
 
 
 def main():
-    usage = 'usage: %prog [options] arg'
     _parser = ArgumentParser(
         prog='aclcheck',
         formatter_class=RawTextHelpFormatter,

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -24,7 +24,6 @@ from aerleon.utils import config
 
 
 def main():
-    # TODO(robankeny): Lets move this to gflags
     # usage = 'usage: %prog [options] arg'
     _parser = ArgumentParser(
         prog='aclcheck',

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -24,7 +24,7 @@ from aerleon.utils import config
 
 
 def main():
-    # usage = 'usage: %prog [options] arg'
+    usage = 'usage: %prog [options] arg'
     _parser = ArgumentParser(
         prog='aclcheck',
         formatter_class=RawTextHelpFormatter,

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -516,7 +516,11 @@ def Run(
 def main(argv):
     del argv  # Unused.
 
-    configs = config.generate_configs(FLAGS)
+    absl_flags = {
+        flag: getattr(FLAGS, flag) for flag in config.defaults.keys() if getattr(FLAGS, flag, None)
+    }
+    configs = config.load_config(config_file=FLAGS.config_file)
+    configs.update(absl_flags)
 
     if configs['verbose']:
         logging.set_verbosity(logging.INFO)

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -519,8 +519,11 @@ def main(argv):
     absl_flags = {
         flag: getattr(FLAGS, flag) for flag in config.defaults.keys() if getattr(FLAGS, flag, None)
     }
-    configs = config.load_config(config_file=FLAGS.config_file)
-    configs.update(absl_flags)
+    try:
+        configs = config.load_config(config_file=FLAGS.config_file)
+        configs.update(absl_flags)
+    except config.ConfigFileError as e:
+        exit(f"Error: {e}")
 
     if configs['verbose']:
         logging.set_verbosity(logging.INFO)

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -17,6 +17,7 @@
 """Check where hosts, ports and protocols are matched in an Aerleon policy."""
 
 import logging
+
 from aerleon.lib import nacaddr, policy, port
 
 

--- a/aerleon/utils/config.py
+++ b/aerleon/utils/config.py
@@ -2,6 +2,7 @@
 # Modifications Copyright 2022-2023 Aerleon Project Authors.
 """A module to handle merging file configurations with CLI configs for Aerleon."""
 
+import pathlib
 import yaml
 
 defaults = {
@@ -19,55 +20,49 @@ defaults = {
     'exp_info': 2,
 }
 
+default_file = './aerleon.yml'
 
-def yaml_loader(filename):
-    with open(filename, 'r') as f:
+
+def load_config(
+    config_file: "str | pathlib.Path | list[str | pathlib.Path]" = None,
+    apply_defaults: bool = True,
+) -> dict:
+    """Load Aerleon configuration file(s).
+
+    Args:
+        config_file: An optional string or pathlib.Path with the location of the config file
+            to open. A list of config files can be given. Default is './aerleon.yml'.
+        apply_defaults: Whether to set missing config fields to their default values. Default
+            is True.
+
+    Raises:
+        IOError: If open(config_file) raises an IOError. Note that it is not an error for the
+            config file to not exist.
+        yaml.YAMLError: If the config file is not valid YAML.
+
+    Returns: a dictionary containing the contents of the config file. If no config file is found
+        all default values will be returned (unless apply_defaults is False). If a list of config
+        files is given their contents will be merged by their order in the list."""
+
+    if not config_file:
+        config_file = [pathlib.Path(default_file)]
+    elif not isinstance(config_file, list):
+        config_file = [config_file]
+
+    local_defaults = {}
+    if apply_defaults:
+        local_defaults.update(defaults)
+
+    for config in config_file:
+        if isinstance(config, str):
+            config = pathlib.Path(config)
+
         try:
-            data = yaml.safe_load(f)
-        except AttributeError:
-            data = yaml.safe_load(f)
+            with open(config, 'r') as f:
+                data = yaml.safe_load(f)
+                local_defaults.update(data)  # NOTE: Safe as long as the config file is flat
 
-    return data
+        except FileNotFoundError:
+            pass
 
-
-def flags_to_dict(absl_flags):
-    base = {
-        'base_directory': absl_flags.base_directory,
-        'definitions_directory': absl_flags.definitions_directory,
-        'policy_file': absl_flags.policy_file,
-        'output_directory': absl_flags.output_directory,
-        'optimize': absl_flags.optimize,
-        'recursive': absl_flags.recursive,
-        'debug': absl_flags.debug,
-        'verbose': absl_flags.verbose,
-        'ignore_directories': absl_flags.ignore_directories,
-        'max_renderers': absl_flags.max_renderers,
-        'shade_check': absl_flags.shade_check,
-        'exp_info': absl_flags.exp_info,
-    }
-
-    return {flag: base[flag] for flag in filter(lambda f: base[f] is not None, base)}
-
-
-def merge_files(*files):
-    result = {}
-
-    for item in files:
-        data = yaml_loader(item)
-        result.update(data)
-
-    return {flag: result[flag] for flag in filter(lambda f: result[f] is not None, result)}
-
-
-def generate_configs(absl_flags):
-    cli_configs = flags_to_dict(absl_flags)
-    if absl_flags.config_file:
-        file_configs = merge_files(*absl_flags.config_file)
-    else:
-        file_configs = {}
-
-    result = defaults.copy()
-    result.update(cli_configs)
-    result.update(file_configs)
-
-    return result
+    return local_defaults

--- a/aerleon/utils/config.py
+++ b/aerleon/utils/config.py
@@ -3,6 +3,7 @@
 """A module to handle merging file configurations with CLI configs for Aerleon."""
 
 import pathlib
+
 import yaml
 
 defaults = {

--- a/tests/lib/aclcheck_test.py
+++ b/tests/lib/aclcheck_test.py
@@ -18,7 +18,6 @@ from absl.testing import absltest
 
 from aerleon.lib import aclcheck, naming, policy, port
 
-
 POLICYTEXT = """
 header {
   comment:: "this is a test acl"

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -1,6 +1,7 @@
 """Unit tests for config.py"""
 
 from unittest import mock
+
 from absl.testing import absltest
 
 from aerleon.utils import config

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -1,0 +1,115 @@
+"""Unit tests for config.py"""
+
+from unittest import mock
+from absl.testing import absltest
+
+from aerleon.utils import config
+
+EXAMPLE_CONFIG_FILE1 = """
+base_directory: ./example_base_directory1
+"""
+
+EXAMPLE_CONFIG_FILE2 = """
+base_directory: ./example_base_directory2
+definitions_directory: ./example_defs_directory2
+"""
+
+
+class ConfigTestSute(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def testDefaultFile(self):
+        """Zero args, aerleon.yml present."""
+        mock_open_conf = mock.mock_open(read_data=EXAMPLE_CONFIG_FILE1)
+        with mock.patch("builtins.open", mock_open_conf):
+            config_data = config.load_config()
+            expected = {}
+            expected.update(config.defaults)
+            expected['base_directory'] = './example_base_directory1'
+            self.assertEqual(str(mock_open_conf.call_args[0][0]), 'aerleon.yml')
+            self.assertDictEqual(expected, config_data)
+
+    def testDefaultFileNotFound(self):
+        """Zero args, aerleon.yml not found."""
+        mock_error = mock.MagicMock()
+        mock_error.return_value.__enter__.side_effect = FileNotFoundError()
+        with mock.patch("builtins.open", mock_error):
+            config_data = config.load_config()
+            self.assertEqual(str(mock_error.call_args[0][0]), 'aerleon.yml')
+            self.assertDictEqual(config.defaults, config_data)
+
+    def testInvalidDefaultFile(self):
+        """Zero args, aerleon.yml present but invalid."""
+        # YAML case
+        with mock.patch("builtins.open", mock.mock_open(read_data="\"")):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'not a valid YAML file'):
+                config.load_config()
+
+        # Invalid case
+        with mock.patch("builtins.open", mock.mock_open(read_data="")):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'contents not valid'):
+                config.load_config()
+
+        # Permissions case
+        mock_error = mock.MagicMock()
+        mock_error.return_value.__enter__.side_effect = PermissionError()
+        with mock.patch("builtins.open", mock_error):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'Insufficient permissions'):
+                config.load_config()
+
+    def testGivenFile(self):
+        """Config file given."""
+        mock_open_conf = mock.mock_open(read_data=EXAMPLE_CONFIG_FILE1)
+        with mock.patch("builtins.open", mock_open_conf):
+            config_data = config.load_config(config_file='config.yaml')
+            expected = {}
+            expected.update(config.defaults)
+            expected['base_directory'] = './example_base_directory1'
+            self.assertEqual(str(mock_open_conf.call_args[0][0]), 'config.yaml')
+            self.assertDictEqual(expected, config_data)
+
+    def testGivenFileNotFound(self):
+        """Config file given but not found."""
+        mock_error = mock.MagicMock()
+        mock_error.return_value.__enter__.side_effect = FileNotFoundError()
+        with mock.patch("builtins.open", mock_error):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'Config file not found'):
+                config.load_config(config_file='config.yaml')
+
+    def testInvalidGivenFile(self):
+        """Config file given but invalid."""
+        # YAML case
+        with mock.patch("builtins.open", mock.mock_open(read_data="\"")):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'not a valid YAML file'):
+                config.load_config(config_file='config.yaml')
+
+        # Invalid case
+        with mock.patch("builtins.open", mock.mock_open(read_data="")):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'contents not valid'):
+                config.load_config(config_file='config.yaml')
+
+        # Permissions case
+        mock_error = mock.MagicMock()
+        mock_error.return_value.__enter__.side_effect = PermissionError()
+        with mock.patch("builtins.open", mock_error):
+            with self.assertRaisesRegexp(config.ConfigFileError, r'Insufficient permissions'):
+                config.load_config(config_file='config.yaml')
+
+    def testGivenFileList(self):
+        """List of config files given."""
+
+        config_files = (data for data in [EXAMPLE_CONFIG_FILE2, EXAMPLE_CONFIG_FILE1])
+
+        mock_open_conf = mock.MagicMock()
+        mock_open_conf.return_value.__enter__.side_effect = lambda: next(config_files)
+        with mock.patch("builtins.open", mock_open_conf):
+            config_data = config.load_config(config_file=['config2.yaml', 'config1.yaml'])
+            expected = {}
+            expected.update(config.defaults)
+            expected['base_directory'] = './example_base_directory1'
+            expected['definitions_directory'] = './example_defs_directory2'
+
+            self.assertEqual(str(mock_open_conf.call_args_list[0][0][0]), 'config2.yaml')
+            self.assertEqual(str(mock_open_conf.call_args_list[1][0][0]), 'config1.yaml')
+            self.assertDictEqual(expected, config_data)


### PR DESCRIPTION
Fixes #237 

<img width="283" alt="image" src="https://user-images.githubusercontent.com/212901/216678009-2cbda04c-5d13-4c4b-a117-5118b818b2f5.png">

### Changes in this PR: aerleon.yml

* `aclgen` and `aclcheck` will now try to read configuration settings from `aerleon.yml` in the current directory.
* Configuration settings found in `aerleon.yml` can be overridden by command line arguments.
* `aclgen` and `aclcheck` can be given the command line argument `--config_file` to use a different config file instead. In the `aclgen` case it is still possible to provide multiple config files with this argument (this was supported before this PR).
* It is not an error if `aerleon.yml` is not found.
* An example `aerleon.yml` file is included in this repo with some default settings.

### Other changes in this PR

* `aclgen` now gives command line arguments precedence over settings found in config files.
* `aclcheck` is upgraded from `optparse` to `argparse`.
* All `absl`-specific code was removed from `aerleon.utils.config`. The config module interface is simplified.

### Future changes

* We should add a JSON Schema for `aerleon.yml` for in-editor validation, autocomplete, and tooltips.