### PR TITLE
Juniper - Add NotSynAck subtoken option

### DIFF
--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -288,6 +288,8 @@ class Term(aclgenerator.Term):
                     from_str.append('tcp-initial;')
                 elif opt.startswith('first-fragment'):
                     from_str.append('first-fragment;')
+                elif opt.startswith('not-syn-ack'):
+                    from_str.append('tcp-flags "!(syn&ack)";')
 
                 # we don't have a special way of dealing with this, so we output it and
                 # hope the user knows what they're doing.
@@ -978,6 +980,7 @@ class Juniper(aclgenerator.ACLGenerator):
                     'tcp-established',
                     'tcp-initial',
                     'inactive',
+                    'not-syn-ack',
                 }
             }
         )

--- a/tests/regression/juniper/JuniperTest.testNotSynAck.stdout.ref
+++ b/tests/regression/juniper/JuniperTest.testNotSynAck.stdout.ref
@@ -1,0 +1,23 @@
+firewall {
+    family inet {
+        /*
+         ** $Id:$
+         ** $Date:$
+         ** $Revision:$
+         **
+         ** this is a test acl
+         */
+        replace: filter test-filter {
+            interface-specific;
+            term notsynack-term-1 {
+                from {
+                    protocol tcp;
+                    destination-port 443;
+                    tcp-flags "!(syn&ack)";
+                }
+                then accept;
+            }
+        }
+    }
+}
+

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -712,7 +712,7 @@ SUPPORTED_SUB_TOKENS = {
         'sample',
         'tcp-established',
         'tcp-initial',
-        'not-syn-ack'
+        'not-syn-ack',
     },
 }
 

--- a/tests/regression/srxlo/SRXloTest.testNotSynAck.stdout.ref
+++ b/tests/regression/srxlo/SRXloTest.testNotSynAck.stdout.ref
@@ -1,0 +1,23 @@
+firewall {
+    family inet {
+        /*
+         ** $Id:$
+         ** $Date:$
+         ** $Revision:$
+         **
+         ** this is a test acl
+         */
+        replace: filter test-filter {
+            interface-specific;
+            term notsynack-term-1 {
+                from {
+                    protocol tcp;
+                    destination-port 443;
+                    tcp-flags "!(syn&ack)";
+                }
+                then accept;
+            }
+        }
+    }
+}
+

--- a/tests/regression/srxlo/srxlo_test.py
+++ b/tests/regression/srxlo/srxlo_test.py
@@ -72,6 +72,14 @@ term good-term-6 {
   action:: accept
 }
 """
+NOTSYNACK_TERM_1 = """
+term notsynack-term-1 {
+  protocol:: tcp
+  destination-port:: HTTPS
+  option:: not-syn-ack
+  action:: accept
+}
+"""
 
 SUPPORTED_TOKENS = {
     'action',
@@ -180,6 +188,7 @@ SUPPORTED_SUB_TOKENS = {
         'sample',
         'tcp-established',
         'tcp-initial',
+        'not-syn-ack',
     },
 }
 
@@ -280,6 +289,18 @@ class SRXloTest(absltest.TestCase):
         self.assertNotIn(
             'icmp;', output, 'missing or incorrect ICMPv6 specification in protocol-except'
         )
+        print(output)
+
+    @capture.stdout
+    def testNotSynAck(self):
+        self.naming.GetServiceByProto.return_value = ['443']
+
+        policy_text = GOOD_HEADER_2 + NOTSYNACK_TERM_1
+        srx = srxlo.SRXlo(policy.ParsePolicy(policy_text, self.naming), EXP_INFO)
+        output = str(srx)
+        self.assertIn('tcp-flags "!(syn&ack)";', output, output)
+
+        self.naming.GetServiceByProto.assert_called_once_with('HTTPS', 'tcp')
         print(output)
 
 


### PR DESCRIPTION
Hi team,
This PR is related to issue https://github.com/aerleon/aerleon/issues/69
As discussed porting our Capirca PR here with associated unit tests.
I've also added the SRXlo tests since syntax is the same.
Thx