### PR TITLE
[Typing] Typing functions missed by monkeytype.

### DIFF
--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -2,13 +2,16 @@ import collections
 import heapq
 import ipaddress
 import itertools
+from typing import List, Union
+
+from aerleon.lib.nacaddr import IPv4, IPv6
 
 
 class Addressbook:
-    def __init__(self):
+    def __init__(self) -> None:
         self.addressbook = collections.OrderedDict()
 
-    def AddAddresses(self, zone, address_list):
+    def AddAddresses(self, zone: str, address_list: List[Union[IPv4, IPv6]]):
         """Create the address book configuration entries.
 
         Args:
@@ -23,7 +26,7 @@ class Addressbook:
         when new networks are added.
         """
 
-        def _drop_subnets(address_list):
+        def _drop_subnets(address_list: List[Union[IPv4, IPv6]]):
             """Remove any network contained by another network in this list.
 
             Args:

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -21,9 +21,8 @@ from typing import Dict, List, Set, Tuple, Union
 
 from absl import logging
 
-from aerleon.lib import aclgenerator
+from aerleon.lib import aclgenerator, policy
 from aerleon.lib.nacaddr import IPv4, IPv6
-from aerleon.lib.policy import Policy
 
 """
           1         2         3
@@ -151,7 +150,7 @@ class Term(aclgenerator.Term):
         },
     }
 
-    def __init__(self, term, term_type, noverbose) -> None:
+    def __init__(self, term: policy.Term, term_type: str, noverbose: bool) -> None:
         super().__init__(term)
         self.term = term
         self.term_type = term_type  # drives the address-family
@@ -393,7 +392,7 @@ class Term(aclgenerator.Term):
 
         return str(config)
 
-    def _processPorts(self, term) -> str:
+    def _processPorts(self, term: policy.Term) -> str:
         port_str = ""
 
         # source port generation
@@ -406,7 +405,7 @@ class Term(aclgenerator.Term):
 
         return port_str
 
-    def _processICMP(self, term) -> Tuple[str, str]:
+    def _processICMP(self, term: policy.Term) -> Tuple[str, str]:
         icmp_types = [""]
         icmp_code_str = ""
         icmp_type_str = " type "
@@ -429,7 +428,7 @@ class Term(aclgenerator.Term):
 
         return icmp_type_str, icmp_code_str
 
