### PR TITLE
OpenConfig: move the transport key one level up

### DIFF
--- a/aerleon/lib/openconfig.py
+++ b/aerleon/lib/openconfig.py
@@ -162,9 +162,9 @@ class Term(aclgenerator.Term):
                     # 'any' starts and ends with zero.
                     if not start == end == 0:
                         if start == end:
-                            ace_dict[family]['transport']['config']['source-port'] = int(start)
+                            ace_dict['transport']['config']['source-port'] = int(start)
                         else:
-                            ace_dict[family]['transport']['config']['source-port'] = '%d..%d' % (
+                            ace_dict['transport']['config']['source-port'] = '%d..%d' % (
                                 start,
                                 end,
                             )
@@ -173,13 +173,12 @@ class Term(aclgenerator.Term):
                     for start, end in dports:
                         if not start == end == 0:
                             if start == end:
-                                ace_dict[family]['transport']['config']['destination-port'] = int(
-                                    start
-                                )
+                                ace_dict['transport']['config']['destination-port'] = int(start)
                             else:
-                                ace_dict[family]['transport']['config'][
-                                    'destination-port'
-                                ] = '%d..%d' % (start, end)
+                                ace_dict['transport']['config']['destination-port'] = '%d..%d' % (
+                                    start,
+                                    end,
+                                )
 
                         # Protocol
                         for proto in protos:
@@ -245,7 +244,6 @@ class OpenConfig(aclgenerator.ACLGenerator):
                     filter_options.remove(i)
 
             for term in terms:
-
                 # TODO(b/196430344): Add support for options such as
                 # established/rst/first-fragment
                 if term.option:

--- a/tests/regression/openconfig/OpenConfigTest.testDport.stdout.ref
+++ b/tests/regression/openconfig/OpenConfigTest.testDport.stdout.ref
@@ -8,11 +8,11 @@
     "ipv4": {
       "config": {
         "protocol": 6
-      },
-      "transport": {
-        "config": {
-          "destination-port": 53
-        }
+      }
+    },
+    "transport": {
+      "config": {
+        "destination-port": 53
       }
     }
   }

--- a/tests/regression/openconfig/OpenConfigTest.testMultiDport.stdout.ref
+++ b/tests/regression/openconfig/OpenConfigTest.testMultiDport.stdout.ref
@@ -7,14 +7,13 @@
     },
     "ipv4": {
       "config": {
-        "destination-address": "10.2.3.4/32",
-        "protocol": 17,
-        "source-address": "10.2.3.4/32"
+        "protocol": 17
       }
     },
     "transport": {
       "config": {
-        "destination-port": 53
+        "destination-port": "1024..65535",
+        "source-port": "1024..65535"
       }
     }
   },
@@ -26,14 +25,13 @@
     },
     "ipv4": {
       "config": {
-        "destination-address": "10.2.3.4/32",
-        "protocol": 6,
-        "source-address": "10.2.3.4/32"
+        "protocol": 6
       }
     },
     "transport": {
       "config": {
-        "destination-port": 53
+        "destination-port": "1024..65535",
+        "source-port": "1024..65535"
       }
     }
   }

--- a/tests/regression/openconfig/OpenConfigTest.testSport.stdout.ref
+++ b/tests/regression/openconfig/OpenConfigTest.testSport.stdout.ref
@@ -8,11 +8,11 @@
     "ipv4": {
       "config": {
         "protocol": 6
-      },
-      "transport": {
-        "config": {
-          "source-port": 53
-        }
+      }
+    },
+    "transport": {
+      "config": {
+        "source-port": 53
       }
     }
   }


### PR DESCRIPTION
To match OpenConfig's spec.

Fixes issue #308 