### PR TITLE
Add a module-level main script

### DIFF
--- a/aerleon/__main__.py
+++ b/aerleon/__main__.py
@@ -1,0 +1,11 @@
+import sys
+
+from aerleon import aclgen
+
+rc = 1
+try:
+    aclgen.EntryPoint()
+    rc = 0
+except Exception as e:
+    print('Error: %s' % e, file=sys.stderr)
+sys.exit(rc)


### PR DESCRIPTION
This change allows users to invoke aclgen by simply running:

```
python3 -m aerleon
```

This is especially useful for scripts that want to invoke aclgen without necessarily having it available in $PATH.