-    def _processProtocol(self, term_type, term, flags) -> str:
+    def _processProtocol(self, term_type: str, term: policy.Term, flags: List[str]) -> str:
         anet_proto_map = {
             "inet": {
                 # <1-255> protocol  values(s) or range(s) of protocol  values
@@ -485,7 +484,7 @@ class Term(aclgenerator.Term):
 
         return protocol_str
 
-    def _processProtocolExcept(self, term_type, term, flags) -> str:
+    def _processProtocolExcept(self, term_type: str, term: policy.Term, flags: List[str]) -> str:
         # EOS does not have a protocol-except keyword. it does, however, support
         # lists of protocol-ids. given a term this function will generate the
         # appropriate list of protocol-id's which *will* be permited. within the
@@ -521,7 +520,9 @@ class Term(aclgenerator.Term):
 
         return protocol_str
 
-    def _processTermOptions(self, term, options) -> Tuple[List[str], List[str]]:
+    def _processTermOptions(
+        self, term: policy.Term, options: List[str]
+    ) -> Tuple[List[str], List[str]]:
         flags = []
         misc_options = []
 
@@ -554,7 +555,7 @@ class Term(aclgenerator.Term):
 
         return flags, misc_options
 
-    def _Group(self, group, lc=True) -> str:
+    def _Group(self, group: List[Union[str, Tuple[int, int]]], lc: bool = True) -> str:
         """If 1 item return it, else return [item1 item2].
 
         Args:
@@ -719,7 +720,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
         field_set = fieldset_hdr + field_list
         return field_set
 
-    def _TranslatePolicy(self, pol: Policy, exp_info: int) -> None:
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         self.arista_traffic_policies = []
         af_map_txt = {"inet": "ipv4", "inet6": "ipv6"}
 

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -16,12 +16,10 @@
 
 """Aruba generator."""
 
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Union
 
-from absl import logging
-
-from aerleon.lib import aclgenerator
-from aerleon.lib.policy import Policy
+from aerleon.lib import aclgenerator, policy
+from aerleon.lib.nacaddr import IPv4, IPv6
 
 _COMMENT_MARKER = '#'
 _TERMINATOR_MARKER = '!'
@@ -69,7 +67,7 @@ class Term(aclgenerator.Term):
         'esp': 50,
     }
 
-    def __init__(self, term, filter_type, verbose=True) -> None:
+    def __init__(self, term: policy.Term, filter_type: str, verbose: bool = True) -> None:
         super().__init__(term)
         self.term = term
         self.filter_type = filter_type
@@ -157,7 +155,7 @@ class Term(aclgenerator.Term):
 
         return '\n'.join(t for t in ret_str if t)
 
-    def _GenerateNetdest(self, addr_netdestid, addresses, af) -> str:
+    def _GenerateNetdest(self, addr_netdestid: str, addresses: Union[IPv4, IPv6], af: int) -> str:
         """Generates the netdestinations text block.
 
         Args:
@@ -181,7 +179,7 @@ class Term(aclgenerator.Term):
 
         return '\n'.join(t for t in ret_str if t)
 
-    def _GenerateNetworkOrHostTokens(self, address) -> str:
+    def _GenerateNetworkOrHostTokens(self, address: Union[IPv4, IPv6]) -> str:
         """Generates the text block host or network identifier for netdestinations.
 
         Args:
@@ -267,7 +265,7 @@ class Aruba(aclgenerator.ACLGenerator):
 
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol: Policy, exp_info: int) -> None:
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         self.aruba_policies = []
 
         for header, terms in pol.filters:

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -378,7 +378,7 @@ class PortMap:
     }
 
     @staticmethod
-    def GetProtocol(port_num, proto, platform='cisco'):
+    def GetProtocol(port_num: int, proto: str, platform: str = 'cisco'):
         """Converts a port number to a name or returns the number.
 
         Args:

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -14,8 +14,7 @@ from typing import Dict, List, Set, Tuple
 
 from absl import logging
 
-from aerleon.lib import aclgenerator
-from aerleon.lib.policy import Policy
+from aerleon.lib import aclgenerator, policy
 
 if sys.version_info < (3, 8):
     from typing_extensions import TypedDict
@@ -53,7 +52,9 @@ class Term(aclgenerator.Term):
 
     _MAX_TERM_COMMENT_LENGTH = 64
 
-    def __init__(self, term, address_family='inet', verbose=True) -> None:
+    def __init__(
+        self, term: policy.Term, address_family: str = 'inet', verbose: bool = True
+    ) -> None:
         super().__init__(term)
         self.term = term
         self.address_family = address_family
@@ -62,7 +63,7 @@ class Term(aclgenerator.Term):
     def __str__(self) -> str:
         return ''
 
-    def ConvertToDict(self, priority_index) -> List[PolicyRule]:
+    def ConvertToDict(self, priority_index: int) -> List[PolicyRule]:
         """Converts term to dictionary representation of CloudArmor's JSON format.
 
         Takes all of the attributes associated with a term (match, action, etc) and
@@ -201,7 +202,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
         supported_sub_tokens = {'action': {'accept', 'deny'}}
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol: Policy, exp_info: int) -> None:
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         """Translates a Aerleon policy into a CloudArmor-specific data structure.
 
         Takes in a POL file, parses each term and populates the cloudarmor_policies

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -30,8 +30,7 @@ from typing import Dict, List, Set, Tuple, Union
 
 from absl import logging
 
-from aerleon.lib import gcp, nacaddr
-from aerleon.lib.policy import Policy, Term
+from aerleon.lib import gcp, nacaddr, policy
 
 if sys.version_info < (3, 8):
     from typing_extensions import TypedDict
@@ -72,7 +71,7 @@ FirewallRule = TypedDict(
 )
 
 
-def IsDefaultDeny(term: Term) -> bool:
+def IsDefaultDeny(term: policy.Term) -> bool:
     """Returns true if a term is a default deny without IPs, ports, etc."""
     skip_attrs = [
         'flattened',
@@ -147,7 +146,9 @@ class Term(gcp.Term):
     # Any protocol not in _ALLOW_PROTO_NAME must be passed by number.
     ALWAYS_PROTO_NUM = set(gcp.Term.PROTO_MAP.keys()) - _ALLOW_PROTO_NAME
 
-    def __init__(self, term, inet_version='inet', policy_inet_version='inet') -> None:
+    def __init__(
+        self, term: policy.Term, inet_version: str = 'inet', policy_inet_version: str = 'inet'
+    ) -> None:
         super().__init__(term)
         self.term = term
         self.inet_version = inet_version
@@ -466,7 +467,7 @@ class GCE(gcp.GCP):
 
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol: Policy, exp_info: int) -> None:
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         self.gce_policies = []
         max_attribute_count = 0
         total_attribute_count = 0

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -12,8 +12,7 @@ from typing import Dict, List, Set, Tuple, Union
 
 from absl import logging
 
-from aerleon.lib import gcp, nacaddr
-from aerleon.lib.policy import Policy
+from aerleon.lib import gcp, nacaddr, policy
 
 if sys.version_info < (3, 8):
     from typing_extensions import TypedDict
@@ -94,7 +93,11 @@ class Term(gcp.Term):
     _TERM_DESTINATION_PORTS_LIMIT = 256
 
     def __init__(
-        self, term, address_family='inet', policy_inet_version='inet', api_version='beta'
+        self,
+        term: policy.Term,
+        address_family: str = 'inet',
+        policy_inet_version: str = 'inet',
+        api_version: str = 'beta',
     ) -> None:
         super().__init__(term)
         self.address_family = address_family
@@ -163,7 +166,7 @@ class Term(gcp.Term):
                 % self.term.name
             )
 
-    def ConvertToDict(self, priority_index) -> List[OrganizationPolicy]:
+    def ConvertToDict(self, priority_index: int) -> List[OrganizationPolicy]:
         """Converts term to dict representation of SecurityPolicy.Rule JSON format.
 
         Takes all of the attributes associated with a term (match, action, etc) and
@@ -399,7 +402,7 @@ class HierarchicalFirewall(gcp.GCP):
         supported_sub_tokens = {'action': {'accept', 'deny', 'next'}}
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol: Policy, exp_info: int) -> None:
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         """Translates a Aerleon policy into a HF-specific data structure.
 
         Takes in a POL file, parses each term and populates the policy

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -23,7 +23,7 @@ https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/
 import copy
 import re
 import sys
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, Set, Tuple
 
 import yaml
 from absl import logging

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -98,7 +98,7 @@ class IPv4(ipaddress.IPv4Network):
             ip = ip_string
         super().__init__(ip, strict)
 
-    def subnet_of(self, other: "IPv4") -> bool:
+    def subnet_of(self, other: IPv4) -> bool:
         """Return True if this network is a subnet of other."""
         if self.version != other.version:
             return False
@@ -110,7 +110,7 @@ class IPv4(ipaddress.IPv4Network):
             return False
         return self._is_subnet_of(other, self)
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict):
         result = self.__class__(self)
         result.text = self.text
         result.token = self.token
