### PR TITLE
Add filter-level includes 

### DIFF
--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -10,15 +10,10 @@ from yaml.error import YAMLError
 
 from aerleon.lib import policy
 from aerleon.lib.policy import BadIncludePath, Policy, _SubpathOf
-from aerleon.lib.policy_builder import (
-    PolicyBuilder,
-    PolicyDict,
-    RawFilter,
-    RawFilterHeader,
-    RawPolicy,
-    RawTerm,
-)
+from aerleon.lib.policy_builder import PolicyBuilder, PolicyDict
 from aerleon.lib.yaml_loader import SpanSafeYamlLoader
+
+MAX_INCLUDE_DEPTH = 5
 
 
 class PolicyTypeError(Exception):
@@ -108,7 +103,7 @@ def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_che
             raise PolicyTypeError(
                 UserMessage("Unable to read file as YAML.", filename=filename)
             ) from yaml_error
-    policy_dict = PreprocessYAMLPolicy(filename, base_dir, policy_dict)
+    policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
     if not policy_dict:
         return
     return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
@@ -140,16 +135,33 @@ def ParsePolicy(
             UserMessage("Unable to read file as YAML.", filename=filename)
         ) from yaml_error
 
-    policy_dict = PreprocessYAMLPolicy(filename, base_dir, policy_dict)
+    policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
     if not policy_dict:
         return
     return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
 
 
