### PR TITLE
Fix schema: lowercase network, service names

### DIFF
--- a/schemas/aerleon-definitions.schema.json
+++ b/schemas/aerleon-definitions.schema.json
@@ -24,7 +24,7 @@
   "$defs": {
     "token": {
       "type": "string",
-      "pattern": "^[-_A-Z0-9]+$"
+      "pattern": "^[-_a-zA-Z0-9]+$"
     },
     "comment": {
       "description": "Attach a comment directly to a value. This comment may be included in generated output on platforms that support it.",


### PR DESCRIPTION
Non-uppercase network names are allowed by Aerleon. The schema should allow them also.