@@ -162,7 +162,6 @@ class IPv4(ipaddress.IPv4Network):
 
     # Backwards compatibility name from v1.
     Supernet = supernet
-    _is_subnet_of = _is_subnet_of
 
 
 class IPv6(ipaddress.IPv6Network):
@@ -190,19 +189,19 @@ class IPv6(ipaddress.IPv6Network):
             ip = ip_string
         super().__init__(ip, strict)
 
-    def subnet_of(self, other: "IPv6") -> bool:
+    def subnet_of(self, other: IPv6) -> bool:
         """Return True if this network is a subnet of other."""
         if self.version != other.version:
             return False
         return self._is_subnet_of(self, other)
 
-    def supernet_of(self, other: "IPv6") -> bool:
+    def supernet_of(self, other: IPv6) -> bool:
         """Return True if this network is a supernet of other."""
         if self.version != other.version:
             return False
         return self._is_subnet_of(other, self)
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict):
         result = self.__class__(self)
         result.text = self.text
         result.token = self.token
@@ -239,7 +238,6 @@ class IPv6(ipaddress.IPv6Network):
 
     # Backwards compatibility name from v1.
     Supernet = supernet
-    _is_subnet_of = _is_subnet_of
 
     def AddComment(self, comment: str = '') -> None:
         """Append comment to self.text, comma separated.
@@ -277,7 +275,7 @@ def IsSuperNet(
     return True
 
 
-def CollapseAddrListPreserveTokens(addresses: List[IPv4]) -> List[IPv4]:
+def CollapseAddrListPreserveTokens(addresses: List[Union[IPv4, IPv6]]) -> List[Union[IPv4, IPv6]]:
     """Collapse an array of IPs only when their tokens are the same.
 
     Args:
@@ -447,14 +445,14 @@ def CollapseAddrList(
     )
 
 
-def SortAddrList(addresses: List[Union[Any, IPv6, IPv4]]) -> List[Union[Any, IPv6, IPv4]]:
+def SortAddrList(addresses: List[Union[IPv6, IPv4]]) -> List[Union[IPv6, IPv4]]:
     """Return a sorted list of nacaddr objects."""
     return sorted(addresses, key=ipaddress.get_mixed_type_key)
 
 
 def RemoveAddressFromList(
     superset: List[Union[IPv4, IPv6]], exclude: Union[IPv4, IPv6]
-) -> List[Union[Any, IPv6, IPv4]]:
+) -> List[Union[IPv6, IPv4]]:
     """Remove a single address from a list of addresses.
 
     Args:

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -125,18 +125,20 @@ class UserMessage:
             The top-level file should be the first item in the list.
     """
 
-    message: str
-    filename: str
-    line: int
-    include_chain: "list[Tuple[str, int]]"
-
-    def __init__(self, message, *, filename, line=None, include_chain=None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        filename: str,
+        line: int = None,
+        include_chain: List[Tuple[str, int]] = None,
+    ):
         self.message = message
         self.filename = filename
         self.line = line
         self.include_chain = include_chain
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Display user-facing error message with include chain (if present).
 
         e.g.
@@ -161,11 +163,11 @@ class UserMessage:
                     error_context += " (Top Level)"
         return error_context
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"UserMessage(\"{str(self)}\")"
 
 
-def is_yaml_suffix(suffix):
+def is_yaml_suffix(suffix: str) -> bool:
     return suffix == '.yaml' or suffix == '.yml'
 
 
@@ -411,7 +413,7 @@ class Naming:
         except ValueError:
             return False
 
-    def GetServiceNames(self):
+    def GetServiceNames(self) -> List[str]:
         """Returns the list of all known service names."""
         return list(self.services.keys())
 
@@ -455,7 +457,7 @@ class Naming:
                 expandset.add(service)
         return sorted(expandset)
 
-    def GetPortParents(self, query, proto):
+    def GetPortParents(self, query: str, proto: str) -> List[str]:
         """Returns a list of all service tokens containing the port/protocol pair.
 
         Args:
@@ -599,7 +601,7 @@ class Naming:
             i.parent_token = token
         return returnlist
 
-    def _Parse(self, definitions_directory):
+    def _Parse(self, definitions_directory: str) -> None:
         """Parse files for tokens and values.
 
         Given a directory name, grab all the appropriate files in that
@@ -612,7 +614,6 @@ class Naming:
         Raises:
           NoDefinitionsError: if no definitions are found.
         """
-
         file_def_type = {
             '.net': DEF_TYPE_NETWORKS,
             '.svc': DEF_TYPE_SERVICES,

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -768,7 +768,7 @@ class Nftables(aclgenerator.ACLGenerator):
         return netfilter_family, netfilter_hook, netfilter_priority, policy_default_action, verbose
 
     def _ConfigurationDictionary(
-        self, nft_pol: List[Union[policy.Header, str, str, str, int, str, bool, DefaultDict]]
+        self, nft_pol: List[Union[policy.Header, str, int, bool, DefaultDict]]
     ) -> DefaultDict[str, Union[str, DefaultDict]]:
         """NFTables configuration object.
 

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -17,10 +17,11 @@
 
 import collections
 import copy