-def PreprocessYAMLPolicy(
+def suffix_is_yaml(filename):
+    return filename[-5:] == '.yaml' or filename[-4:] == '.yml'
+
+
+def _preprocessYAMLPolicy(
     filename: str, base_dir: str, policy_dict: Optional[PolicyDict]
 ) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
     """Process includes and validate the file data as a PolicyDict."""
+    debug_stack = []
+    return _preprocessYAMLPolicyInner(
+        MAX_INCLUDE_DEPTH,
+        debug_stack,
+        filename=filename,
+        base_dir=base_dir,
+        policy_dict=policy_dict,
+    )
+
+
+def _preprocessYAMLPolicyInner(
+    depth: int, debug_stack: list, filename: str, base_dir: str, policy_dict: Optional[PolicyDict]
+) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
 
     # Empty files are ignored with a warning
     if policy_dict is None or not policy_dict:
@@ -167,10 +179,70 @@ def PreprocessYAMLPolicy(
             UserMessage("Policy file must contain one or more filter sections.", filename=filename)
         )
 
+    found_filters = []
+
     for filter in policy_dict['filters']:
         # Malformed filters should generate a PolicyTypeError
         if not isinstance(filter, dict):
             raise PolicyTypeError(UserMessage("Filter must be a mapping.", filename=filename))
+
+        def expand_filter(filter):
+            stack = debug_stack.copy()
+            stack.append(
+                (filter['__filename__'], filter['__line__'])
+            )  # TODO check if this debug info exists
+
+            if depth <= 0:
+                raise ExcessiveRecursionError(
+                    UserMessage(
+                        f"Excessive recursion: include depth limit of {MAX_INCLUDE_DEPTH} reached.",  # noqa: E501
+                        filename=term_item['__filename__'],
+                        line=term_item['__line__'],
+                        include_chain=stack,
+                    )
+                )
+            if not suffix_is_yaml(filter['include']):
+                raise PolicyTypeError(
+                    UserMessage(
+                        f"Policy include source {filter['include']} must end in \".yaml\".",  # noqa: E501
+                        filename=term_item['__filename__'],
+                        line=term_item['__line__'],
+                        include_chain=stack,
+                    )
+                )
+            include_path = pathlib.Path(base_dir).joinpath(filter['include'])
+            if not _SubpathOf(base_dir, include_path):
+                raise BadIncludePath(
+                    f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
+                )
+            try:
+                include_file = _LoadIncludeFile(include_path)
+                include_data = yaml.load(
+                    include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
+                )
+            except YAMLError as yaml_error:
+                raise PolicyTypeError(
+                    UserMessage(
+                        "Unable to read file as YAML.",
+                        filename=str(include_path),
+                        include_chain=stack,
+                    )
+                ) from yaml_error
+            data = _preprocessYAMLPolicyInner(
+                depth - 1,
+                stack,
+                filename=include_path.name,
+                base_dir=base_dir,
+                policy_dict=include_data,
+            )
+            if data and data['filters']:
+                found_filters.extend(data['filters'])
+
+        if 'include' in filter:
+            # This is an include directive
+            expand_filter(filter)
+            continue
+
         if 'header' not in filter or not isinstance(filter['header'], dict):
             raise PolicyTypeError(
                 UserMessage(
@@ -179,6 +251,7 @@ def PreprocessYAMLPolicy(
                     line=filter['__line__'],
                 )
             )
+
         if 'terms' not in filter or not filter['terms'] or not isinstance(filter['terms'], list):
             raise PolicyTypeError(
                 UserMessage(
@@ -199,6 +272,7 @@ def PreprocessYAMLPolicy(
                     line=header['__line__'],
                 )
             )
+
         # Filters with an empty target list can be ignored with a warning
         elif not header['targets']:
             raise PolicyTypeError(
@@ -210,70 +284,64 @@ def PreprocessYAMLPolicy(
             )
 
         found_terms = []
-        max_include_depth = 5
-
-        def process_include(depth, stack, include_filename):
-            include_path = pathlib.Path(base_dir).joinpath(include_filename)
-            if not _SubpathOf(base_dir, include_path):
-                raise BadIncludePath(
-                    f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
-                )
-
-            try:
-                include_file = _LoadIncludeFile(include_path)
-                include_data = yaml.load(
-                    include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
-                )
-            except YAMLError as yaml_error:
-                raise PolicyTypeError(
-                    UserMessage(
-                        "Unable to read file as YAML.",
-                        filename=str(include_path),
-                        include_chain=stack,
-                    )
-                ) from yaml_error
-            if not include_data or 'terms' not in include_data or not include_data['terms']:
-                logging.warning(
-                    UserMessage(
-                        "Ignoring empty policy include source.",
-                        filename=str(include_path),
-                        include_chain=stack,
-                    )
-                )
-                return
-            process_terms(depth, stack, include_data['terms'])
 
         def process_terms(depth, stack, term_items):
             for term_item in term_items:
-                if 'include' in term_item:
-                    new_stack = stack.copy()
-                    new_stack.append((term_item['__filename__'], term_item['__line__']))
-                    if depth <= 0:
-                        raise ExcessiveRecursionError(
-                            UserMessage(
-                                f"Excessive recursion: include depth limit of {max_include_depth} reached.",  # noqa: E501
-                                filename=term_item['__filename__'],
-                                line=term_item['__line__'],
-                                include_chain=new_stack,
-                            )
-                        )
-                    if (
-                        term_item['include'][-5:] != '.yaml'
-                        and term_item['include'][-4:] != '.yml'
-                    ):
-                        raise PolicyTypeError(
-                            UserMessage(
-                                f"Policy include source {term_item['include']} must end in \".yaml\".",  # noqa: E501
-                                filename=term_item['__filename__'],
-                                line=term_item['__line__'],
-                                include_chain=new_stack,
-                            )
-                        )
-                    process_include(depth - 1, new_stack, term_item['include'])
-                else:
+                if 'include' not in term_item:
                     found_terms.append(term_item)
+                    continue
+                new_stack = stack.copy()
+                new_stack.append((term_item['__filename__'], term_item['__line__']))
+                if depth <= 0:
+                    raise ExcessiveRecursionError(
+                        UserMessage(
+                            f"Excessive recursion: include depth limit of {MAX_INCLUDE_DEPTH} reached.",  # noqa: E501
+                            filename=term_item['__filename__'],
+                            line=term_item['__line__'],
+                            include_chain=new_stack,
+                        )
+                    )
+                if not suffix_is_yaml(term_item['include']):
+                    raise PolicyTypeError(
+                        UserMessage(
+                            f"Policy include source {term_item['include']} must end in \".yaml\".",  # noqa: E501
+                            filename=term_item['__filename__'],
+                            line=term_item['__line__'],
+                            include_chain=new_stack,
+                        )
+                    )
+                # process_include(depth - 1, new_stack, term_item['include'])
+                include_path = pathlib.Path(base_dir).joinpath(term_item['include'])
+                if not _SubpathOf(base_dir, include_path):
+                    raise BadIncludePath(
+                        f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
+                    )
 
-        process_terms(max_include_depth, [], filter['terms'])
+                try:
+                    include_file = _LoadIncludeFile(include_path)
+                    include_data = yaml.load(
+                        include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
+                    )
+                except YAMLError as yaml_error:
+                    raise PolicyTypeError(
+                        UserMessage(
+                            "Unable to read file as YAML.",
+                            filename=str(include_path),
+                            include_chain=new_stack,
+                        )
+                    ) from yaml_error
+                if not include_data or 'terms' not in include_data or not include_data['terms']:
+                    logging.warning(
+                        UserMessage(
+                            "Ignoring empty policy include source.",
+                            filename=str(include_path),
+                            include_chain=new_stack,
+                        )
+                    )
+                    continue
+                process_terms(depth - 1, new_stack, include_data['terms'])
+
+        process_terms(MAX_INCLUDE_DEPTH, [], filter['terms'])
 
         if not found_terms:
             logging.warning(
@@ -296,6 +364,9 @@ def PreprocessYAMLPolicy(
                 )
 
         filter['terms'] = found_terms
+        found_filters.append(filter)
+
+    policy_dict['filters'] = found_filters
 
     def StripDebuggingData(data):
         if isinstance(data, list):

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -106,6 +106,8 @@ def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_che
     policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
     if not policy_dict:
         return
+    if not policy_dict['filters']:
+        return
     return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
 
 
@@ -137,6 +139,8 @@ def ParsePolicy(
 
     policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
     if not policy_dict:
+        return
+    if not policy_dict['filters']:
         return
     return policy.FromBuilder(PolicyBuilder(policy_dict, definitions, optimize, shade_check))
 
@@ -180,7 +184,7 @@ def _preprocessYAMLPolicyInner(
         policy_dict['filters'] = policy_dict['filters_include_only']
         del policy_dict['filters_include_only']
     elif 'terms' in policy_dict or 'filters_include_only' in policy_dict:
-        # We are looking at an include file and should quietly ignore it.
+        # We are looking at an include file outside of an include and should quietly ignore it.
         return
     else:
         raise PolicyTypeError(

--- a/docs/reference/yaml_reference.md
+++ b/docs/reference/yaml_reference.md
@@ -208,22 +208,21 @@ may find this representation easier to assemble.
 
 ### Includes
 
-Place an item in the list of terms with a key "include" containing a file path
-to include that file. All terms found in the include file will be inserted into
-the terms list, replacing the "include" item. The include file will be resolved
-relative to the base directory. The include file name must match
-\*.yaml.
+Place an item in the list of terms with the key "include" containing the path
+of the file to include, relative to the base directory. All terms found in the
+included file will be inserted into the list of terms, replacing the "include" item.
+The included file name must end in ".yaml".
 
 ```
 # example_policy.yaml
 filters:
 - header:
-# ...
+    # ...
   terms:
   - name: deny-to-reserved
     destination-address: RESERVED
     action: deny
-  - include: include_1.yaml
+  - include: deny_bogons_include.yaml
   - name: allow-web-to-mail
     source-address: WEB_SERVERS
     destination-address: MAIL_SERVERS
@@ -231,14 +230,41 @@ filters:
 ```
 
 ```
-# include_1.yaml
+# deny_bogons_include.yaml
 terms:
 - name: deny-to-bogons
   destination-address: RESERVED
   action: deny
 ```
 
-Recursive includes are supported up to a recursion limit of 5. This is the same
+You can also include one or more filters by placing an item in the list of filters
+with the key "include" containing the path of the file to include, relative to the
+base directory. If you wish to create a common list of filters that should not be
+turned directly into ACLs, use the top level key "filters_include_only" instead of
+"filters".
+
+```
+# example_policy.yaml
+filters:
+- include: common_filters.yaml
+```
+
+```
+# common_filters.yaml
+filters_include_only:
+- header:
+    # ...
+  terms:
+  - name: deny-to-reserved
+    destination-address: RESERVED
+    action: deny
+  - name: allow-web-to-mail
+    source-address: WEB_SERVERS
+    destination-address: MAIL_SERVERS
+    action: accept
+```
+
+Recursive includes are supported with a recursion limit of 5. This is the same
 recursion limit as for .pol files.
 
 ### YAML Aliases and Anchors

--- a/schemas/aerleon-policies.schema.json
+++ b/schemas/aerleon-policies.schema.json
@@ -4,7 +4,8 @@
   "$comment": "https://aerleon.readthedocs.io/en/latest/reference/yaml_reference/",
   "title": "Aerleon Policy File",
   "oneOf": [
-    { "$ref": "#/$defs/policyIncludeFile" },
+    { "$ref": "#/$defs/policyTermIncludeFile" },
+    { "$ref": "#/$defs/policyFilterIncludeFile" },
     { "$ref": "#/$defs/policyFile" }
   ],
   "$defs": {
@@ -20,7 +21,19 @@
         }
       }
     },
-    "policyIncludeFile": {
+    "policyFilterIncludeFile": {
+      "type": "object",
+      "title": "Policy File",
+      "required": ["filters_include_only"],
+      "properties": {
+        "filters_include_only": {
+          "description": "A policy file contains one or more filters. Each filter has a header that lists the generator target platforms and their options. The filter ACL rules appear in the terms section.\n\nfilters_include_only defines a list of filters that will not be directly converted into a ACL, but can be included by other files.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/filter" }
+        }
+      }
+    },
+    "policyTermIncludeFile": {
       "type": "object",
       "title": "Policy Include File",
       "required": ["terms"],
@@ -33,30 +46,46 @@
       }
     },
     "filter": {
-      "type": "object",
-      "required": ["header", "terms"],
-      "properties": {
-        "header": {
+      "oneOf": [
+        {
           "type": "object",
-          "title": "Filter Header",
-          "description": "The filter header lists the generator target platforms and their options. Other filter-level settings can be defined in the header.",
-          "required": ["targets"],
+          "required": ["header", "terms"],
           "properties": {
-            "targets": {
-              "title": "Filter Targets",
-              "description": "aclgen will generate an acl for each target platforms identified here.",
-              "type": "object"
+            "header": {
+              "type": "object",
+              "title": "Filter Header",
+              "description": "The filter header lists the generator target platforms and their options. Other filter-level settings can be defined in the header.",
+              "required": ["targets"],
+              "properties": {
+                "targets": {
+                  "title": "Filter Targets",
+                  "description": "aclgen will generate an acl for each target platforms identified here.",
+                  "type": "object"
+                }
+              }
+            },
+            "terms": {
+              "title": "Term List",
+              "description": "The ACL rules for this filter. Each entry in this list is a term and must have a 'name' property defined.\n\nCommon lists of terms shared between policy files can be placed in an include file. Create an item in the list with a single property, 'include', that references the path to the include file.",
+              "type": "array",
+              "items": { "$ref": "#/$defs/term" }
             }
-          }
+          },
+          "additionalProperties": true
         },
-        "terms": {
-          "title": "Term List",
-          "description": "The ACL rules for this filter. Each entry in this list is a term and must have a 'name' property defined.\n\nCommon lists of terms shared between policy files can be placed in an include file. Create an item in the list with a single property, 'include', that references the path to the include file.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/term" }
+        {
+          "type": "object",
+          "required": ["include"],
+          "properties": {
+            "include": {
+              "type": "string",
+              "title": "Filter List Include",
+              "description": "Common filters shared between policy files can be placed in an include file. Create an item in the list with a single property, 'include', that references the path to the include file. The path will be resolved relative to the --base_directory given to aclgen, which is './policies/' by default."
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": true
+      ]
     },
     "term": {
       "oneOf": [

--- a/schemas/aerleon-policies.schema.json
+++ b/schemas/aerleon-policies.schema.json
@@ -27,7 +27,7 @@
       "required": ["filters_include_only"],
       "properties": {
         "filters_include_only": {
-          "description": "A policy file contains one or more filters. Each filter has a header that lists the generator target platforms and their options. The filter ACL rules appear in the terms section.\n\nfilters_include_only defines a list of filters that will not be directly converted into a ACL, but can be included by other files.",
+          "description": "A policy file contains one or more filters. Each filter has a header that lists the generator target platforms and their options. The filter ACL rules appear in the terms section.\n\nfilters_include_only defines a list of filters that will not be directly converted into an ACL, but can be included by other files.",
           "type": "array",
           "items": { "$ref": "#/$defs/filter" }
         }
@@ -59,7 +59,7 @@
               "properties": {
                 "targets": {
                   "title": "Filter Targets",
-                  "description": "aclgen will generate an acl for each target platforms identified here.",
+                  "description": "aclgen will generate an ACL for each target platforms identified here.",
                   "type": "object"
                 }
               }

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -39,11 +39,30 @@ filters:
     destination-address: MAIL_SERVERS
     action: accept
 """
+GOOD_POLICY_INCLUDE_FILTERS = """
+filters:
+- include: filters_include1.yaml
+- include: filters_include2.yaml
+"""
 GOOD_INCLUDE_YAML = """
 terms:
 - name: deny-to-bogons
   destination-address: RESERVED
   action: deny
+"""
+GOOD_INCLUDE_FILTERS_YAML = """
+filters:
+- header:
+    targets:
+      ipset: OUTPUT DROP
+  terms:
+  - name: deny-to-reserved
+    destination-address: RESERVED
+    action: deny
+  - name: allow-web-to-mail
+    source-address: WEB_SERVERS
+    destination-address: MAIL_SERVERS
+    action: accept
 """
 BAD_INCLUDE_YAML_EMPTY = """
 terms:
@@ -61,6 +80,24 @@ terms:
 - include: /tmp/include_2.yaml
 """
 BAD_INCLUDE_YAML_INVALID_YAML = """
+%INVALID YAML% &unknown
+"""
+BAD_INCLUDE_FILTERS_YAML_EMPTY = """
+filters:
+"""
+BAD_INCLUDE_FILTERS_YAML_INFINITE_RECURSION = """
+filters:
+- include: filters_include1.yaml
+"""
+BAD_INCLUDE_FILTERS_YAML_INVALID_STRUCTURE = """
+terms:
+- include: include_1.pol
+"""
+BAD_INCLUDE_FILTERS_YAML_INVALID_PATH = """
+filters:
+- include: /tmp/include_2.yaml
+"""
+BAD_INCLUDE_FILTERS_YAML_INVALID_YAML = """
 %INVALID YAML% &unknown
 """
 BAD_YAML_POLICY_NO_HEADER = """
@@ -155,19 +192,7 @@ filters2:
 """
 
 
-def open_good_includes():
-    pass
-
-
-def open_bad_include_infinite_recursion():
-    pass
-
-
-def open_bad_include_empty():
-    pass
-
-
-class YAMLFrontEndTest(absltest.TestCase):
+class YAMLParsePolicyTest(absltest.TestCase):
     def setUp(self):
         self.naming = mock.create_autospec(naming.Naming)
         self.naming.GetNetAddr.return_value = [nacaddr.IP('10.1.1.1/32')]
@@ -329,34 +354,47 @@ class YAMLFrontEndTest(absltest.TestCase):
         )
         self.assertEqual(mock_warning.call_args[0][0].filename, "include_1.yaml")
 
+    @mock.patch.object(yaml_frontend.policy, "FromBuilder")
+    @mock.patch.object(yaml_frontend.logging, "warning")
+    def testFiltersIncludeEmptySource(self, mock_warning, _mock_raw_to_policy):
+        with mock.patch("builtins.open", mock.mock_open(read_data="")):
+            yaml_frontend.ParsePolicy(
+                GOOD_POLICY_INCLUDE_FILTERS,
+                filename="policy_with_empty_include.yaml",
+                base_dir=self.base_dir,
+                definitions=self.naming,
+            )
+        self.assertEqual(mock_warning.call_args[0][0].message, "Ignoring empty policy file.")
+        self.assertEqual(mock_warning.call_args[0][0].filename, "filters_include2.yaml")
+
     def testIncludeInfiniteRecursion(self):
-        with mock.patch(
-            "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INFINITE_RECURSION)
-        ):
-            with self.assertRaises(yaml_frontend.ExcessiveRecursionError) as arcm:
+        with self.assertRaises(yaml_frontend.ExcessiveRecursionError) as arcm:
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INFINITE_RECURSION)
+            ):
                 yaml_frontend.ParsePolicy(
                     GOOD_YAML_POLICY_INCLUDE,
                     filename="policy_with_include.yaml",
                     base_dir=self.base_dir,
                     definitions=self.naming,
                 )
-            user_message = arcm.exception.args[0]
-            self.assertEqual(user_message.filename, "include_1.yaml")
-            self.assertEqual(user_message.line, 3)
-            self.assertEqual(
-                user_message.include_chain,
-                [
-                    ('policy_with_include.yaml', 10),
-                    ('include_1.yaml', 3),
-                    ('include_1.yaml', 3),
-                    ('include_1.yaml', 3),
-                    ('include_1.yaml', 3),
-                    ('include_1.yaml', 3),
-                ],
-            )
-            self.assertEqual(
-                str(user_message),
-                """Excessive recursion: include depth limit of 5 reached. File=include_1.yaml, Line=3.
+        user_message = arcm.exception.args[0]
+        self.assertEqual(user_message.filename, "include_1.yaml")
+        self.assertEqual(user_message.line, 3)
+        self.assertEqual(
+            user_message.include_chain,
+            [
+                ('policy_with_include.yaml', 10),
+                ('include_1.yaml', 3),
+                ('include_1.yaml', 3),
+                ('include_1.yaml', 3),
+                ('include_1.yaml', 3),
+                ('include_1.yaml', 3),
+            ],
+        )
+        self.assertEqual(
+            str(user_message),
+            """Excessive recursion: include depth limit of 5 reached. File=include_1.yaml, Line=3.
 Include stack:
 > File='policy_with_include.yaml', Line=10 (Top Level)
 > File='include_1.yaml', Line=3
@@ -364,37 +402,39 @@ Include stack:
 > File='include_1.yaml', Line=3
 > File='include_1.yaml', Line=3
 > File='include_1.yaml', Line=3""",  # noqa: E501
-            )
+        )
 
     def testIncludeInvalidFilename(self):
-        with mock.patch(
-            "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_FILENAME)
-        ):
-            with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
+        with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_FILENAME)
+            ):
                 yaml_frontend.ParsePolicy(
                     GOOD_YAML_POLICY_INCLUDE,
                     filename="policy_with_include.yaml",
                     base_dir=self.base_dir,
                     definitions=self.naming,
                 )
-            user_message = arcm.exception.args[0]
-            self.assertEqual(user_message.filename, "include_1.yaml")
-            self.assertEqual(user_message.line, 3)
-            self.assertEqual(
-                user_message.include_chain,
-                [('policy_with_include.yaml', 10), ('include_1.yaml', 3)],
-            )
-            self.assertEqual(
-                str(user_message),
-                """Policy include source include_1.pol must end in ".yaml". File=include_1.yaml, Line=3.
+        user_message = arcm.exception.args[0]
+        self.assertEqual(user_message.filename, "include_1.yaml")
+        self.assertEqual(user_message.line, 3)
+        self.assertEqual(
+            user_message.include_chain,
+            [('policy_with_include.yaml', 10), ('include_1.yaml', 3)],
+        )
+        self.assertEqual(
+            str(user_message),
+            """Policy include source include_1.pol must end in ".yaml". File=include_1.yaml, Line=3.
 Include stack:
 > File='policy_with_include.yaml', Line=10 (Top Level)
 > File='include_1.yaml', Line=3""",  # noqa: E501
-            )
+        )
 
     def testIncludeInvalidPath(self):
-        with mock.patch("builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_PATH)):
-            with self.assertRaises(yaml_frontend.BadIncludePath):
+        with self.assertRaises(yaml_frontend.BadIncludePath):
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_PATH)
+            ):
                 yaml_frontend.ParsePolicy(
                     GOOD_YAML_POLICY_INCLUDE,
                     filename="policy_with_include.yaml",
@@ -403,26 +443,28 @@ Include stack:
                 )
 
     def testIncludeInvalidYAML(self):
-        with mock.patch("builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_YAML)):
-            with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
+        with self.assertRaises(yaml_frontend.PolicyTypeError) as arcm:
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data=BAD_INCLUDE_YAML_INVALID_YAML)
+            ):
                 yaml_frontend.ParsePolicy(
                     GOOD_YAML_POLICY_INCLUDE,
                     filename="policy_with_include.yaml",
                     base_dir=self.base_dir,
                     definitions=self.naming,
                 )
-            user_message = arcm.exception.args[0]
-            self.assertEqual(user_message.filename, "include_1.yaml")
-            self.assertEqual(
-                user_message.include_chain,
-                [('policy_with_include.yaml', 10)],
-            )
-            self.assertEqual(
-                str(user_message),
-                """Unable to read file as YAML. File=include_1.yaml.""",
-            )
+        user_message = arcm.exception.args[0]
+        self.assertEqual(user_message.filename, "include_1.yaml")
+        self.assertEqual(
+            user_message.include_chain,
+            [('policy_with_include.yaml', 10)],
+        )
+        self.assertEqual(
+            str(user_message),
+            """Unable to read file as YAML. File=include_1.yaml.""",
+        )
 
-    def testBasicPolicyModel(self):
+    def testParsePolicy(self):
         pol = yaml_frontend.ParsePolicy(
             GOOD_YAML_POLICY_BASIC,
             filename="policy_basic.yaml",
@@ -439,9 +481,45 @@ Include stack:
   action: ['accept']]}"""
         self.assertEqual(str(pol), expected_pol)
 
+    def testParsePolicyInclude(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data=GOOD_INCLUDE_YAML)):
+            pol = yaml_frontend.ParsePolicy(
+                GOOD_YAML_POLICY_INCLUDE,
+                filename="policy_include.yaml",
+                base_dir=self.base_dir,
+                definitions=self.naming,
+            )
+        expected_pol = """Policy: {Target[ipset], Comments [], Apply groups: [], except: []:[ name: deny-to-reserved
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['deny'],  name: deny-to-bogons
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['deny'],  name: allow-web-to-mail
+  source_address: [IPv4('10.1.1.1/32')]
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['accept']]}"""
+        self.assertEqual(str(pol), expected_pol)
+
+    def testParsePolicyIncludeFilter(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data=GOOD_INCLUDE_FILTERS_YAML)):
+            pol = yaml_frontend.ParsePolicy(
+                GOOD_POLICY_INCLUDE_FILTERS,
+                filename="policy_include_filters.yaml",
+                base_dir=self.base_dir,
+                definitions=self.naming,
+            )
+        expected_pol = """Policy: {Target[ipset], Comments [], Apply groups: [], except: []:[ name: deny-to-reserved
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['deny'],  name: allow-web-to-mail
+  source_address: [IPv4('10.1.1.1/32')]
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['accept']], Target[ipset], Comments [], Apply groups: [], except: []:[ name: deny-to-reserved
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['deny'],  name: allow-web-to-mail
+  source_address: [IPv4('10.1.1.1/32')]
+  destination_address: [IPv4('10.1.1.1/32')]
+  action: ['accept']]}"""
+        self.assertEqual(str(pol), expected_pol)
+
 
 if __name__ == '__main__':
     absltest.main()
-
-# TODO(jb) try MULTI_DOC example
-# TODO(jb) seems like buildPolicy crashes when targets is not recognized, should raise


### PR DESCRIPTION
Policy files can now include other policy files at the filter level by adding an item to the filters: list like:
```yaml
filters:
-   include: "path/to/include.yaml"
```

Include items can be interspersed with filter items or other includes.

`aclgen` will try to generate ACLs for all files in the base_directory with `filters:` as the top level key, which might not be desired if a file is meant only to be included by other files. In that case, change the top level key to `filters_include_only:`, which is identical to `filters:` except that `aclgen` won't try to generate ACLs for it.

```yaml
# This file can be included by other files but will not generate ACLs directly
filters_include_only:
-   header: ...
    terms: ...
-   header: ...
    terms: ...
```

## Compatibility

This change is fully backwards compatible. Aerleon >= 1.6.0 will be required to use this feature (assuming it goes out in 1.6.0).

## Schema Update

This change extends the policy file schema. Merging this PR will automatically update JSON Schema Store and thus all IDEs that use it.

<img width="596" alt="Screenshot 2023-07-26 at 9 37 31 AM" src="https://github.com/aerleon/aerleon/assets/212901/d4719432-0053-4939-a764-df9ce22848b8">
<img width="546" alt="Screenshot 2023-07-26 at 9 37 22 AM" src="https://github.com/aerleon/aerleon/assets/212901/647003ae-6d28-4019-a403-a58a757e185c">

## Docs

This change updates the YAML policy reference section on includes in the docs.

Fixes #325