### PR TITLE
aclcheck CLI help message

### DIFF
--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -29,42 +29,42 @@ def main():
         formatter_class=RawTextHelpFormatter,
     )
     _parser.add_argument(
+        '-p',
+        '--policy-file',
+        dest='pol',
+        help='The policy file to examine.',
+        required=True,
+    )
+    _parser.add_argument(
         '--definitions-directory',
         dest='definitions_directory',
-        help='definitions directory',
+        help='The directory where network and service definition files can be found.',
     )
     _parser.add_argument(
         '--base-directory',
         dest='base_directory',
-        help='The base directory to look for include files.',
-    )
-    _parser.add_argument(
-        '-p',
-        '--policy-file',
-        dest='pol',
-        help='policy file',
-        required=True,
+        help='The base directory to use when resolving policy include paths.',
     )
     _parser.add_argument(
         '--config-file',
         dest='config_file',
-        help='config file',
+        help='Change the location searched for the configuration YAML file.',
     )
-    _parser.add_argument('-d', '--destination', dest='dst', help='destination IP')
+    _parser.add_argument('-d', '--destination', dest='destination_ip', help='destination IP')
     _parser.add_argument(
         '-s',
         '--source',
-        dest='src',
-        help='source IP',
+        dest='source_ip',
+        help='Source IP.',
     )
     _parser.add_argument(
         '--proto',
         '--protocol',
-        dest='proto',
+        dest='protocol',
         help='Protocol (tcp, udp, icmp, etc.)',
     )
-    _parser.add_argument('--dport', '--destination-port', dest='dport', help='destination port')
-    _parser.add_argument('--sport', '--source-port', dest='sport', help='source port')
+    _parser.add_argument('--dport', '--destination-port', dest='destination_port', help='Destination port.')
+    _parser.add_argument('--sport', '--source-port', dest='source_port', help='Source port.')
     FLAGS = _parser.parse_args()
 
     default_flags = {
@@ -72,11 +72,11 @@ def main():
         'definitions_directory': './def',
         'pol': None,
         'config_file': None,
-        'dst': '200.1.1.1',
-        'src': 'any',
-        'proto': 'any',
-        'dport': '80',
-        'sport': '1025',
+        'destination_ip': '200.1.1.1',
+        'source_ip': 'any',
+        'protocol': 'any',
+        'destination_port': '80',
+        'source_port': '1025',
     }
 
     configs = {}
@@ -113,11 +113,11 @@ def main():
         policy_obj = policy.ParsePolicy(conf, defs, base_dir=configs['base_directory'])
     check = aclcheck.AclCheck(
         policy_obj,
-        src=configs['src'],
-        dst=configs['dst'],
-        sport=configs['sport'],
-        dport=configs['dport'],
-        proto=configs['proto'],
+        src=configs['source_ip'],
+        dst=configs['destination_ip'],
+        sport=configs['source_port'],
+        dport=configs['destination_port'],
+        proto=configs['protocol'],
     )
     print(str(check))
 

--- a/aerleon/aclcheck_cmdline.py
+++ b/aerleon/aclcheck_cmdline.py
@@ -26,6 +26,7 @@ from aerleon.utils import config
 def main():
     _parser = ArgumentParser(
         prog='aclcheck',
+        description=aclcheck.AclCheck.__doc__.splitlines()[0],
         formatter_class=RawTextHelpFormatter,
     )
     _parser.add_argument(
@@ -50,7 +51,7 @@ def main():
         dest='config_file',
         help='Change the location searched for the configuration YAML file.',
     )
-    _parser.add_argument('-d', '--destination', dest='destination_ip', help='destination IP')
+    _parser.add_argument('-d', '--destination', dest='destination_ip', help='Destination IP.')
     _parser.add_argument(
         '-s',
         '--source',
@@ -63,7 +64,9 @@ def main():
         dest='protocol',
         help='Protocol (tcp, udp, icmp, etc.)',
     )
-    _parser.add_argument('--dport', '--destination-port', dest='destination_port', help='Destination port.')
+    _parser.add_argument(
+        '--dport', '--destination-port', dest='destination_port', help='Destination port.'
+    )
     _parser.add_argument('--sport', '--source-port', dest='source_port', help='Source port.')
     FLAGS = _parser.parse_args()
 

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -55,7 +55,7 @@ class AclCheck:
       An AclCheck Object
 
     Raises:
-      port.BarPortValue: An invalid source port is used
+      port.BadPortValue: An invalid source port is used
       port.BadPortRange: A port is outside of the acceptable range 0-65535
       AddressError: Incorrect ip address or format
 


### PR DESCRIPTION
This change tidies up the help message for aclcheck.

New help message:
```
$ aclcheck --help
usage: aclcheck [-h] -p POL [--definitions-directory DEFINITIONS_DIRECTORY] [--base-directory BASE_DIRECTORY] [--config-file CONFIG_FILE] [-d DESTINATION_IP] [-s SOURCE_IP]
                [--proto PROTOCOL] [--dport DESTINATION_PORT] [--sport SOURCE_PORT]

Check where hosts, ports and protocols match in a NAC policy.

options:
  -h, --help            show this help message and exit
  -p POL, --policy-file POL
                        The policy file to examine.
  --definitions-directory DEFINITIONS_DIRECTORY
                        The directory where network and service definition files can be found.
  --base-directory BASE_DIRECTORY
                        The base directory to use when resolving policy include paths.
  --config-file CONFIG_FILE
                        Change the location searched for the configuration YAML file.
  -d DESTINATION_IP, --destination DESTINATION_IP
                        Destination IP.
  -s SOURCE_IP, --source SOURCE_IP
                        Source IP.
  --proto PROTOCOL, --protocol PROTOCOL
                        Protocol (tcp, udp, icmp, etc.)
  --dport DESTINATION_PORT, --destination-port DESTINATION_PORT
                        Destination port.
  --sport SOURCE_PORT, --source-port SOURCE_PORT
                        Source port.
```

Old help message:
```
usage: aclcheck [-h] [--definitions-directory DEFINITIONS_DIRECTORY] [--base-directory BASE_DIRECTORY] -p POL [--config-file CONFIG_FILE] [-d DST] [-s SRC] [--proto PROTO] [--dport DPORT]
                [--sport SPORT]

options:
  -h, --help            show this help message and exit
  --definitions-directory DEFINITIONS_DIRECTORY
                        definitions directory
  --base-directory BASE_DIRECTORY
                        The base directory to look for include files.
  -p POL, --policy-file POL
                        policy file
  --config-file CONFIG_FILE
                        config file
  -d DST, --destination DST
                        destination IP
  -s SRC, --source SRC  source IP
  --proto PROTO, --protocol PROTO
                        Protocol (tcp, udp, icmp, etc.)
  --dport DPORT, --destination-port DPORT
                        destination port
  --sport SPORT, --source-port SPORT
                        source port
```