### PR TITLE
Fix the usage of SIP on Arista by using integer.

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -297,7 +297,6 @@ class PortMap:
         123: 'ntp',
         496: 'pim-auto-rp',
         520: 'rip',
-        5060: 'sip',
         161: 'snmp',
         162: 'snmptrap',
         111: 'sunrpc',
@@ -354,6 +353,7 @@ class PortMap:
         1645: 'radius',
         1646: 'radius-acct',
         5510: 'secureid-udp',
+        5060: 'sip',
     }
     _CISCO_PORTS_UDP.update(_PORTS_UDP)
 

--- a/tests/regression/arista/AristaTest.testSIPUsesInt.stdout.ref
+++ b/tests/regression/arista/AristaTest.testSIPUsesInt.stdout.ref
@@ -1,0 +1,14 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list test-filter
+ip access-list test-filter
+ remark $Id:$
+ remark this is a test extended acl
+
+
+ remark good-term-2
+ permit udp any any eq 5060
+
+exit
+

--- a/tests/regression/arista/arista_test.py
+++ b/tests/regression/arista/arista_test.py
@@ -118,6 +118,13 @@ term good-term-6 {
   action:: accept
 }
 """
+GOOD_TERM_8 = """
+term good-term-2 {
+  destination-port:: SIP
+  protocol:: udp
+  action:: accept
+}
+"""
 
 SUPPORTED_TOKENS = {
     'action',
@@ -313,6 +320,14 @@ class AristaTest(absltest.TestCase):
         self.assertIn(expected, str(acl), str(acl))
 
         self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST')])
+    
+    @capture.stdout
+    def testSIPUsesInt(self):
+        self.naming.GetServiceByProto.return_value = ['5060']
+        pol = policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_8, self.naming)
+        acl = arista.Arista(pol, EXP_INFO)
+        self.assertIn('5060', str(acl))
+        self.assertNotIn('sip', str(acl))
 
 
 if __name__ == '__main__':

--- a/tests/regression/arista/arista_test.py
+++ b/tests/regression/arista/arista_test.py
@@ -326,6 +326,7 @@ class AristaTest(absltest.TestCase):
         self.naming.GetServiceByProto.return_value = ['5060']
         pol = policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_8, self.naming)
         acl = arista.Arista(pol, EXP_INFO)
+        print(acl)
         self.assertIn('5060', str(acl))
         self.assertNotIn('sip', str(acl))
 

--- a/tests/regression/arista/arista_test.py
+++ b/tests/regression/arista/arista_test.py
@@ -320,7 +320,7 @@ class AristaTest(absltest.TestCase):
         self.assertIn(expected, str(acl), str(acl))
 
         self.naming.GetNetAddr.assert_has_calls([mock.call('SOME_HOST')])
-    
+
     @capture.stdout
     def testSIPUsesInt(self):
         self.naming.GetServiceByProto.return_value = ['5060']


### PR DESCRIPTION
See issue #304 
Arista does not use the word sip in place of the protocol number. This was accidentally introduced in #100 
This fix adds a simple test to check for this regression but a future test should take into account all proto to int checks.