### PR TITLE
Removing "IP" as prerequisite to using fragments in Cisco ACLs

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -571,7 +571,7 @@ class Term(aclgenerator.Term):
             if 'established' not in self.options:
                 self.options.append('established')
         # Using both 'fragments' and 'is-fragment', ref Github Issue #187
-        if ('ip' in protocol) and (('fragments' in opts) or ('is-fragment' in opts)):
+        if (('fragments' in opts) or ('is-fragment' in opts)):
             if 'fragments' not in self.options:
                 self.options.append('fragments')
         # ACL-based Forwarding

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -571,7 +571,7 @@ class Term(aclgenerator.Term):
             if 'established' not in self.options:
                 self.options.append('established')
         # Using both 'fragments' and 'is-fragment', ref Github Issue #187
-        if (('fragments' in opts) or ('is-fragment' in opts)):
+        if ('fragments' in opts) or ('is-fragment' in opts):
             if 'fragments' not in self.options:
                 self.options.append('fragments')
         # ACL-based Forwarding


### PR DESCRIPTION
In a extended or object-group term we check if `fragments` or `is-fragments` is set as an option inside the term. We also check if `ip` is present in the list of protocols. I don't believe this check is actually necessary.

```
R1(config-ext-nacl)#permit pim any any ?
  dscp        Match packets with given dscp value
  fragments   Check non-initial fragments
  log         Log matches against this entry
  log-input   Log matches against this entry, including input interface
  option      Match packets with given IP Options value
  precedence  Match packets with given precedence value
  reflect     Create reflexive access list entry
  time-range  Specify a time-range
  tos         Match packets with given TOS value
  ttl         Match packets with given TTL value
  <cr>
```
You can see `fragments` in the above available options for `pim`
Looking through the available protocols that are given by name

```
R1(config-ext-nacl)#permit ?
  <0-255>       An IP protocol number
  ahp           Authentication Header Protocol
  eigrp         Cisco's EIGRP routing protocol
  esp           Encapsulation Security Payload
  gre           Cisco's GRE tunneling
  icmp          Internet Control Message Protocol
  igmp          Internet Gateway Message Protocol
  ip            Any Internet Protocol
  ipinip        IP in IP tunneling
  nos           KA9Q NOS compatible IP over IP tunneling
  object-group  Service object group
  ospf          OSPF routing protocol
  pcp           Payload Compression Protocol
  pim           Protocol Independent Multicast
  tcp           Transmission Control Protocol
  udp           User Datagram Protocol
```

All the ones I checked allowed for fragments and a random sampling of protocols by number also showed fragments as available.

This fixes https://github.com/aerleon/aerleon/issues/42