+from typing import DefaultDict, Dict, List, Set, Tuple, Union
 
 from absl import logging
 
-from aerleon.lib import aclgenerator, nacaddr
+from aerleon.lib import aclgenerator, nacaddr, policy
 
 # NFTables and Aerleon have conflicting definitions of 'address family'
 # In Aerleon:
@@ -38,13 +39,13 @@ ip6 = 'ip6'
 mixed = 'inet'
 
 
-def TabSpacer(number_spaces, string):
+def TabSpacer(number_spaces: int, string: str) -> str:
     """Configuration indentation utility function."""
     blank_space = ' '
     return (blank_space * number_spaces) + string
 
 
-def Add(statement):
+def Add(statement: str) -> str:
     """Prefix space appending utility to handle text joins."""
     if statement:
         return TabSpacer(1, statement)
@@ -52,7 +53,7 @@ def Add(statement):
         return statement
 
 
-def ChainFormat(kind, name, ruleset):
+def ChainFormat(kind: str, name: str, ruleset: List[str]) -> str:
     """Builds a chain in NFtables configuration format.
 
     Args:
@@ -106,7 +107,7 @@ class Term(aclgenerator.Term):
     )
     _ACTIONS = {'accept': 'accept', 'deny': 'drop'}
 
-    def __init__(self, term, nf_af, nf_hook, verbose=True):
+    def __init__(self, term: policy.Term, nf_af: str, nf_hook: str, verbose: bool = True):
         """Individual instances of a Term for NFtables.
 
         Args:
@@ -121,7 +122,7 @@ class Term(aclgenerator.Term):
         self.hook = nf_hook
         self.verbose = verbose
 
-    def MapICMPtypes(self, af, term_icmp_types):
+    def MapICMPtypes(self, af: SyntaxWarning, term_icmp_types: List[str]) -> List[str]:
         """Normalize certain ICMP_TYPES for NFTables rendering.
 
         If we encounter certain keyword values in policy.Term.ICMP_TYPE keywords,
@@ -132,6 +133,7 @@ class Term(aclgenerator.Term):
         Function is used inside PortsAndProtocols.
 
         Args:
+          af:
           term_icmp_types: ICMP types keywords.
 
         Returns:
@@ -174,7 +176,7 @@ class Term(aclgenerator.Term):
                     term_icmp_types[term_icmp_types.index(item)] = ICMP_TYPE_REMAP[6].get(item)
         return term_icmp_types
 
-    def CreateAnonymousSet(self, data):
+    def CreateAnonymousSet(self, data: List[str]) -> str:
         """Build a nftables anonymous set from some elements.
 
         Anonymous are formatted using curly braces then some data. These sets are
@@ -213,7 +215,7 @@ class Term(aclgenerator.Term):
 
         """
 
-        def PortStatement(protocol, source, destination):
+        def PortStatement(protocol: List[str], source: str, destination: str) -> List[str]:
             """NFT port statement. Returns empty if no ports defined."""
             ports_list = []
 
@@ -306,7 +308,7 @@ class Term(aclgenerator.Term):
 
         return statement_lines
 
-    def _OptionsHandler(self, term):
+    def _OptionsHandler(self, term: policy.Term) -> str:
         """Term 'option' handler.
 
         Function used to evaluate term.logging and also term.option values. Then
@@ -350,7 +352,9 @@ class Term(aclgenerator.Term):
         else:
             return ''
 
-    def GroupExpressions(self, address_expr, pp_expr, options, verdict):
+    def GroupExpressions(
+        self, address_expr: List[str], pp_expr: List[str], options: str, verdict: str
+    ) -> List[str]:
         """Combines all expressions with a verdict (decision).
 
         The inputs are already pre-sanitized by RulesetGenerator. NFTables processes
@@ -390,7 +394,12 @@ class Term(aclgenerator.Term):
             statement.append((Add(options) + verdict))
         return statement
 
-    def _AddrStatement(self, address_family, src_addr, dst_addr):
+    def _AddrStatement(
+        self,
+        address_family: str,
+        src_addr: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
+        dst_addr: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
+    ) -> List[str]:
         """Builds an NFTables address statement.
 
         Args:
