### PR TITLE
Removing dead code from nacaddr.py.

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -517,7 +517,7 @@ class Term(aclgenerator.Term):
                 'source_address_exclude', self.af
             )
             if source_address_exclude:
-                source_address = nacaddr.ExcludeAddrs(source_address, source_address_exclude)
+                source_address = nacaddr.AddressListExclude(source_address, source_address_exclude)
             if not source_address:
                 if self.filter_type != 'mixed':
                     logging.warning(
@@ -540,7 +540,7 @@ class Term(aclgenerator.Term):
                 'destination_address_exclude', self.af
             )
             if destination_address_exclude:
-                destination_address = nacaddr.ExcludeAddrs(
+                destination_address = nacaddr.AddressListExclude(
                     destination_address, destination_address_exclude
                 )
             if not destination_address:

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -103,7 +103,7 @@ class Term(cisco.ExtendedTerm):
                 'source_address_exclude', self.af
             )
             if source_address_exclude:
-                source_address = nacaddr.ExcludeAddrs(source_address, source_address_exclude)
+                source_address = nacaddr.AddressListExclude(source_address, source_address_exclude)
             if self.enable_dsmo and len(source_address) > 1:
                 source_address = summarizer.Summarize(source_address)
         else:
@@ -117,7 +117,7 @@ class Term(cisco.ExtendedTerm):
                 'destination_address_exclude', self.af
             )
             if destination_address_exclude:
-                destination_address = nacaddr.ExcludeAddrs(
+                destination_address = nacaddr.AddressListExclude(
                     destination_address, destination_address_exclude
                 )
             if self.enable_dsmo and len(destination_address) > 1:

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -129,7 +129,7 @@ class Term(iptables.Term):
                 for addr_exclude in addr_exclude_list
                 if addr_exclude.version == target_af
             ]
-            addr_list = nacaddr.ExcludeAddrs(addr_list, addr_exclude_list)
+            addr_list = nacaddr.AddressListExclude(addr_list, addr_exclude_list)
         if len(addr_list) > 1:
             set_name = self._GenerateSetName(self.term.name, direction)
             self.addr_sets[direction] = (set_name, addr_list)

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -423,14 +423,14 @@ class Term(aclgenerator.Term):
         if not term_saddr:
             term_saddr = [self._all_ips]
         if exclude_saddr:
-            term_saddr_excluded.extend(nacaddr.ExcludeAddrs(term_saddr, exclude_saddr))
+            term_saddr_excluded.extend(nacaddr.AddressListExclude(term_saddr, exclude_saddr))
 
         # destination address
         term_daddr_excluded = []
         if not term_daddr:
             term_daddr = [self._all_ips]
         if exclude_daddr:
-            term_daddr_excluded.extend(nacaddr.ExcludeAddrs(term_daddr, exclude_daddr))
+            term_daddr_excluded.extend(nacaddr.AddressListExclude(term_daddr, exclude_daddr))
 
         # Just to be safe, always have a result of at least 1 to avoid * by zero
         # returning incorrect results (10src*10dst=100, but 10src*0dst=0, not 10)
@@ -461,8 +461,8 @@ class Term(aclgenerator.Term):
         v6_dst_count = len([x for x in term_daddr if x.version == 6])
         num_pairs = v4_src_count * v4_dst_count + v6_src_count * v6_dst_count
         if num_pairs > 100:
-            new_exclude_source = nacaddr.ExcludeAddrs([self._all_ips], term_saddr)
-            new_exclude_dest = nacaddr.ExcludeAddrs([self._all_ips], term_daddr)
+            new_exclude_source = nacaddr.AddressListExclude([self._all_ips], term_saddr)
+            new_exclude_dest = nacaddr.AddressListExclude([self._all_ips], term_daddr)
             # Invert the shortest list that does not already have exclude addresses
             if len(new_exclude_source) < len(new_exclude_dest) and not exclude_saddr:
                 if len(new_exclude_source) + len(term_daddr) < num_pairs:

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -442,7 +442,7 @@ class Term(aclgenerator.Term):
         exclude_count = (len(term_saddr_excluded) or 1) * (len(term_daddr_excluded) or 1)
 
         # Use bailout jumps for excluded addresses if it results in fewer output
