### PR TITLE
Better ciscoasa dsmo test

### DIFF
--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -123,7 +123,6 @@ class Term(cisco.ExtendedTerm):
                     destination_address, destination_address_exclude
                 )
             if self.enable_dsmo and len(destination_address) > 1:
-                
                 destination_address = summarizer.Summarize(destination_address)
         else:
             # destination address not set

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -123,6 +123,7 @@ class Term(cisco.ExtendedTerm):
                     destination_address, destination_address_exclude
                 )
             if self.enable_dsmo and len(destination_address) > 1:
+                
                 destination_address = summarizer.Summarize(destination_address)
         else:
             # destination address not set

--- a/tests/regression/ciscoasa/CiscoASATest.testDSMOdestination.stdout.ref
+++ b/tests/regression/ciscoasa/CiscoASATest.testDSMOdestination.stdout.ref
@@ -1,0 +1,8 @@
+clear configure access-list foo
+access-list foo remark $Id:$
+access-list foo remark $Date:$
+access-list foo remark $Revision:$
+
+
+access-list foo remark good-dst-term-3
+access-list foo extended permit ip any 128.168.0.0 191.255.255.128

--- a/tests/regression/ciscoasa/CiscoASATest.testDSMOsource.stdout.ref
+++ b/tests/regression/ciscoasa/CiscoASATest.testDSMOsource.stdout.ref
@@ -1,0 +1,8 @@
+clear configure access-list foo
+access-list foo remark $Id:$
+access-list foo remark $Date:$
+access-list foo remark $Revision:$
+
+
+access-list foo remark good-src-term-3
+access-list foo extended permit ip 128.168.0.0 191.255.255.128 any

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -188,7 +188,7 @@ class CiscoASATest(parameterized.TestCase):
         ]
         pol = ciscoasa.CiscoASA(policy.ParsePolicy(DSMO_HEADER + term, self.naming), EXP_INFO)
         print(pol)
-        # self.assertIn(expected, str(pol))
+        self.assertIn(expected, str(pol))
 
 
 if __name__ == '__main__':

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -180,13 +180,15 @@ class CiscoASATest(parameterized.TestCase):
         ('source', GOOD_TERM_3, 'permit ip 10.0.0.0 255.255.254.0 any'),
         ('destination', GOOD_TERM_4, 'permit ip any 10.0.0.0 255.255.254.0'),
     )
+    @capture.stdout
     def testDSMO(self, term, expected):
         self.naming.GetNetAddr.return_value = [
-            nacaddr.IP('10.0.0.0/24'),
-            nacaddr.IPv4('10.0.1.0/24'),
+            nacaddr.IPv4('192.168.0.0/25'),
+            nacaddr.IPv4('128.168.0.0/25'),
         ]
         pol = ciscoasa.CiscoASA(policy.ParsePolicy(DSMO_HEADER + term, self.naming), EXP_INFO)
-        self.assertIn(expected, str(pol))
+        print(pol)
+        # self.assertIn(expected, str(pol))
 
 
 if __name__ == '__main__':

--- a/tests/regression/ciscoasa/ciscoasa_test.py
+++ b/tests/regression/ciscoasa/ciscoasa_test.py
@@ -177,8 +177,8 @@ class CiscoASATest(parameterized.TestCase):
         self.assertIn(expect, str(pol))
 
     @parameterized.named_parameters(
-        ('source', GOOD_TERM_3, 'permit ip 10.0.0.0 255.255.254.0 any'),
-        ('destination', GOOD_TERM_4, 'permit ip any 10.0.0.0 255.255.254.0'),
+        ('source', GOOD_TERM_3, 'permit ip 128.168.0.0 191.255.255.128 any'),
+        ('destination', GOOD_TERM_4, 'permit ip any 128.168.0.0 191.255.255.128'),
     )
     @capture.stdout
     def testDSMO(self, term, expected):


### PR DESCRIPTION
The original test did not take into account that the IPs would be summarized. This changes to a set of subnets that are summarizable but are discontiguous.