@@ -450,7 +459,7 @@ class Term(aclgenerator.Term):
                     )
         return address_statement
 
-    def RulesetGenerator(self, term):
+    def RulesetGenerator(self, term: policy.Term) -> List[str]:
         """Generate string rules of a given Term.
 
         Rules are constructed from Terms() and are contained within chains.
@@ -496,7 +505,9 @@ class Term(aclgenerator.Term):
         term_ruleset.extend(nftable_rule)
         return term_ruleset
 
-    def _AddressClassifier(self, address_to_classify):
+    def _AddressClassifier(
+        self, address_to_classify: List[Union[nacaddr.IPv4, nacaddr.IPv6]]
+    ) -> DefaultDict[str, List[Union[nacaddr.IPv4, nacaddr.IPv6]]]:
         """Organizes network addresses according to IP family in a dict.
 
         Args:
@@ -513,7 +524,7 @@ class Term(aclgenerator.Term):
                 addresses['ip6'].append(str(addr))
         return addresses
 
-    def _Group(self, group):
+    def _Group(self, group: List[Tuple[int, int]]) -> str:
         """If 1 item return it, else return [ item1 item2 ].
 
         Args:
@@ -542,7 +553,7 @@ class Term(aclgenerator.Term):
             rval = ''
         return rval
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Terms printing function.
 
         Each term is expressed as its own chain. Later referenced to a parent chain
@@ -573,7 +584,7 @@ class Nftables(aclgenerator.ACLGenerator):
     # In Nftables 'inet' contains both IPv4 and IPv6 addresses and rules.
     NF_TABLE_AF_MAP = {'inet': 'ip', 'inet6': 'ip6', 'mixed': 'inet'}
 
-    def _BuildTokens(self):
+    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
         """NFTables generator list of supported tokens and sub tokens.
 
         Returns:
@@ -618,7 +629,7 @@ class Nftables(aclgenerator.ACLGenerator):
         }
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol, exp_info):
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int):
         """Translates a Aerleon policy file into NFtables specific data structure.
 
         Reads a POL file, filters for NFTables specific data, parses each term
@@ -702,7 +713,7 @@ class Nftables(aclgenerator.ACLGenerator):
                 )
             )
 
-    def _ProcessHeader(self, header_options):
+    def _ProcessHeader(self, header_options: List[str]) -> Tuple[str, str, int, str, bool]:
         """Aerleon policy header processing.
 
         Args:
@@ -756,7 +767,9 @@ class Nftables(aclgenerator.ACLGenerator):
             header_options.remove('noverbose')
         return netfilter_family, netfilter_hook, netfilter_priority, policy_default_action, verbose
 
-    def _ConfigurationDictionary(self, nft_pol):
+    def _ConfigurationDictionary(
+        self, nft_pol: List[Union[policy.Header, str, str, str, int, str, bool, DefaultDict]]
+    ) -> DefaultDict[str, Union[str, DefaultDict]]:
         """NFTables configuration object.
 
         Organizes policies into a data structure that can keep relationships with
@@ -792,7 +805,7 @@ class Nftables(aclgenerator.ACLGenerator):
             }
         return nftables
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Render the policy as Nftables configuration."""
         nft_config = []
         configuration = self._ConfigurationDictionary(self.nftables_policies)

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -18,10 +18,11 @@
 
 import re
 import xml
+from typing import Dict, List, Set, Tuple
 
 from absl import logging
 