-        # lines than nacaddr.ExcludeAddrs() method.
+        # lines than nacaddr.AddressListExclude() method.
         if exclude_count < bailout_count:
             exclude_saddr = []
             exclude_daddr = []

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -21,9 +21,31 @@ from __future__ import annotations
 import collections
 import ipaddress
 import itertools
+import warnings
 from typing import Union, cast
 
 import aerleon.utils.iputils as iputils
+
+# Names kept only for backwards compatibility with Capirca / nacaddr v1. Calling
+# one emits a DeprecationWarning pointing at its replacement.
+# TODO(aerleon): remove the deprecated names (IPv4.Supernet, IPv6.Supernet,
+# ExcludeAddrs, PrefixlenDiffInvalidError) in February 2027.
+_DEPRECATION_REMOVAL = 'February 2027'
+
+
+def _WarnDeprecatedName(old_name: str, new_name: str) -> None:
+    """Emit a DeprecationWarning for a deprecated backwards compatibility name.
+
+    Args:
+      old_name: the deprecated name that was called.
+      new_name: the name callers should use instead.
+    """
+    warnings.warn(
+        f"nacaddr.{old_name} is deprecated and will be removed in "
+        f"{_DEPRECATION_REMOVAL}. Use nacaddr.{new_name} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 def IP(
@@ -146,8 +168,9 @@ class IPv4(ipaddress.IPv4Network):
           An IPv4 object
 
         Raises:
-          PrefixlenDiffInvalidError: Raised when prefixlen - prefixlen_diff results
-            in a negative number.
+          PrefixlenDiffInvalidError: A deprecated subclass of
+            ipaddress.NetmaskValueError. Raised when prefixlen - prefixlen_diff
+            results in a negative number.
         """
         if self.prefixlen == 0:
             return self
@@ -163,8 +186,19 @@ class IPv4(ipaddress.IPv4Network):
         )
         return ret_addr
 
-    # Backwards compatibility name from v1.
-    Supernet = supernet
+    # DEPRECATED: backwards compatibility name from v1.
+    # TODO(aerleon): remove in February 2027, callers should use supernet().
+    def Supernet(self, prefixlen_diff: int = 1) -> IPv4:
+        """Deprecated alias for supernet().
+
+        Args:
+          prefixlen_diff: Prefix length difference.
+
+        Returns:
+          An IPv4 object
+        """
+        _WarnDeprecatedName('IPv4.Supernet', 'IPv4.supernet')
+        return self.supernet(prefixlen_diff)
 
 
 class IPv6(ipaddress.IPv6Network):
@@ -222,8 +256,9 @@ class IPv6(ipaddress.IPv6Network):
           An IPv4 object
 
         Raises:
-          PrefixlenDiffInvalidError: Raised when prefixlen - prefixlen_diff results
-            in a negative number.
+          PrefixlenDiffInvalidError: A deprecated subclass of
+            ipaddress.NetmaskValueError. Raised when prefixlen - prefixlen_diff
+            results in a negative number.
         """
         if self.prefixlen == 0:
             return self
@@ -239,8 +274,19 @@ class IPv6(ipaddress.IPv6Network):
         )
         return ret_addr
 
