### PR TITLE
Hoist unseed check to intermediate representation

### DIFF
--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -765,6 +765,8 @@ class Naming:
             # No '=', so this is a value only line
             else:
                 values = line_parts[0]  # values for previous var are continued this line
+                if value_check:
+                    value_check(line, values)
 
             for value_piece in values.split():
                 if not value_piece:

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -675,16 +675,8 @@ class Naming:
                 '%s %s' % ('Received an unexpected definition type:', def_type)
             )
 
-        items.update(
-            dict(
-                [
-                    (unit.name, unit)
-                    for unit in self._ParseLines(
-                        file_handle, def_type, items, unseen_items, value_check
-                    )
-                ]
-            )
-        )
+        generator = self._ParseLines(file_handle, def_type, items, unseen_items, value_check)
+        items.update(dict([(unit.name, unit) for unit in generator]))
 
     def ParseServiceList(self, data: List[str]) -> None:
         """Take an array of service data and import into class.
@@ -695,20 +687,14 @@ class Naming:
         Args:
           data: array of text lines containing service definitions.
         """
-        self.services.update(
-            dict(
-                [
-                    (unit.name, unit)
-                    for unit in self._ParseLines(
-                        data,
-                        DEF_TYPE_SERVICES,
-                        self.services,
-                        self.unseen_services,
-                        self._PortCheck,
-                    )
-                ]
-            )
+        generator = self._ParseLines(
+            data,
+            DEF_TYPE_SERVICES,
+            self.services,
+            self.unseen_services,
+            self._PortCheck,
         )
+        self.services.update(dict([(unit.name, unit) for unit in generator]))
 
     def ParseNetworkList(self, data: List[str]) -> None:
         """Take an array of network data and import into class.
@@ -720,17 +706,8 @@ class Naming:
           data: array of text lines containing net definitions.
 
         """
-        gen = ()
-        self.networks.update(
-            dict(
-                [
-                    (unit.name, unit)
-                    for unit in self._ParseLines(
-                        data, DEF_TYPE_NETWORKS, self.networks, self.unseen_networks
-                    )
-                ]
-            )
-        )
+        generator = self._ParseLines(data, DEF_TYPE_NETWORKS, self.networks, self.unseen_networks)
+        self.networks.update(dict([(unit.name, unit) for unit in generator]))
 
     def _PortCheck(self, line, values):
         for port in values.strip().split():
@@ -781,7 +758,6 @@ class Naming:
                     if value_piece[0].isalpha() and ':' not in value_piece:
                         if value_piece not in items and value_piece not in unseen_items:
                             unseen_items[value_piece] = True
-
 
     def ParseYaml(self, file_handle: str, file_name: str) -> None:
         """Load a definition yaml file as a string.

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -144,8 +144,9 @@ class NamingUnitTest(absltest.TestCase):
         baddefs = naming.Naming(None)
         baddefs.ParseServiceList(bad_servicedata)
         baddefs.ParseNetworkList(bad_networkdata)
-        self.assertRaises(naming.UndefinedServiceError, baddefs._CheckUnseen, 'services')
-        self.assertRaises(naming.UndefinedAddressError, baddefs._CheckUnseen, 'networks')
+        self.assertRaises(
+            (naming.UndefinedAddressError, naming.UndefinedServiceError), baddefs._CheckUnseen
+        )
 
     def testParseNetFile(self):
         filedefs = naming.Naming(None)

--- a/tests/lib/naming_test.py
+++ b/tests/lib/naming_test.py
@@ -167,6 +167,14 @@ class NamingUnitTest(absltest.TestCase):
         testdefs = naming.Naming(None)
         self.assertRaises(naming.NamingSyntaxError, testdefs.ParseServiceList, badservicedata)
 
+    def testServiceIncorrectSyntaxMultiline(self):
+        badservicedata = []
+        badservicedata.append('SVC1 = 80/udp')
+        badservicedata.append('       80//tcp')
+        badservicedata.append('SVC2 = 81/tcp')
+        testdefs = naming.Naming(None)
+        self.assertRaises(naming.NamingSyntaxError, testdefs.ParseServiceList, badservicedata)
+
     def testGetNetChildrenSingle(self):
         expected = ['NET1']
         self.assertEqual(expected, self.defs.GetNetChildren('NET2'))

--- a/tests/regression/aruba/aruba_test.py
+++ b/tests/regression/aruba/aruba_test.py
@@ -977,9 +977,9 @@ class ArubaTest(absltest.TestCase):
     @capture.stdout
     def testMultiplePorts(self):
         definitions = naming.Naming()
-        definitions._ParseNetworkLine('SOME_NETWORK = 100.0.0.0/8')
-        definitions._ParseServiceLine(
-            'DNS = 53/tcp 54/tcp 55/tcp 60/tcp 61/tcp 62/tcp 63/tcp 65/tcp'
+        definitions.ParseNetworkList(['SOME_NETWORK = 100.0.0.0/8'])
+        definitions.ParseServiceList(
+            ['DNS = 53/tcp 54/tcp 55/tcp 60/tcp 61/tcp 62/tcp 63/tcp 65/tcp']
         )
         aru = aruba.Aruba(
             policy.ParsePolicy(GOOD_HEADER_V4 + GOOD_TERM_DESTINATION_IS_USER, definitions),

--- a/tests/regression/aruba/aruba_test.py
+++ b/tests/regression/aruba/aruba_test.py
@@ -977,9 +977,9 @@ class ArubaTest(absltest.TestCase):
     @capture.stdout
     def testMultiplePorts(self):
         definitions = naming.Naming()
-        definitions._ParseLine('SOME_NETWORK = 100.0.0.0/8', 'networks')
-        definitions._ParseLine(
-            'DNS = 53/tcp 54/tcp 55/tcp 60/tcp 61/tcp 62/tcp 63/tcp 65/tcp', 'services'
+        definitions._ParseNetworkLine('SOME_NETWORK = 100.0.0.0/8')
+        definitions._ParseServiceLine(
+            'DNS = 53/tcp 54/tcp 55/tcp 60/tcp 61/tcp 62/tcp 63/tcp 65/tcp'
         )
         aru = aruba.Aruba(
             policy.ParsePolicy(GOOD_HEADER_V4 + GOOD_TERM_DESTINATION_IS_USER, definitions),

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -593,10 +593,10 @@ class PaloAltoFWTest(absltest.TestCase):
     @capture.stdout
     def testServiceMap(self):
         definitions = naming.Naming()
-        definitions._ParseLine('SSH = 22/tcp', 'services')
-        definitions._ParseLine('SMTP = 25/tcp', 'services')
-        definitions._ParseLine('FOOBAR = 10.0.0.0/8', 'networks')
-        definitions._ParseLine('         2001:4860:8000::/33', 'networks')
+        definitions._ParseServiceLine('SSH = 22/tcp')
+        definitions._ParseServiceLine('SMTP = 25/tcp')
+        definitions._ParseNetworkLine('FOOBAR = 10.0.0.0/8')
+        definitions._ParseNetworkLine('         2001:4860:8000::/33')
 
         pol1 = paloaltofw.PaloAltoFW(
             policy.ParsePolicy(GOOD_HEADER_1 + SVC_TERM_1, definitions), EXP_INFO
@@ -1389,8 +1389,8 @@ term rule-1 {
         self.assertEqual(x, 'any-tcp', output)
 
         definitions = naming.Naming()
-        definitions._ParseLine('PORT1 = 8080/tcp', 'services')
-        definitions._ParseLine('PORT2 = 8081/tcp', 'services')
+        definitions._ParseServiceLine('PORT1 = 8080/tcp')
+        definitions._ParseServiceLine('PORT2 = 8081/tcp')
         pol = policy.ParsePolicy(POL3 % T2, definitions)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
@@ -1439,8 +1439,8 @@ term rule-1 {
 """
 
         definitions = naming.Naming()
-        definitions._ParseLine('NTP = 123/tcp 123/udp', 'services')
-        definitions._ParseLine('DNS = 53/tcp 53/udp', 'services')
+        definitions._ParseServiceLine('NTP = 123/tcp 123/udp')
+        definitions._ParseServiceLine('DNS = 53/tcp 53/udp')
 
         pol = policy.ParsePolicy(POL % T, definitions)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
@@ -1621,15 +1621,15 @@ term rule-1 {
     @capture.stdout
     def testNoAddrObj(self):
         definitions = naming.Naming()
-        definitions._ParseLine('NET1 = 10.1.0.0/24', 'networks')
-        definitions._ParseLine('NET2 = 10.2.0.0/24', 'networks')
-        definitions._ParseLine('NET3 = 10.3.1.0/24', 'networks')
-        definitions._ParseLine('       10.3.2.0/24', 'networks')
-        definitions._ParseLine('NET4 = 2001:db8:0:aa::/64', 'networks')
-        definitions._ParseLine('       2001:db8:0:bb::/64', 'networks')
-        definitions._ParseLine('NET5 = NET3 NET4', 'networks')
-        definitions._ParseLine('NET6 = 4000::/2', 'networks')
-        definitions._ParseLine('NET7 = 8000::/1', 'networks')
+        definitions._ParseNetworkLine('NET1 = 10.1.0.0/24')
+        definitions._ParseNetworkLine('NET2 = 10.2.0.0/24')
+        definitions._ParseNetworkLine('NET3 = 10.3.1.0/24')
+        definitions._ParseNetworkLine('       10.3.2.0/24')
+        definitions._ParseNetworkLine('NET4 = 2001:db8:0:aa::/64')
+        definitions._ParseNetworkLine('       2001:db8:0:bb::/64')
+        definitions._ParseNetworkLine('NET5 = NET3 NET4')
+        definitions._ParseNetworkLine('NET6 = 4000::/2')
+        definitions._ParseNetworkLine('NET7 = 8000::/1')
 
         POL = """
 header {
@@ -1743,12 +1743,12 @@ term rule-1 {
     @capture.stdout
     def testAddrObj(self):
         definitions = naming.Naming()
-        definitions._ParseLine('NET1 = 10.1.0.0/24', 'networks')
-        definitions._ParseLine('NET2 = 10.2.0.0/24', 'networks')
-        definitions._ParseLine('NET3 = 10.3.1.0/24', 'networks')
-        definitions._ParseLine('       10.3.2.0/24', 'networks')
-        definitions._ParseLine('NET4 = 4000::/128', 'networks')
-        definitions._ParseLine('NET5 = 4000::/2', 'networks')
+        definitions._ParseNetworkLine('NET1 = 10.1.0.0/24')
+        definitions._ParseNetworkLine('NET2 = 10.2.0.0/24')
+        definitions._ParseNetworkLine('NET3 = 10.3.1.0/24')
+        definitions._ParseNetworkLine('       10.3.2.0/24')
+        definitions._ParseNetworkLine('NET4 = 4000::/128')
+        definitions._ParseNetworkLine('NET5 = 4000::/2')
 
         POL = """
 header {

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -1389,8 +1389,8 @@ term rule-1 {
         self.assertEqual(x, 'any-tcp', output)
 
         definitions = naming.Naming()
-        definitions._ParseServiceLine('PORT1 = 8080/tcp')
-        definitions._ParseServiceLine('PORT2 = 8081/tcp')
+        definitions.ParseServiceList(['PORT1 = 8080/tcp'])
+        definitions.ParseServiceList(['PORT2 = 8081/tcp'])
         pol = policy.ParsePolicy(POL3 % T2, definitions)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
@@ -1439,8 +1439,8 @@ term rule-1 {
 """
 
         definitions = naming.Naming()
-        definitions._ParseServiceLine('NTP = 123/tcp 123/udp')
-        definitions._ParseServiceLine('DNS = 53/tcp 53/udp')
+        definitions.ParseServiceList(['NTP = 123/tcp 123/udp'])
+        definitions.ParseServiceList(['DNS = 53/tcp 53/udp'])
 
         pol = policy.ParsePolicy(POL % T, definitions)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
@@ -1621,15 +1621,13 @@ term rule-1 {
     @capture.stdout
     def testNoAddrObj(self):
         definitions = naming.Naming()
-        definitions._ParseNetworkLine('NET1 = 10.1.0.0/24')
-        definitions._ParseNetworkLine('NET2 = 10.2.0.0/24')
-        definitions._ParseNetworkLine('NET3 = 10.3.1.0/24')
-        definitions._ParseNetworkLine('       10.3.2.0/24')
-        definitions._ParseNetworkLine('NET4 = 2001:db8:0:aa::/64')
-        definitions._ParseNetworkLine('       2001:db8:0:bb::/64')
-        definitions._ParseNetworkLine('NET5 = NET3 NET4')
-        definitions._ParseNetworkLine('NET6 = 4000::/2')
-        definitions._ParseNetworkLine('NET7 = 8000::/1')
+        definitions.ParseNetworkList(['NET1 = 10.1.0.0/24'])
+        definitions.ParseNetworkList(['NET2 = 10.2.0.0/24'])
+        definitions.ParseNetworkList(['NET3 = 10.3.1.0/24', '       10.3.2.0/24'])
+        definitions.ParseNetworkList(['NET4 = 2001:db8:0:aa::/64', '       2001:db8:0:bb::/64'])
+        definitions.ParseNetworkList(['NET5 = NET3 NET4'])
+        definitions.ParseNetworkList(['NET6 = 4000::/2'])
+        definitions.ParseNetworkList(['NET7 = 8000::/1'])
 
         POL = """
 header {
@@ -1743,12 +1741,11 @@ term rule-1 {
     @capture.stdout
     def testAddrObj(self):
         definitions = naming.Naming()
-        definitions._ParseNetworkLine('NET1 = 10.1.0.0/24')
-        definitions._ParseNetworkLine('NET2 = 10.2.0.0/24')
-        definitions._ParseNetworkLine('NET3 = 10.3.1.0/24')
-        definitions._ParseNetworkLine('       10.3.2.0/24')
-        definitions._ParseNetworkLine('NET4 = 4000::/128')
-        definitions._ParseNetworkLine('NET5 = 4000::/2')
+        definitions.ParseNetworkList(['NET1 = 10.1.0.0/24'])
+        definitions.ParseNetworkList(['NET2 = 10.2.0.0/24'])
+        definitions.ParseNetworkList(['NET3 = 10.3.1.0/24', '       10.3.2.0/24'])
+        definitions.ParseNetworkList(['NET4 = 4000::/128'])
+        definitions.ParseNetworkList(['NET5 = 4000::/2'])
 
         POL = """
 header {

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -593,10 +593,9 @@ class PaloAltoFWTest(absltest.TestCase):
     @capture.stdout
     def testServiceMap(self):
         definitions = naming.Naming()
-        definitions._ParseServiceLine('SSH = 22/tcp')
-        definitions._ParseServiceLine('SMTP = 25/tcp')
-        definitions._ParseNetworkLine('FOOBAR = 10.0.0.0/8')
-        definitions._ParseNetworkLine('         2001:4860:8000::/33')
+        definitions.ParseServiceList(['SSH = 22/tcp'])
+        definitions.ParseServiceList(['SMTP = 25/tcp'])
+        definitions.ParseNetworkList(['FOOBAR = 10.0.0.0/8', '         2001:4860:8000::/33'])
 
         pol1 = paloaltofw.PaloAltoFW(
             policy.ParsePolicy(GOOD_HEADER_1 + SVC_TERM_1, definitions), EXP_INFO


### PR DESCRIPTION
Also raise NamingSyntaxError for invalid port syntax for multiline services.

fixes #138 