### PR TITLE
add ethernet-switching filter type

### DIFF
--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -103,7 +103,13 @@ class Term:
         'udplite': 136,
         'all': -1,  # Used for GCE default deny, do not use in pol file.
     }
-    AF_MAP = {'inet': 4, 'inet6': 6, 'bridge': 4}  # if this doesn't exist, output includes v4 & v6
+    AF_MAP = {
+        'inet': 4,
+        'inet6': 6,
+        'bridge': 4,
+        'ethernet-switching': 4,
+    }
+    # if this doesn't exist, output includes v4 & v6
     # These protos are always expressed as numbers instead of name
     #  due to inconsistencies on the end platform's name-to-number
     #  mapping.

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -181,6 +181,14 @@ class Term(aclgenerator.Term):
             'protocol-except': 'ip-protocol-except',
             'tcp-est': 'tcp-flags "(ack|rst)"',
         },
+        'ethernet-switching': {
+            'addr': 'ip-address',
+            'saddr': 'ip-source-address',
+            'daddr': 'ip-destination-address',
+            'protocol': 'ip-protocol',
+            'protocol-except': 'ip-protocol-except',
+            'tcp-est': 'tcp-established',
+        },
     }
 
     def __init__(
@@ -920,7 +928,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
     _PLATFORM = 'juniper'
     _DEFAULT_PROTOCOL = 'ip'
-    _SUPPORTED_AF = frozenset(('inet', 'inet6', 'bridge', 'mixed'))
+    _SUPPORTED_AF = frozenset(('inet', 'inet6', 'bridge', 'ethernet-switching', 'mixed'))
     _TERM = Term
     SUFFIX = '.jcl'
 

--- a/tests/regression/juniper/JuniperTest.testEthernetSwitchingFilterType.stdout.ref
+++ b/tests/regression/juniper/JuniperTest.testEthernetSwitchingFilterType.stdout.ref
@@ -1,0 +1,30 @@
+firewall {
+    family ethernet-switching {
+        /*
+         ** $Id:$
+         ** $Date:$
+         ** $Revision:$
+         **
+         */
+        replace: filter test-filter {
+            interface-specific;
+            term good-term-1 {
+                from {
+                    ip-protocol icmp;
+                }
+                then accept;
+            }
+            term good-term-2 {
+                from {
+                    ip-destination-address {
+                        10.0.0.0/8;
+                    }
+                    ip-protocol tcp;
+                    destination-port 25;
+                }
+                then accept;
+            }
+        }
+    }
+}
+

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -52,6 +52,11 @@ header {
   target:: juniper test-filter bridge
 }
 """
+GOOD_HEADER_ETHERNET_SWITCHING = """
+header {
+  target:: juniper test-filter ethernet-switching
+}
+"""
 GOOD_DSMO_HEADER = """
 header {
   target:: juniper test-filter enable_dsmo
@@ -773,6 +778,22 @@ class JuniperTest(parameterized.TestCase):
 
         jcl = juniper.Juniper(
             policy.ParsePolicy(GOOD_HEADER_2 + GOOD_TERM_1, self.naming), EXP_INFO
+        )
+        output = str(jcl)
+        self.assertIn('ip-protocol tcp;', output, output)
+        self.assertNotIn(' destination-address {', output, output)
+
+        self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
+        self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
+        print(output)
+
+    @capture.stdout
+    def testEthernetSwitchingFilterType(self):
+        self.naming.GetNetAddr.return_value = [nacaddr.IP('10.0.0.0/8')]
+        self.naming.GetServiceByProto.return_value = ['25']
+
+        jcl = juniper.Juniper(
+            policy.ParsePolicy(GOOD_HEADER_ETHERNET_SWITCHING + GOOD_TERM_1, self.naming), EXP_INFO
         )
         output = str(jcl)
         self.assertIn('ip-protocol tcp;', output, output)
@@ -2063,6 +2084,7 @@ class JuniperYAMLTest(JuniperTest):
             GOOD_HEADER_V6=YAML_GOOD_HEADER_V6,
             GOOD_HEADER_MIXED=YAML_GOOD_HEADER_MIXED,
             GOOD_HEADER_BRIDGE=YAML_GOOD_HEADER_BRIDGE,
+            GOOD_HEADER_ETHERNET_SWITCHING=YAML_GOOD_HEADER_ETHERNET_SWITCHING,
             GOOD_DSMO_HEADER=YAML_GOOD_DSMO_HEADER,
             GOOD_FILTER_ENHANCED_MODE_HEADER=YAML_GOOD_FILTER_ENHANCED_MODE_HEADER,
             GOOD_NOVERBOSE_V4_HEADER=YAML_GOOD_NOVERBOSE_V4_HEADER,
@@ -2183,6 +2205,13 @@ filters:
 - header:
     targets:
       juniper: test-filter bridge
+  terms:
+"""
+YAML_GOOD_HEADER_ETHERNET_SWITCHING = """
+filters:
+- header:
+    targets:
+      juniper: test-filter ethernet-switching
   terms:
 """
 YAML_GOOD_DSMO_HEADER = """


### PR DESCRIPTION
Hi team,
This PR is related to issue https://github.com/aerleon/aerleon/issues/56
As discussed porting our Capirca PR here with associated unit tests.
It's basically adding `ethernet-switching` filter type for Juniper EX platform.
Thx