-    # Backwards compatibility name from v1.
-    Supernet = supernet
+    # DEPRECATED: backwards compatibility name from v1.
+    # TODO(aerleon): remove in February 2027, callers should use supernet().
+    def Supernet(self, prefixlen_diff: int = 1) -> IPv6:
+        """Deprecated alias for supernet().
+
+        Args:
+          prefixlen_diff: Prefix length difference.
+
+        Returns:
+          An IPv6 object
+        """
+        _WarnDeprecatedName('IPv6.Supernet', 'IPv6.supernet')
+        return self.supernet(prefixlen_diff)
 
     def AddComment(self, comment: str = '') -> None:
         """Append comment to self.text, comma separated.
@@ -514,11 +560,36 @@ def AddressListExclude(
         return sorted(set(ret_array + superset))
 
 
-ExcludeAddrs = AddressListExclude
+# DEPRECATED: backwards compatibility name from v1.
+# TODO(aerleon): remove in February 2027, callers should use AddressListExclude().
+def ExcludeAddrs(
+    superset: list[IPv4 | IPv6],
+    excludes: list[IPv4 | IPv6],
+    collapse_addrs: bool = True,
+) -> list[IPv4 | IPv6]:
+    """Deprecated alias for AddressListExclude().
+
+    Args:
+      superset: a List of nacaddr IPv4 or IPv6 addresses
+      excludes: a List nacaddr IPv4 or IPv6 addresses
+      collapse_addrs: whether or not to collapse contiguous CIDRs togethe
+
+    Returns:
+      a List of nacaddr IPv4 or IPv6 addresses
+    """
+    _WarnDeprecatedName('ExcludeAddrs', 'AddressListExclude')
+    return AddressListExclude(superset, excludes, collapse_addrs)
 
 
+# DEPRECATED: holdover from ipaddr v1. It subclasses ipaddress.NetmaskValueError,
+# so callers should catch ipaddress.NetmaskValueError instead.
+# TODO(aerleon): remove in February 2027 and raise ipaddress.NetmaskValueError
+# directly from IPv4.supernet() and IPv6.supernet().
 class PrefixlenDiffInvalidError(ipaddress.NetmaskValueError):
-    """Holdover from ipaddr v1."""
+    """Holdover from ipaddr v1.
+
+    Deprecated: catch ipaddress.NetmaskValueError instead.
+    """
 
 
 if __name__ == '__main__':

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -400,7 +400,7 @@ def _CollapseAddrListInternal(
             ):  # pylint disable=protected-access
                 # Preserve addr's comment, then merge with it.
                 prev_addr.AddComment(addr.text)
-                addr = ret_array.pop().Supernet()
+                addr = ret_array.pop().supernet()
                 addr_is_fresh = True
             else:
                 ret_array.append(addr)

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -220,7 +220,9 @@ class Term(aclgenerator.Term):
                     'source_address_exclude', af
                 )
                 if source_address_exclude:
-                    source_address = nacaddr.ExcludeAddrs(source_address, source_address_exclude)
+                    source_address = nacaddr.AddressListExclude(
+                        source_address, source_address_exclude
+                    )
 
                 if source_address:
                     if af == 4:
@@ -236,7 +238,7 @@ class Term(aclgenerator.Term):
                     'destination_address_exclude', af
                 )
                 if destination_address_exclude:
-                    destination_address = nacaddr.ExcludeAddrs(
+                    destination_address = nacaddr.AddressListExclude(
                         destination_address, destination_address_exclude
                     )
 

--- a/aerleon/lib/proxmox.py
+++ b/aerleon/lib/proxmox.py
@@ -2,7 +2,7 @@ import math
 from collections.abc import MutableMapping
 
 from aerleon.lib import aclgenerator, policy
-from aerleon.lib.nacaddr import ExcludeAddrs, IPv4, IPv6
+from aerleon.lib.nacaddr import AddressListExclude, IPv4, IPv6
 from aerleon.lib.policy import PROTOS_WITH_PORTS, Policy
 from aerleon.utils.options import BooleanKeywordOption as _BooleanKeywordOption
 from aerleon.utils.options import (
@@ -283,7 +283,7 @@ class Term(aclgenerator.Term):
     def _ComputeAddresses(addresses, exclude_addresses):
         addresses_with_exclude = addresses
         if exclude_addresses:
-            addresses_with_exclude = ExcludeAddrs(addresses, exclude_addresses)
+            addresses_with_exclude = AddressListExclude(addresses, exclude_addresses)
         return addresses_with_exclude
 
     def __str__(self) -> str:

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Unittest for nacaddr.py module."""
-
+import ipaddress
 from absl.testing import absltest
 
 from aerleon.lib import nacaddr
@@ -85,9 +85,9 @@ class NacaddrUnitTest(absltest.TestCase):
         self.assertEqual(nacaddr.IP('0.0.0.0/0').supernet(), nacaddr.IP('0.0.0.0/0'))
         self.assertEqual(nacaddr.IP('::0/0').supernet(), nacaddr.IP('::0/0'))
 
-        self.assertRaises(nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('1.1.1.0/24').supernet, 25)
+        self.assertRaises(ipaddress.NetmaskValueError, nacaddr.IP('1.1.1.0/24').supernet, 25)
         self.assertRaises(
-            nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('::1/64', strict=False).supernet, 65
+            ipaddress.NetmaskValueError, nacaddr.IP('::1/64', strict=False).supernet, 65
         )
 
     def testAddressListExclusion(self):

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -15,6 +15,7 @@
 
 """Unittest for nacaddr.py module."""
 import ipaddress
