### PR TITLE
Configure Material theme and refresh docs content

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 Generate firewall configs for multiple firewall platforms from a single platform-agnostic configuration language through a command line tool and Python API.
 
-Aerleon is a fork of [Capirca](https://github.com/google/capirca) with the following enhancements:
+Aerleon is a fork of [Capirca](https://github.com/google/capirca) with the following major additions:
 
-- New platform generators can now be added as plugins. Users no longer need to fork the project to add support for new platforms. Common platform support is still built in.
-- YAML is now supported for policy files, network definitions, and service definitions.
-- A powerful new Generate API is added that accepts policies, network definitions, and service definitions as native Python data.
-- Performance in address book generation for SRX and Palo Alto targets is greatly improved.
-- A detailed regression test suite was added to the project.
-- Unit and regression tests run automatically on all pull requests.
-- New developer tools are integrated with the project: Poetry, PyProject, nox, Codecov, Sigstore.
+- YAML policy and network definitions files are supported. A [converter from Capirca's policy DSL to YAML](https://github.com/aerleon/pol2yaml) is available.
+- FQDN values are supported in network definitions.
+- Support for new firewall platforms can be added through plugins.
+- Typed Python APIs are provided for ACL generation and aclcheck queries.
+- A [SLSA-compatible verifiable release process](https://aerleon.readthedocs.io/en/latest/install/#verifying-installation).
+- A detailed regression test suite.
+- Many bug fixes and performance enhancements.
 
 ## Install
 

--- a/aerleon/lib/fqdn.py
+++ b/aerleon/lib/fqdn.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 @dataclass
 class FQDN:
+    """Contains a single fully qualified domain name associated with a token, parent_token and optional comment."""
+
     # https://regexr.com/3g5j0
     fqdn_re = re.compile(
         r'^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$', re.IGNORECASE
@@ -15,7 +17,7 @@ class FQDN:
 
     def __init__(self, fqdn: str, token: str, comment: str = ''):
         if not self.fqdn_re.match(fqdn):
-            raise ValueError(f"{fqdn} is not a FQDN.")
+            raise ValueError(f"Not a valid FQDN: {fqdn}")
         self.fqdn = fqdn
         self.text = comment
         self.token = token

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,4 @@
-# CLI Reference
+# Command Line Usage
 
 Aerleon contains three command line programs:
 

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -86,35 +86,35 @@ defs.GetServiceByProto('DNS','udp')
 
 ### Network Query Methods
 
-#### Naming.GetNet(query: str) -> List[Union[IPv4, IPv6]]
+#### Naming.GetNet
 ::: aerleon.lib.naming.Naming.GetNet
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetIpParents(query: str) -> List[str]
+#### Naming.GetIpParents
 ::: aerleon.lib.naming.Naming.GetIpParents
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetNetParents(query: str) -> List[str]
+#### Naming.GetNetParents
 ::: aerleon.lib.naming.Naming.GetNetParents
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetNetChildren(query: str) -> List[str]
+#### Naming.GetNetChildren
 ::: aerleon.lib.naming.Naming.GetNetChildren
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetFQDN(query: str) -> List[str]
+#### Naming.GetFQDN
 ::: aerleon.lib.naming.Naming.GetFQDN
     options:
       show_source: false
@@ -123,28 +123,28 @@ defs.GetServiceByProto('DNS','udp')
 
 ### Service Query Methods
 
-#### Naming.GetService(query: str) -> List[str]
+#### Naming.GetService
 ::: aerleon.lib.naming.Naming.GetService
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetServiceByProto(query: str, proto: str) -> List[str]
+#### Naming.GetServiceByProto
 ::: aerleon.lib.naming.Naming.GetServiceByProto
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetPortParents(query: str) -> List[str]
+#### Naming.GetPortParents
 ::: aerleon.lib.naming.Naming.GetPortParents
     options:
       show_source: false
       show_root_heading: false
       show_root_toc_entry: false
 
-#### Naming.GetServiceParents(query: str) -> List[str]
+#### Naming.GetServiceParents
 ::: aerleon.lib.naming.Naming.GetServiceParents
     options:
       show_source: false

--- a/docs/reference/yaml_reference.md
+++ b/docs/reference/yaml_reference.md
@@ -1,4 +1,4 @@
-# YAML Policy Files
+# Policy Files
 
 ## Usage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
-    - search.highlight
 extra_css:
   - css/extra.css
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,17 +6,18 @@ site_url: 'https://aerleon.readthedocs.io/en/latest/'
 repo_url: 'https://github.com/aerleon/aerleon'
 copyright: Copyright &copy; The Authors
 theme:
-  name: "material"
-  navigation_depth: 4
+  name: material
   hljs_languages:
-    - "python"
-    - "yaml"
+    - python
+    - yaml
   features:
-    - "navigation.tracking"
-    - "search.suggest"
-    - "search.highlight"
-    - "search.share"
-    - "navigation.indexes"
+    - navigation.footer
+    - navigation.indexes
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - search.highlight
 extra_css:
   - css/extra.css
 extra:
@@ -56,16 +57,19 @@ plugins:
           options:
             docstring_section_style: table
 nav:
-  - Introduction: index.md
-  - Install and Configure: install.md
-  - Getting Started: getting_started.md
-  - Using the API: api.md
-  - Frequently Asked Questions: faq.md
-  - Contributing: contributing.md
-  - Links: links.md
+  - Overview:
+    - Overview: index.md
+    - Install and Configure: install.md
+    - Getting Started: getting_started.md
+    - FAQ: faq.md
+    - Contributing: contributing.md
+    - Links: links.md
+  - Usage:
+    - Command Line Usage: reference/cli.md
+    - Policy Files: reference/yaml_reference.md
+    - Naming: reference/naming.md
+  - API:
+    - API Reference: api.md
   - Reference:
-      - CLI Reference: reference/cli.md
-      - Generators: reference/generators.md
-      - Naming: reference/naming.md
-      - Generator Development: reference/generator_patterns.md
-      - YAML Reference: reference/yaml_reference.md
+    - Generators: reference/generators.md
+    - Generator Development: reference/generator_patterns.md


### PR DESCRIPTION
This builds on https://github.com/aerleon/aerleon/pull/238 with broader changes across the docs site to take advantage of the switch to Material theme. This also re-words the README fork features list and includes a variety of touch-ups.