### PR TITLE
Update FQDN validation

### DIFF
--- a/aerleon/lib/fqdn.py
+++ b/aerleon/lib/fqdn.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 class FQDN:
     # https://regexr.com/3g5j0
     fqdn_re = re.compile(
-        r'^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$', re.IGNORECASE
+        r'^(?!.*:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$', re.IGNORECASE
     )
     fqdn: str
     text: str

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -891,7 +891,7 @@ class Naming:
                 # 1. A string, understood as a network name reference
                 # 2. A dictionary, with these fields:
                 #    'address': A specific IP address or CIDR range
-                #    'hostname': A FQDN for use in DNS filtering.
+                #    'fqdn': A FQDN for use in DNS filtering.
                 #    'name': A network name reference
                 #    'comment': An optional comment
                 # 'address' or 'name' must be present in any dictionary item

--- a/schemas/aerleon-definitions.schema.json
+++ b/schemas/aerleon-definitions.schema.json
@@ -34,6 +34,11 @@
       "description": "Specifies an IP address or CIDR IP address range expression.",
       "type": "string"
     },
+    "fqdn": {
+      "description": "Specifies a fully qualified domain name with at least two labels.",
+      "type": "string",
+      "pattern": "^(?!:\/\/)(?=.{1,255}$)((.{1,63}.){1,127}(?![0-9]*$)[a-z0-9-]+.?)$"
+    },
     "port": {
       "description": "Specifies a port or port range.",
       "oneOf": [
@@ -73,6 +78,15 @@
                 "required": ["address"],
                 "properties": {
                   "address": { "$ref": "#/$defs/address" },
+                  "comment": { "$ref": "#/$defs/comment" }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": ["fqdn"],
+                "properties": {
+                  "fqdn": { "$ref": "#/$defs/fqdn" },
                   "comment": { "$ref": "#/$defs/comment" }
                 },
                 "additionalProperties": false

--- a/schemas/aerleon-definitions.schema.json
+++ b/schemas/aerleon-definitions.schema.json
@@ -37,7 +37,7 @@
     "fqdn": {
       "description": "Specifies a fully qualified domain name with two or more labels.",
       "type": "string",
-      "pattern": "^(?!:\/\/)(?=.{1,255}$)((.{1,63}.){1,127}(?![0-9]*$)[a-z0-9-]+.?)$"
+      "pattern": "^(?!.*://)(?=.{1,255}$)((.{1,63}\\.){1,127}(?![0-9]*$)[a-z0-9-]+\\.?)$"
     },
     "port": {
       "description": "Specifies a port or port range.",

--- a/schemas/aerleon-definitions.schema.json
+++ b/schemas/aerleon-definitions.schema.json
@@ -35,7 +35,7 @@
       "type": "string"
     },
     "fqdn": {
-      "description": "Specifies a fully qualified domain name with at least two labels.",
+      "description": "Specifies a fully qualified domain name with two or more labels.",
       "type": "string",
       "pattern": "^(?!:\/\/)(?=.{1,255}$)((.{1,63}.){1,127}(?![0-9]*$)[a-z0-9-]+.?)$"
     },

--- a/tests/lib/fqdn_test.py
+++ b/tests/lib/fqdn_test.py
@@ -38,6 +38,7 @@ class FQDNTest(parameterized.TestCase):
             '',
             True,
         ),
+        ('URL scheme must not be included', 'https://foo.bar', '', '', True),
     )
     def testFQDNCreation(self, possible_fqdn: str, token: str, comment: str, error: Exception):
 


### PR DESCRIPTION
* Updates the FQDN regex in fqdn.py to disallow URL schemes, e.g. `https://foo.bar` is forbidden but `foo.bar` is allowed.
* Enables the `fqdn:` field in the definition YAML schema.