+
 from absl.testing import absltest
 
 from aerleon.lib import nacaddr

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -75,19 +75,19 @@ class NacaddrUnitTest(absltest.TestCase):
         self.assertEqual(self.addr2.text, 'An IPv6 Address')
 
     def testSupernetting(self):
-        self.assertEqual(self.addr1.Supernet().text, 'The 10 block')
-        self.assertEqual(self.addr2.Supernet().text, 'An IPv6 Address')
-        self.assertEqual(self.addr1.Supernet().prefixlen, 7)
-        self.assertEqual(self.addr2.Supernet().prefixlen, 63)
+        self.assertEqual(self.addr1.supernet().text, 'The 10 block')
+        self.assertEqual(self.addr2.supernet().text, 'An IPv6 Address')
+        self.assertEqual(self.addr1.supernet().prefixlen, 7)
+        self.assertEqual(self.addr2.supernet().prefixlen, 63)
 
         token_ip = nacaddr.IP('1.1.1.0/24', token='FOO_TOKEN')
-        self.assertEqual(token_ip.Supernet().token, 'FOO_TOKEN')
-        self.assertEqual(nacaddr.IP('0.0.0.0/0').Supernet(), nacaddr.IP('0.0.0.0/0'))
-        self.assertEqual(nacaddr.IP('::0/0').Supernet(), nacaddr.IP('::0/0'))
+        self.assertEqual(token_ip.supernet().token, 'FOO_TOKEN')
+        self.assertEqual(nacaddr.IP('0.0.0.0/0').supernet(), nacaddr.IP('0.0.0.0/0'))
+        self.assertEqual(nacaddr.IP('::0/0').supernet(), nacaddr.IP('::0/0'))
 
-        self.assertRaises(nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('1.1.1.0/24').Supernet, 25)
+        self.assertRaises(nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('1.1.1.0/24').supernet, 25)
         self.assertRaises(
-            nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('::1/64', strict=False).Supernet, 65
+            nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('::1/64', strict=False).supernet, 65
         )
 
     def testAddressListExclusion(self):

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -91,6 +91,24 @@ class NacaddrUnitTest(absltest.TestCase):
             ipaddress.NetmaskValueError, nacaddr.IP('::1/64', strict=False).supernet, 65
         )
 
+    def testDeprecatedSupernet(self):
+        for addr in (self.addr1, self.addr2):
+            with self.assertWarns(DeprecationWarning):
+                supernet = addr.Supernet()
+            self.assertEqual(supernet, addr.supernet())
+            self.assertEqual(supernet.text, addr.text)
+
+    def testDeprecatedExcludeAddrs(self):
+        superset = [nacaddr.IPv4('1.1.1.0/24')]
+        excludes = [nacaddr.IPv4('1.1.1.0/25')]
+        with self.assertWarns(DeprecationWarning):
+            result = nacaddr.ExcludeAddrs(superset, excludes)
+        self.assertListEqual(result, nacaddr.AddressListExclude(superset, excludes))
+
+    def testDeprecatedPrefixlenDiffInvalidError(self):
+        self.assertTrue(issubclass(nacaddr.PrefixlenDiffInvalidError, ipaddress.NetmaskValueError))
+        self.assertRaises(nacaddr.PrefixlenDiffInvalidError, nacaddr.IP('1.1.1.0/24').supernet, 25)
+
     def testAddressListExclusion(self):
         a1 = nacaddr.IPv4('1.1.1.0/24')
         a2 = nacaddr.IPv4('10.0.0.0/24')


### PR DESCRIPTION
Back in when this project was first created Python had no ipaddress library. IIRC Peter Moody created it and open sourced it which is why you will find it copyrighted by Google in https://github.com/python/cpython/blob/main/Lib/ipaddress.py#L1276

You can see there are some slight differences between the one in the "third party" folder and the open source version which is what these deleted lined helped to bridge.
https://github.com/google/capirca/commit/4f694aa1af94352e6f89a87bb85ac201488b4967

I also deleted a function ` _is_subnet_of` that was necessary while Google was stuck in pre 3.7 but is included at 3.7. We only support 3.7+ so it is safe to remove ` _is_subnet_of`.