### PR TITLE
PR282 Fixes destination hosts being outputted incorrectly.

### DIFF
--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -231,25 +231,25 @@ class Term(cisco.ExtendedTerm):
                 saddr = '%s %s' % (saddr.network_address, saddr.netmask)
             else:
                 saddr = 'host %s' % (saddr.network_address)
-        elif isinstance(daddr, nacaddr.IPv4) or isinstance(daddr, ipaddress.IPv4Network):
+        if isinstance(daddr, nacaddr.IPv4) or isinstance(daddr, ipaddress.IPv4Network):
             daddr = cast(self.IPV4_ADDRESS, daddr)
             if daddr.num_addresses > 1:
                 daddr = '%s %s' % (daddr.network_address, daddr.netmask)
             else:
                 daddr = 'host %s' % (daddr.network_address)
-        elif isinstance(saddr, summarizer.DSMNet):
+        if isinstance(saddr, summarizer.DSMNet):
             saddr = '%s %s' % summarizer.ToDottedQuad(saddr, negate=False)
 
         if isinstance(daddr, summarizer.DSMNet):
             daddr = '%s %s' % summarizer.ToDottedQuad(daddr, negate=False)
         # inet6
-        elif isinstance(saddr, nacaddr.IPv6) or isinstance(saddr, ipaddress.IPv6Network):
+        if isinstance(saddr, nacaddr.IPv6) or isinstance(saddr, ipaddress.IPv6Network):
             saddr = cast(self.IPV6_ADDRESS, saddr)
             if saddr.num_addresses > 1:
                 saddr = '%s/%s' % (saddr.network_address, saddr.prefixlen)
             else:
                 saddr = 'host %s' % (saddr.network_address)
-        elif isinstance(daddr, nacaddr.IPv6) or isinstance(daddr, ipaddress.IPv6Network):
+        if isinstance(daddr, nacaddr.IPv6) or isinstance(daddr, ipaddress.IPv6Network):
             daddr = cast(self.IPV6_ADDRESS, daddr)
             if daddr.num_addresses > 1:
                 daddr = '%s/%s' % (daddr.network_address, daddr.prefixlen)

--- a/tests/regression/ciscoasa/CiscoASATest.testHostAddressFormat.stdout.ref
+++ b/tests/regression/ciscoasa/CiscoASATest.testHostAddressFormat.stdout.ref
@@ -1,0 +1,8 @@
+clear configure access-list allowtointernet
+access-list allowtointernet remark $Id:$
+access-list allowtointernet remark $Date:$
+access-list allowtointernet remark $Revision:$
+
+
+access-list allowtointernet remark accept-foo
+access-list allowtointernet extended permit ip host 10.0.0.1 host 10.0.0.1

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -188,7 +188,7 @@ class CiscoASATest(parameterized.TestCase):
         ]
         pol = ciscoasa.CiscoASA(policy.ParsePolicy(DSMO_HEADER + term, self.naming), EXP_INFO)
         self.assertIn(expected, str(pol))
-    
+
     @capture.stdout
     def testHostAddressFormat(self):
         defs = naming.Naming()
@@ -204,11 +204,11 @@ class CiscoASATest(parameterized.TestCase):
                 destination-address: FOO
                 action: accept
         """
-        pol = ciscoasa.CiscoASA(_YamlParsePolicy(
-            HEADER, definitions=defs), EXP_INFO)
+        pol = ciscoasa.CiscoASA(_YamlParsePolicy(HEADER, definitions=defs), EXP_INFO)
         print(pol)
-        self.assertIn('access-list allowtointernet extended permit ip host 10.0.0.1 host 10.0.0.1',
-                      str(pol))
+        self.assertIn(
+            'access-list allowtointernet extended permit ip host 10.0.0.1 host 10.0.0.1', str(pol)
+        )
 
 
 def _YamlParsePolicy(
@@ -222,5 +222,7 @@ def _YamlParsePolicy(
         optimize=optimize,
         shade_check=shade_check,
     )
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -193,7 +193,7 @@ class CiscoASATest(parameterized.TestCase):
     def testHostAddressFormat(self):
         defs = naming.Naming()
         defs._ParseLine('FOO = 10.0.0.1/32', 'networks')
-        HEADER = """
+        pol_yaml = """
         filters:
           - header:
               targets:
@@ -204,7 +204,7 @@ class CiscoASATest(parameterized.TestCase):
                 destination-address: FOO
                 action: accept
         """
-        pol = ciscoasa.CiscoASA(_YamlParsePolicy(HEADER, definitions=defs), EXP_INFO)
+        pol = ciscoasa.CiscoASA(_YamlParsePolicy(pol_yaml, definitions=defs), EXP_INFO)
         print(pol)
         self.assertIn(
             'access-list allowtointernet extended permit ip host 10.0.0.1 host 10.0.0.1', str(pol)

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -20,8 +20,8 @@ from unittest import mock
 from absl.testing import absltest, parameterized
 
 from aerleon.lib import ciscoasa, nacaddr, naming, policy
-from tests.regression_utils import capture
 from aerleon.lib import yaml as yaml_frontend
+from tests.regression_utils import capture
 
 GOOD_HEADER = """
 header {


### PR DESCRIPTION
The term to str function currently does if/elif rather than sequential if statements. Regression test added to prevent this from happening during any cleanup we may perform in the future.