### PR TITLE
Skip NO_AF_LOG_ADDR when target=mixed

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -426,6 +426,7 @@ class Term(aclgenerator.Term):
         term_remark: bool = True,
         platform: str = 'cisco',
         verbose: bool = True,
+        filter_type: str = None,
     ) -> None:
         self.term = term
         self.proto_int = proto_int
@@ -434,6 +435,7 @@ class Term(aclgenerator.Term):
         self.term_remark = term_remark
         self.platform = platform
         self.verbose = verbose
+        self.filter_type = filter_type
         # Our caller should have already verified the address family.
         assert af in (4, 6)
         self.af = af
@@ -518,11 +520,12 @@ class Term(aclgenerator.Term):
             if source_address_exclude:
                 source_address = nacaddr.ExcludeAddrs(source_address, source_address_exclude)
             if not source_address:
-                logging.warning(
-                    self.NO_AF_LOG_ADDR.substitute(
-                        term=self.term.name, direction='source', af=self.text_af
+                if self.filter_type != 'mixed':
+                    logging.warning(
+                        self.NO_AF_LOG_ADDR.substitute(
+                            term=self.term.name, direction='source', af=self.text_af
+                        )
                     )
-                )
                 return ''
             if self.enable_dsmo:
                 source_address = summarizer.Summarize(source_address)
@@ -542,11 +545,12 @@ class Term(aclgenerator.Term):
                     destination_address, destination_address_exclude
                 )
             if not destination_address:
-                logging.warning(
-                    self.NO_AF_LOG_ADDR.substitute(
-                        term=self.term.name, direction='destination', af=self.text_af
+                if self.filter_type != 'mixed':
+                    logging.warning(
+                        self.NO_AF_LOG_ADDR.substitute(
+                            term=self.term.name, direction='destination', af=self.text_af
+                        )
                     )
-                )
                 return ''
             if self.enable_dsmo:
                 destination_address = summarizer.Summarize(destination_address)
@@ -971,6 +975,7 @@ class Cisco(aclgenerator.ACLGenerator):
                                 term_remark=self._TERM_REMARK,
                                 platform=self._PLATFORM,
                                 verbose=self.verbose,
+                                filter_type=filter_type,
                             )
                         )
                     elif next_filter == 'object-group':
@@ -984,6 +989,7 @@ class Cisco(aclgenerator.ACLGenerator):
                                 proto_int=self._PROTO_INT,
                                 platform=self._PLATFORM,
                                 verbose=self.verbose,
+                                filter_type=filter_type,
                             )
                         )
 

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -155,20 +155,24 @@ class Term(aclgenerator.Term):
         # source address
         term_saddrs = self._CheckAddressAf(self.term.source_address)
         if not term_saddrs:
-            logging.warning(
-                self.NO_AF_LOG_ADDR.substitute(term=self.term.name, direction='source', af=self.af)
-            )
+            if self.af != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='source', af=self.af
+                    )
+                )
             return ''
         term_saddr = self._GenerateAddrStatement(term_saddrs, self.term.source_address_exclude)
 
         # destination address
         term_daddrs = self._CheckAddressAf(self.term.destination_address)
         if not term_daddrs:
-            logging.warning(
-                self.NO_AF_LOG_ADDR.substitute(
-                    term=self.term.name, direction='destination', af=self.af
+            if self.af != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='destination', af=self.af
+                    )
                 )
-            )
             return ''
         term_daddr = self._GenerateAddrStatement(
             term_daddrs, self.term.destination_address_exclude

--- a/aerleon/lib/pcap.py
+++ b/aerleon/lib/pcap.py
@@ -128,9 +128,12 @@ class Term(aclgenerator.Term):
         # source address
         term_saddrs = self._CheckAddressAf(self.term.source_address)
         if not term_saddrs:
-            logging.warning(
-                self.NO_AF_LOG_ADDR.substitute(term=self.term.name, direction='source', af=self.af)
-            )
+            if self.af != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='source', af=self.af
+                    )
+                )
             return ''
 
         conditions.append(
@@ -140,11 +143,12 @@ class Term(aclgenerator.Term):
         # destination address
         term_daddrs = self._CheckAddressAf(self.term.destination_address)
         if not term_daddrs:
-            logging.warning(
-                self.NO_AF_LOG_ADDR.substitute(
-                    term=self.term.name, direction='destination', af=self.af
+            if self.af != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_ADDR.substitute(
+                        term=self.term.name, direction='destination', af=self.af
+                    )
                 )
-            )
             return ''
 
         conditions.append(

--- a/tests/regression/arista_tp/AristaTpTest.testSkipTermAF.stdout.ref
+++ b/tests/regression/arista_tp/AristaTpTest.testSkipTermAF.stdout.ref
@@ -1,0 +1,7 @@
+traffic-policies
+   no traffic-policy test-filter
+   traffic-policy test-filter
+      match good-term-1 ipv6
+         protocol icmpv6
+      !
+

--- a/tests/regression/cisco/CiscoTest.testMixedFilterSkipTerms.stdout.ref
+++ b/tests/regression/cisco/CiscoTest.testMixedFilterSkipTerms.stdout.ref
@@ -1,0 +1,21 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list extended mixed_acl
+ip access-list extended mixed_acl
+ remark $Id:$
+ remark mixed inet/inet6 header test
+
+
+ remark good-term
+ permit tcp any 10.0.0.0 0.255.255.255
+
+exit
+
+no ipv6 access-list ipv6-mixed_acl
+ipv6 access-list ipv6-mixed_acl
+ remark $Id:$
+ remark mixed inet/inet6 header test
+
+exit
+

--- a/tests/regression/cisco/CiscoTest.testSkippedTerm.stdout.ref
+++ b/tests/regression/cisco/CiscoTest.testSkippedTerm.stdout.ref
@@ -1,0 +1,10 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ipv6 access-list inet6_acl
+ipv6 access-list inet6_acl
+ remark $Id:$
+ remark inet6 header test
+
+exit
+

--- a/tests/regression/juniper/JuniperTest.testSkipTerm.stdout.ref
+++ b/tests/regression/juniper/JuniperTest.testSkipTerm.stdout.ref
@@ -1,0 +1,35 @@
+firewall {
+    family inet {
+        /*
+         ** $Id:$
+         ** $Date:$
+         ** $Revision:$
+         **
+         */
+        replace: filter test-filter4 {
+            interface-specific;
+            term good-term-12 {
+                from {
+                    source-address {
+                        127.0.0.1/32;
+                    }
+                }
+                then accept;
+            }
+        }
+    }
+}
+firewall {
+    family inet6 {
+        /*
+         ** $Id:$
+         ** $Date:$
+         ** $Revision:$
+         **
+         */
+        replace: filter test-filter6 {
+            interface-specific;
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes #324

Aerleon will issue a warning when it finds a term where none of the match conditions are relevant for the current address family (the warning is called NO_AF_LOG_ADDR internally). However the code is too eager to generate this warning since the parent filter may have target=mixed, which is a two-pass process that ultimately will render these terms, making the warning inaccurate and unnecessary. This change removes that warning when target=mixed.