### PR TITLE
Add api.AclCheck and accept PolicyDict input in more places

### DIFF
--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -419,7 +419,7 @@ def PolicyFromDict(
 
 
 def AclCheck(
-    input_policy: dict,
+    input_policy: policy_builder.PolicyDict,
     definitions: naming.Naming,
     src: str = None,
     dst: str = None,
@@ -435,6 +435,5 @@ def AclCheck(
             'Error parsing policy %s:\n%s%s' % (filename, sys.exc_info()[0], sys.exc_info()[1])
         ) from e
 
-    # TODO: return a dict or list with data organized in the same fashion as str(check)
     check = aclcheck.AclCheck(policy_obj, src, dst, sport, dport, proto)
-    return check
+    return check.Summarize()

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -345,7 +345,9 @@ def _GenerateACL(
 ):
     filename = input_policy.get("filename")
     try:
-        _, policy_obj = PolicyFromDict(input_policy, definitions, optimize, shade_check)
+        policy_obj = policy.FromBuilder(
+            policy_builder.PolicyBuilder(input_policy, definitions, optimize, shade_check)
+        )
     except policy.ShadingError as e:
         logging.warning('shading errors for %s:\n%s', filename, e)
         return
@@ -402,20 +404,6 @@ def _GenerateACL(
             raise ACLGeneratorError(
                 'Error generating target ACL for %s:\n%s' % (filename, e)
             ) from e
-
-
-def PolicyFromDict(
-    input_policy: policy_builder.PolicyDict,
-    definitions: naming.Naming,
-    optimize: bool = False,
-    shade_check: bool = False,
-):
-    filename = input_policy.get("filename")
-    policy_obj = policy.FromBuilder(
-        policy_builder.PolicyBuilder(input_policy, definitions, optimize, shade_check)
-    )
-
-    return filename, policy_obj
 
 
 def AclCheck(

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -429,11 +429,11 @@ def AclCheck(
 ):
     filename = input_policy.get("filename")
     try:
-        _, policy_obj = PolicyFromDict(input_policy, definitions)
+        check = aclcheck.AclCheck.FromPolicyDict(
+            input_policy, definitions, src, dst, sport, dport, proto
+        )
+        return check.Summarize()
     except (policy.Error, naming.Error) as e:
         raise ACLParserError(
             'Error parsing policy %s:\n%s%s' % (filename, sys.exc_info()[0], sys.exc_info()[1])
         ) from e
-
-    check = aclcheck.AclCheck(policy_obj, src, dst, sport, dport, proto)
-    return check.Summarize()

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -215,7 +215,7 @@ class AclCheck:
         text = []
         summary = self.Summarize()
         for filter, terms in summary.items():
-            text.append('  filter: ' + filter)
+            text.append(f"{' ' * 2}filter: {filter}")
             for matches in terms.values():
                 text.append(matches['message'])
         return '\n'.join(text)

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -75,7 +75,7 @@ class AclCheck:
     ):
         """Construct an AclCheck object from a PolicyDict + Naming object."""
         policy_obj = policy.FromBuilder(policy_builder.PolicyBuilder(policy_dict, definitions))
-        cls(policy_obj, src, dst, sport, dport, proto)
+        return cls(policy_obj, src, dst, sport, dport, proto)
 
     def __init__(
         self,
@@ -90,20 +90,20 @@ class AclCheck:
         self.proto = proto
 
         # validate source port
-        if sport == 'any':
-            self.sport = sport
+        if not sport or sport == 'any':
+            self.sport = 'any'
         else:
             self.sport = port.Port(sport)
 
         # validate destination port
-        if dport == 'any':
-            self.dport = dport
+        if not dport or dport == 'any':
+            self.dport = 'any'
         else:
             self.dport = port.Port(dport)
 
         # validate source address
-        if src == 'any':
-            self.src = src
+        if not src or src == 'any':
+            self.src = 'any'
         else:
             try:
                 self.src = nacaddr.IP(src)
@@ -111,8 +111,8 @@ class AclCheck:
                 raise AddressError('bad source address: %s\n' % src)
 
         # validate destination address
-        if dst == 'any':
-            self.dst = dst
+        if not dst or dst == 'any':
+            self.dst = 'any'
         else:
             try:
                 self.dst = nacaddr.IP(dst)

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from aerleon.lib import nacaddr, policy, port
+from aerleon.lib import nacaddr, naming, policy, policy_builder, port
 
 
 class Error(Exception):
@@ -61,9 +61,24 @@ class AclCheck:
 
     """
 
+    @classmethod
+    def FromPolicyDict(
+        cls,
+        policy_dict: policy_builder.PolicyDict,
+        definitions: naming.Naming,
+        src,
+        dst,
+        sport,
+        dport,
+        proto,
+    ):
+        """Construct an AclCheck object from a PolicyDict + Naming object."""
+        policy_obj = policy.FromBuilder(policy_builder.PolicyBuilder(policy_dict, definitions))
+        cls(policy_obj, src, dst, sport, dport, proto)
+
     def __init__(
         self,
-        pol,
+        pol: policy.Policy,
         src='any',
         dst='any',
         sport='any',

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -29,6 +29,11 @@ from aerleon.lib.recognizers import (
     TValue,
 )
 
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
+
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated
 else:
@@ -43,11 +48,6 @@ if sys.version_info < (3, 11):
     from typing_extensions import NotRequired, Required
 else:
     from typing import NotRequired, Required
-
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
 
 if typing.TYPE_CHECKING:
     from datetime import datetime

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -185,7 +185,6 @@ def PreprocessYAMLPolicy(filename, base_dir, policy_dict: PolicyDict):
                 )
             )
 
-
         header = filter['header']
         if 'targets' not in header or (
             header['targets'] is not None and not isinstance(header['targets'], dict)

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -11,6 +11,7 @@ from aerleon.lib import policy
 from aerleon.lib.policy import BadIncludePath, _SubpathOf
 from aerleon.lib.policy_builder import (
     PolicyBuilder,
+    PolicyDict,
     RawFilter,
     RawFilterHeader,
     RawPolicy,
@@ -101,15 +102,15 @@ def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_che
     """
     with open(pathlib.Path(base_dir).joinpath(filename), 'r') as file:
         try:
-            file_data = yaml.load(file, Loader=SpanSafeYamlLoader(filename=filename))
+            policy_dict = yaml.load(file, Loader=SpanSafeYamlLoader(filename=filename))
         except YAMLError as yaml_error:
             raise PolicyTypeError(
                 UserMessage("Unable to read file as YAML.", filename=filename)
             ) from yaml_error
-    raw_policy = _RawPolicyFromFile(filename, base_dir, file_data)
-    if not raw_policy:
+    policy_dict = PreprocessYAMLPolicy(filename, base_dir, policy_dict)
+    if not policy_dict:
         return
-    return _PolicyFromRawPolicy(raw_policy, definitions, optimize, shade_check)
+    return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
 
 
 def ParsePolicy(
@@ -132,31 +133,30 @@ def ParsePolicy(
         PolicyTypeError: The policy file provided is not valid.
     """
     try:
-        file_data = yaml.load(file, Loader=SpanSafeYamlLoader(filename=filename))
+        policy_dict = yaml.load(file, Loader=SpanSafeYamlLoader(filename=filename))
     except YAMLError as yaml_error:
         raise PolicyTypeError(
             UserMessage("Unable to read file as YAML.", filename=filename)
         ) from yaml_error
-    raw_policy = _RawPolicyFromFile(filename, base_dir, file_data)
-    if not raw_policy:
+
+    policy_dict = PreprocessYAMLPolicy(filename, base_dir, policy_dict)
+    if not policy_dict:
         return
-    return _PolicyFromRawPolicy(raw_policy, definitions, optimize, shade_check)
+    return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
 
 
-def _RawPolicyFromFile(filename, base_dir, file_data):
-    """Construct and return a RawPolicy from file data."""
-
-    filters_model = []
+def PreprocessYAMLPolicy(filename, base_dir, policy_dict: PolicyDict):
+    """Process includes and validate the file data as a PolicyDict."""
 
     # Empty files are ignored with a warning
-    if file_data is None or not file_data:
+    if policy_dict is None or not policy_dict:
         logging.warning(UserMessage("Ignoring empty policy file.", filename=filename))
         return
 
     # Malformed policy files should generate a PolicyTypeError (unless this is an include file)
-    if 'filters' not in file_data or not isinstance(file_data['filters'], list):
+    if 'filters' not in policy_dict or not isinstance(policy_dict['filters'], list):
 
-        if 'terms' in file_data:
+        if 'terms' in policy_dict:
             # In this case we are looking at an include file and need to quietly ignore it.
             return
 
@@ -164,7 +164,7 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
             UserMessage("Policy file must contain one or more filter sections.", filename=filename)
         )
 
-    for filter in file_data['filters']:
+    for filter in policy_dict['filters']:
         # Malformed filters should generate a PolicyTypeError
         if not isinstance(filter, dict):
             raise PolicyTypeError(UserMessage("Filter must be a mapping.", filename=filename))
@@ -176,9 +176,7 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
                     line=filter['__line__'],
                 )
             )
-        if 'terms' not in filter or (
-            filter['terms'] is not None and not isinstance(filter['terms'], list)
-        ):
+        if 'terms' not in filter or not filter['terms'] or not isinstance(filter['terms'], list):
             raise PolicyTypeError(
                 UserMessage(
                     "Filter must contain a terms section.",
@@ -186,16 +184,7 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
                     line=filter['__line__'],
                 )
             )
-        # Filters with an empty term list can be ignored with a warning
-        elif filter['terms'] is None:
-            logging.warning(
-                UserMessage(
-                    "Ignoring filter with zero terms.",
-                    filename=filename,
-                    line=filter['__line__'],
-                )
-            )
-            continue
+
 
         header = filter['header']
         if 'targets' not in header or (
@@ -217,20 +206,6 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
                     line=filter['__line__'],
                 )
             )
-            continue
-
-        targets_model = {
-            target: options
-            for target, options in header['targets'].items()
-            if target not in ('__line__', '__filename__')
-        }
-
-        header_kvs_model = {
-            key: value
-            for key, value in header.items()
-            if key not in ('targets', '__line__', '__filename__')
-        }
-        header_model = RawFilterHeader(targets=targets_model, kvs=header_kvs_model)
 
         found_terms = []
         max_include_depth = 5
@@ -308,7 +283,6 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
             )
             continue
 
-        terms_model = []
         for term_item in found_terms:
             if 'name' not in term_item or len(term_item['name'].strip()) == 0:
                 raise PolicyTypeError(
@@ -318,23 +292,24 @@ def _RawPolicyFromFile(filename, base_dir, file_data):
                         line=term_item['__line__'],
                     )
                 )
-            name = term_item['name']
-            term_kvs_model = {
-                key: value
-                for key, value in term_item.items()
-                if key not in ('name', '__filename__', '__line__')
-            }
 
-            # strip any nested debugging data
-            for value in term_kvs_model.values():
-                if isinstance(value, dict):
-                    value.pop('__line__')
-                    value.pop('__filename__')
+        filter['terms'] = found_terms
 
-            terms_model.append(RawTerm(name=name, kvs=term_kvs_model))
-        filters_model.append(RawFilter(header=header_model, terms=terms_model))
+    def StripDebuggingData(data):
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, list) or isinstance(item, dict):
+                    StripDebuggingData(item)
+        elif isinstance(data, dict):
+            data.pop('__line__', None)
+            data.pop('__filename__', None)
+            for item in data.values():
+                if isinstance(item, list) or isinstance(item, dict):
+                    StripDebuggingData(item)
 
-    return RawPolicy(filename=filename, filters=filters_model)
+    StripDebuggingData(policy_dict)
+
+    return policy_dict
 
 
 def _LoadIncludeFile(include_path):
@@ -342,10 +317,3 @@ def _LoadIncludeFile(include_path):
 
     with open(include_path, 'r') as include_file:
         return include_file.read()
-
-
-def _PolicyFromRawPolicy(raw_policy, definitions, optimize=False, shade_check=False):
-    """Construct and return a policy.Policy model from a RawPolicy."""
-
-    policy_builder = PolicyBuilder(raw_policy, definitions, optimize, shade_check)
-    return policy.FromBuilder(policy_builder)

--- a/tests/api/ApiTest.testDocsExample.stdout.ref
+++ b/tests/api/ApiTest.testDocsExample.stdout.ref
@@ -1,0 +1,24 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list extended test-filter
+ip access-list extended test-filter
+ remark $Id:$
+
+
+ remark deny-to-reserved
+ deny ip any 0.0.0.0 0.255.255.255
+ deny ip any 10.0.0.0 0.255.255.255
+
+
+ remark deny-to-bogons
+ deny ip any 192.0.0.0 0.0.0.255
+ deny ip any 192.0.2.0 0.0.0.255
+
+
+ remark allow-web-to-mail
+ permit ip any host 200.1.2.4
+ permit ip any host 200.1.2.5
+
+exit
+

--- a/tests/api/api_test.py
+++ b/tests/api/api_test.py
@@ -5,6 +5,7 @@ from absl.testing import absltest
 from aerleon import api
 from aerleon.lib import naming
 from aerleon.lib.policy_builder import PolicyDict
+from tests.regression_utils import capture
 
 # fmt: off
 GOOD_POLICY_1: PolicyDict = {
@@ -204,6 +205,18 @@ class ApiTest(absltest.TestCase):
         self.assertTrue(re.search(' deny-to-reserved', str(acl)))
         self.assertTrue(re.search(' deny ip any 10.2.0.0 0.0.255.255', str(acl)))
 
+    def testAclCheck(self):
+        definitions = naming.Naming()
+        definitions.ParseDefinitionsObject(SERVICES_1, "blah")
+        definitions.ParseDefinitionsObject(NETWORKS_1, "blah")
+
+        configs = api.AclCheck(GOOD_POLICY_1, definitions, src="10.2.0.0")
+        self.assertIn('deny-to-reserved', configs['test-filter'].keys())
+
+        configs = api.AclCheck(GOOD_POLICY_1, definitions, src="1.2.3.4")
+        self.assertIn('deny-to-reserved', configs['test-filter'].keys())
+
+    @capture.stdout
     def testDocsExample(self):
         USE_MAIL_SERVER_SET = 1
         mail_server_ips_set0 = ["200.1.1.4/32", "200.1.1.5/32"]

--- a/tests/api/api_test.py
+++ b/tests/api/api_test.py
@@ -4,9 +4,10 @@ from absl.testing import absltest
 
 from aerleon import api
 from aerleon.lib import naming
+from aerleon.lib.policy_builder import PolicyDict
 
 # fmt: off
-GOOD_POLICY_1 = {
+GOOD_POLICY_1: PolicyDict = {
     "filename": "raw_policy_all_builtin",
     "filters": [
         {
@@ -239,7 +240,7 @@ class ApiTest(absltest.TestCase):
         else:
             networks["networks"]["MAIL_SERVERS"]["values"] = mail_server_ips_set1
 
-        cisco_example_policy = {
+        cisco_example_policy: PolicyDict = {
             "filename": "cisco_example_policy",
             "filters": [
                 {

--- a/tests/lib/AclCheckTest.testSummarize.stdout.ref
+++ b/tests/lib/AclCheckTest.testSummarize.stdout.ref
@@ -1,0 +1,7 @@
+  filter: test-filter
+          term: term-1
+                next
+          term: term-2 (possible match)
+                accept if ['first-frag', 'frag-offset', 'packet-length', 'tcp-est']
+          term: term-3
+                accept

--- a/tests/lib/aclcheck_test.py
+++ b/tests/lib/aclcheck_test.py
@@ -17,6 +17,7 @@
 from absl.testing import absltest
 
 from aerleon.lib import aclcheck, naming, policy, port
+from tests.regression_utils import capture
 
 POLICYTEXT = """
 header {
@@ -105,6 +106,27 @@ class AclCheckTest(absltest.TestCase):
         # term-4 should never match
         self.assertNotIn('term-4', str(matches))
         self.assertNotIn('term-5', str(matches))
+
+    @capture.stdout
+    def testSummarize(self):
+        srcip = '172.16.1.1'
+        dstip = '10.2.2.10'
+        sport = '10000'
+        dport = '22'
+        proto = 'tcp'
+        check = aclcheck.AclCheck(
+            self.pol, src=srcip, dst=dstip, sport=sport, dport=dport, proto=proto
+        )
+
+        summary = check.Summarize()
+
+        self.assertIn('term-1', summary['test-filter'].keys())
+        self.assertIn('term-2', summary['test-filter'].keys())
+        self.assertIn('term-3', summary['test-filter'].keys())
+        self.assertNotIn('term-4', summary['test-filter'].keys())
+        self.assertNotIn('term-5', summary['test-filter'].keys())
+
+        print(str(check))
 
     def testExceptions(self):
         srcip = '172.16.1.1'

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -254,6 +254,18 @@ class YAMLFrontEndTest(absltest.TestCase):
 
         with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
             yaml_frontend.ParsePolicy(
+                IGNORED_YAML_POLICY_NO_TERMS,
+                filename="policy_no_targets.pol.yaml",
+                base_dir=self.base_dir,
+                definitions=self.naming,
+            )
+        self.assertEqual(
+            str(user_message),
+            "Filter must contain a terms section. File=policy_no_terms.pol.yaml, Line=3.",
+        )
+
+        with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
+            yaml_frontend.ParsePolicy(
                 BAD_YAML_POLICY_SCALAR_TERMS,
                 filename="policy_scalar_terms.pol.yaml",
                 base_dir=self.base_dir,
@@ -290,7 +302,7 @@ class YAMLFrontEndTest(absltest.TestCase):
             "Filter header cannot be empty. File=policy_no_targets.pol.yaml, Line=3.",
         )
 
-    @mock.patch.object(yaml_frontend, "_PolicyFromRawPolicy")
+    @mock.patch.object(yaml_frontend.policy, "FromBuilder")
     @mock.patch.object(yaml_frontend.logging, "warning")
     def testWarnings(self, mock_warning, _mock_raw_to_policy):
         yaml_frontend.ParsePolicy(
@@ -302,16 +314,7 @@ class YAMLFrontEndTest(absltest.TestCase):
         self.assertEqual(mock_warning.call_args[0][0].message, "Ignoring empty policy file.")
         mock_warning.reset_mock()
 
-        yaml_frontend.ParsePolicy(
-            IGNORED_YAML_POLICY_NO_TERMS,
-            filename="policy_no_targets.pol.yaml",
-            base_dir=self.base_dir,
-            definitions=self.naming,
-        )
-        self.assertEqual(mock_warning.call_args[0][0].message, "Ignoring filter with zero terms.")
-        mock_warning.reset_mock()
-
-    @mock.patch.object(yaml_frontend, "_PolicyFromRawPolicy")
+    @mock.patch.object(yaml_frontend.policy, "FromBuilder")
     @mock.patch.object(yaml_frontend.logging, "warning")
     def testIncludeEmptySource(self, mock_warning, _mock_raw_to_policy):
         with mock.patch("builtins.open", mock.mock_open(read_data="")):

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -44,19 +44,19 @@ class ConfigTestSute(absltest.TestCase):
         """Zero args, aerleon.yml present but invalid."""
         # YAML case
         with mock.patch("builtins.open", mock.mock_open(read_data="\"")):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'not a valid YAML file'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'not a valid YAML file'):
                 config.load_config()
 
         # Invalid case
         with mock.patch("builtins.open", mock.mock_open(read_data="")):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'contents not valid'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'contents not valid'):
                 config.load_config()
 
         # Permissions case
         mock_error = mock.MagicMock()
         mock_error.return_value.__enter__.side_effect = PermissionError()
         with mock.patch("builtins.open", mock_error):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'Insufficient permissions'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'Insufficient permissions'):
                 config.load_config()
 
     def testGivenFile(self):
@@ -75,26 +75,26 @@ class ConfigTestSute(absltest.TestCase):
         mock_error = mock.MagicMock()
         mock_error.return_value.__enter__.side_effect = FileNotFoundError()
         with mock.patch("builtins.open", mock_error):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'Config file not found'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'Config file not found'):
                 config.load_config(config_file='config.yaml')
 
     def testInvalidGivenFile(self):
         """Config file given but invalid."""
         # YAML case
         with mock.patch("builtins.open", mock.mock_open(read_data="\"")):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'not a valid YAML file'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'not a valid YAML file'):
                 config.load_config(config_file='config.yaml')
 
         # Invalid case
         with mock.patch("builtins.open", mock.mock_open(read_data="")):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'contents not valid'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'contents not valid'):
                 config.load_config(config_file='config.yaml')
 
         # Permissions case
         mock_error = mock.MagicMock()
         mock_error.return_value.__enter__.side_effect = PermissionError()
         with mock.patch("builtins.open", mock_error):
-            with self.assertRaisesRegexp(config.ConfigFileError, r'Insufficient permissions'):
+            with self.assertRaisesRegex(config.ConfigFileError, r'Insufficient permissions'):
                 config.load_config(config_file='config.yaml')
 
     def testGivenFileList(self):


### PR DESCRIPTION
Status of this PR:

* Ready to review

Changes in this PR

* Adds `api.AclCheck()` which accepts a policy dictionary and returns a list of matches grouped by filter, term. This mirrors the command-line aclcheck functionality.
* Defines a type 'PolicyDict' for the existing policy dictionary used by the API.
* PolicyBuilder can now accept a PolicyDict, so users can create a Policy model directly from a dictionary. RawPolicy is no longer part of the public interface.
* The YAML policy front-end no longer needs to generate a RawPolicy so the code has been simplified.

Other changes

* Test coverage for AclCheck was expanded.
* AclCheck.\_\_str\_\_ (used by the command line) and AclCheck.Summarize (used by the API) share the same code.
* AclCheck has a new constructor FromPolicyDict so users can create an AclCheck instance directly from PolicyDict for advanced usage.