-from aerleon.lib import aclgenerator, nacaddr
+from aerleon.lib import aclgenerator, nacaddr, policy
 
 _ACTION_TABLE = {
     'accept': 'allow',
@@ -109,7 +110,7 @@ class NsxvDuplicateTermError(Error):
 class Term(aclgenerator.Term):
     """Creates a  single ACL Term for Nsxv."""
 
-    def __init__(self, term, filter_type, applied_to=None, af=4):
+    def __init__(self, term: policy.Term, filter_type: str, applied_to: str = None, af: int = 4):
         self.term = term
         # Our caller should have already verified the address family.
         assert af in (4, 6)
@@ -117,7 +118,7 @@ class Term(aclgenerator.Term):
         self.filter_type = filter_type
         self.applied_to = applied_to
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Convert term to a rule string.
 
         Returns:
@@ -391,7 +392,9 @@ class Term(aclgenerator.Term):
         ret_str.extend(stripped_ret_lines)
         return ''.join(ret_str)
 
-    def _ServiceToString(self, proto, sports, dports, icmp_types):
+    def _ServiceToString(
+        self, proto: int, sports: Tuple[int, int], dports: Tuple[int, int], icmp_types: List[str]
+    ):
         """Converts service to string.
 
         Args:
@@ -495,7 +498,7 @@ class Nsxv(aclgenerator.ACLGenerator):
     )
     _FILTER_OPTIONS_DICT = {}
 
-    def _BuildTokens(self):
+    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -510,7 +513,7 @@ class Nsxv(aclgenerator.ACLGenerator):
         del supported_sub_tokens['option']
         return supported_tokens, supported_sub_tokens
 
-    def _TranslatePolicy(self, pol, exp_info):
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int):
         self.nsxv_policies = []
         for header, terms in pol.filters:
             filter_options = header.FilterOptions(self._PLATFORM)
@@ -572,7 +575,7 @@ class Nsxv(aclgenerator.ACLGenerator):
 
             self.nsxv_policies.append((header, filter_name, [filter_type], new_terms))
 
-    def _ParseFilterOptions(self, filter_options):
+    def _ParseFilterOptions(self, filter_options: List[str]):
         """Parses the target in header for filter type, section_id and applied_to.
 
         Args:
@@ -631,7 +634,7 @@ class Nsxv(aclgenerator.ACLGenerator):
         self._FILTER_OPTIONS_DICT['section_id'] = section_id
         self._FILTER_OPTIONS_DICT['applied_to'] = applied_to
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Render the output of the Nsxv policy."""
 
         target_header = []

--- a/aerleon/lib/openconfig.py
+++ b/aerleon/lib/openconfig.py
@@ -21,9 +21,7 @@ http://ops.openconfig.net/branches/models/master/openconfig-acl.html
 """
 
 import copy
-import ipaddress
 import json
-import re
 import sys
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Set, Tuple, Union
@@ -94,7 +92,7 @@ class Term(aclgenerator.Term):
         # flattened_saddr, flattened_daddr, flattened_addr.
         self.term.FlattenAll()
 
-    def __str__(self):
+    def __str__(self) -> None:
         """Convert term to a string."""
         rules = self.ConvertToDict()
         json.dumps(rules, indent=2)

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -23,7 +23,6 @@ import os
 import pathlib
 import sys
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
-from unittest.mock import MagicMock
 
 from absl import logging
 from ply import lex, yacc
@@ -1768,13 +1767,13 @@ class Target:
     def __str__(self) -> str:
         return self.platform
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
     def __eq__(self, other: Target) -> bool:
         return self.platform == other.platform and self.options == other.options
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not self.__eq__(other)
 
 

--- a/aerleon/lib/policy_simple.py
+++ b/aerleon/lib/policy_simple.py
@@ -45,12 +45,12 @@ class Field:
         indent = len(f) + 5
         return '%s::%s' % (f, self.ValueStr().replace('\n', '\n' + ' ' * indent))
 
-    def __eq__(self, o: "Target") -> bool:
+    def __eq__(self, o: Target) -> bool:
         if not isinstance(o, self.__class__):
             return False
         return self.value == o.value
 
-    def __ne__(self, o: "Target") -> bool:
+    def __ne__(self, o: Target) -> bool:
         return not self == o
 
     def Append(self, value: str) -> None:

--- a/aerleon/lib/port.py
+++ b/aerleon/lib/port.py
@@ -43,7 +43,7 @@ class PPP:
     Make port/protocol pairs an object for easy comparisons
     """
 
-    def __init__(self, service):
+    def __init__(self, service) -> None:
         """Init for PPP object.
 
         Args:

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -43,7 +43,8 @@ class DSMNet:
         self.netmask = netmask
         self.text = text
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        print(type(hash(str(self.address) + str(self.netmask))))
         return hash(str(self.address) + str(self.netmask))
 
     def __eq__(self, other: DSMNet) -> bool:
@@ -52,19 +53,20 @@ class DSMNet:
         except AttributeError:
             return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: DSMNet) -> bool:
+        print(type(other))
         eq = self.__eq__(other)
         if eq is NotImplemented:
             return NotImplemented
         return not eq
 
-    def __le__(self, other):
+    def __le__(self, other: DSMNet) -> bool:
         gt = self.__gt__(other)
         if gt is NotImplemented:
             return NotImplemented
         return not gt
 
-    def __ge__(self, other):
+    def __ge__(self, other: DSMNet) -> bool:
         lt = self.__lt__(other)
         if lt is NotImplemented:
             return NotImplemented
@@ -78,7 +80,7 @@ class DSMNet:
             return NotImplemented
         return False
 
-    def __gt__(self, other):
+    def __gt__(self, other: DSMNet) -> bool:
         try:
             if self.address != other.address:
                 return self.address > other.address
@@ -86,7 +88,7 @@ class DSMNet:
             return NotImplemented
         return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ' '.join([self.address, self.netmask])
 
     def MergeText(self, text: str = '') -> str:

--- a/tests/regression/aruba/aruba_test.py
+++ b/tests/regression/aruba/aruba_test.py
@@ -16,13 +16,12 @@
 """Unittest for Aruba acl rendering module."""
 
 import datetime
-import logging
 import textwrap
 from unittest import mock
 
 from absl.testing import absltest
 
-from aerleon.lib import aruba, nacaddr, naming, policy
+from aerleon.lib import aclgenerator, aruba, nacaddr, naming, policy
 from tests.regression_utils import capture
 
 GOOD_HEADER_V4 = """
@@ -277,7 +276,7 @@ class ArubaTest(absltest.TestCase):
         self.assertEqual(SUPPORTED_TOKENS, st)
         self.assertEqual(SUPPORTED_SUB_TOKENS, sst)
 
-    @mock.patch.object(aruba.logging, 'warning')
+    @mock.patch.object(aclgenerator.logging, 'warning')
     def testExpiredTerm(self, mock_warn):
         aruba.Aruba(policy.ParsePolicy(GOOD_HEADER_V4 + EXPIRED_TERM, self.naming), EXP_INFO)
         mock_warn.assert_called_once_with(
@@ -286,7 +285,7 @@ class ArubaTest(absltest.TestCase):
             'test-filter',
         )
 
-    @mock.patch.object(aruba.logging, 'info')
+    @mock.patch.object(aclgenerator.logging, 'info')
     def testExpiringTerm(self, mock_info):
         exp_date = datetime.date.today() + datetime.timedelta(weeks=EXP_INFO)
         aruba.Aruba(


### PR DESCRIPTION
This PR creates a ton of type hinting across the code base. Some things to note for future improvements.

- `_Group` is a function that is common across multiple generators. There are some slight differences but mostly it is copy/paste. We should bring this out of those.
- `ports.py` was mostly skipped. PPP looks to be mostly unused except in one function in `naming.py` which is unused. In general I think we should be creating a real port object similar to our discussions of a better nacaddr object and fixing the usage of strings being passed into places a nacaddr object should be passed in.
- To differentiate `policy.Term` from `aclgenerator.Term` I have changed many generators to import policy rather than the objects within.
- `nftables.py` has some missing functions. The test coverage here is low (~70%) so I am unconfident in what is being passed into every function. I could guess but I would rather add more tests and ensure this.
- Fixed a double `isinstance(el, str) in `juniper.py` that was left over from the py2 to py3 conversion.
- Removed a few comments that are no longer relevant.
- Removed unused imports
- In a few instances removed double quotes around type hints.
- Fixed unused import in `aruba.py` by patching `logging` in its parent `aclgenerator` rather than importing it unused in `aruba.py`.