### PR TITLE
Adding FQDN filtering into Juniper SRX generator.

### DIFF
--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -12,19 +12,29 @@ class Addressbook:
     def __init__(self) -> None:
         self._fqdn_addressbook = collections.OrderedDict()
         self._ip_addressbook = collections.OrderedDict()
+        
+    def GetZoneNames(self) -> List:
+        return list(self._ip_addressbook.keys())
+    
+    def WalkAddressBook(self, zone_filter=None):
+        
+        return self._walk(zone_filter)
 
-    def WalkAddressBook(self):
-        return self._walk()
-    def _walk(self):
+    def _walk(self, zone_filter=None):
         for zone in self._ip_addressbook:
-            groups = self._ip_addressbook[zone].keys()
-            groups.extend(self._fqdn_addressbook[zone].keys())
-            for group in groups:
+            if zone_filter and zone != zone_filter:
+                continue
+            groups = set(self._ip_addressbook[zone].keys())
+            groups.update(list(self._fqdn_addressbook[zone].keys()))
+            for group in sorted(groups):
                 ips = []
+                fqdns = []
                 if group in self._ip_addressbook[zone]:
                     ips = self._ip_addressbook[zone][group]
-                yield zone, group
-        
+                if group in self._fqdn_addressbook[zone]:
+                    fqdns = self._fqdn_addressbook[zone][group]
+                yield zone, group, ips, fqdns
+
     def GetFQDN(self, zone: str, name: str):
         return self._fqdn_addressbook[zone][name]
 

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -14,44 +14,87 @@ class Addressbook:
         self._ip_addressbook = collections.OrderedDict()
 
     def GetZoneNames(self) -> List:
+        """Get each zone name contained within the address book.
+
+        Returns:
+          A list containing the names of each zone within the addressbook.
+        """
         return list(self._ip_addressbook.keys())
 
-    def WalkAddressBook(self, zone_filter=None):
+    def Walk(self, zone=None):
+        """Walks the addressbook by each zone and address/fqdns within.
 
-        return self._walk(zone_filter)
+        Args:
+          zone_filter: A specific zone to walk rather than the entire addressbook.
 
-    def _walk(self, zone_filter=None):
-        for zone in self._ip_addressbook:
-            if zone_filter and zone != zone_filter:
+        Yields:
+          izone: The zone of the addressbook.
+          group: The token of a set of address objects.
+          ips: A list of nacaddr objects.
+          fqdns: A list of FQDN objects.
+        """
+        for izone in self._ip_addressbook:
+            if zone and izone != zone:
                 continue
-            groups = set(self._ip_addressbook[zone].keys())
-            groups.update(list(self._fqdn_addressbook[zone].keys()))
+            groups = set(self._ip_addressbook[izone].keys())
+            groups.update(list(self._fqdn_addressbook[izone].keys()))
             for group in sorted(groups):
                 ips = []
                 fqdns = []
-                if group in self._ip_addressbook[zone]:
-                    ips = self._ip_addressbook[zone][group]
-                if group in self._fqdn_addressbook[zone]:
-                    fqdns = self._fqdn_addressbook[zone][group]
-                yield zone, group, ips, fqdns
+                if group in self._ip_addressbook[izone]:
+                    ips = self._ip_addressbook[izone][group]
+                if group in self._fqdn_addressbook[izone]:
+                    fqdns = self._fqdn_addressbook[izone][group]
+                yield izone, group, ips, fqdns
 
     def GetFQDN(self, zone: str, name: str):
+        """Gets an FQDN entry from the addressbook.
+        Args:
+          zone: The zone to retrieve from.
+          name: The name of the address object to retrieve.
+        Returns:
+          A list of FQDN objects.
+        """
         return self._fqdn_addressbook[zone][name]
 
     def GetAddressTokensInZone(self, zone: str):
-        return [i for i in self._ip_addressbook['zone']]
+        """Gets all address tokens in a zone.
+        Args:
+          zone: The zone to retrieve from.
+        Returns:
+          A list of address tokens."""
+        return [i for i in self._ip_addressbook[zone]]
 
     def GetFQDNTokensInZone(self, zone: str):
-        return [i for i in self._fqdn_addressbook['zone']]
+        """Gets all FQDN tokens in a zone.
+        Args:
+          zone: The zone to retrieve from.
+        Returns:
+          A list of FQDN tokens
+        """
+        return [i for i in self._fqdn_addressbook[zone]]
 
-    def AddFQDNs(self, zone: str, fqdn_list: List[FQDN]):
+    def AddFQDNs(self, zone: str, fqdn_list: List[FQDN], suffix=''):
+        """Adds a list of FQDNs to the addressbook.
+        Args:
+          zone: The zone in which to add the FQDNs.
+          fqdn_list: A list of FQDN objects.
+          suffix: An optional suffix to add to the token.
+        """
         if zone not in self._fqdn_addressbook:
             self._ip_addressbook[zone] = collections.defaultdict(list)
             self._fqdn_addressbook[zone] = collections.defaultdict(list)
         for fqdn in fqdn_list:
-            self._fqdn_addressbook[zone][fqdn.parent_token].append(fqdn)
+            self._fqdn_addressbook[zone][fqdn.parent_token + suffix].append(fqdn)
 
     def GetAddress(self, zone: str, name: str):
+        """Gets an Nacaddr entry from the addressbook.
+        Args:
+          zone: The zone to retrieve from.
+          name: The name of the address object to retrieve.
+        Returns:
+          A list of Nacaddr objects.
+        """
         return self._ip_addressbook[zone][name]
 
     def AddAddresses(self, zone: str, address_list: List[Union[IPv4, IPv6]]):

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -8,8 +8,6 @@ from aerleon.lib.nacaddr import IPv4, IPv6
 from aerleon.lib.fqdn import FQDN
 
 
-
-
 class Addressbook:
     def __init__(self) -> None:
         self.addressbook = collections.OrderedDict()
@@ -92,9 +90,10 @@ class Addressbook:
             key=lambda address: address.parent_token,
         ):
             # merge sorted lists of IP objects
-            addrs = list(heapq.merge(self.addressbook[zone][parent_token]['ips'],address_list,key=ipaddress.get_mixed_type_key,))
+            addrs = self.addressbook[zone][parent_token]['ips']
+            addrs = list(heapq.merge(addrs,address_list,key=ipaddress.get_mixed_type_key,))
 
             # drop redundant addresses and networks
-            self.addressbook[zone][parent_token]['ips'].extend(list(
+            self.addressbook[zone][parent_token]['ips'] = list(
                 _drop_subnets(addrs)
-            ))
+            )

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -12,12 +12,12 @@ class Addressbook:
     def __init__(self) -> None:
         self._fqdn_addressbook = collections.OrderedDict()
         self._ip_addressbook = collections.OrderedDict()
-        
+
     def GetZoneNames(self) -> List:
         return list(self._ip_addressbook.keys())
-    
+
     def WalkAddressBook(self, zone_filter=None):
-        
+
         return self._walk(zone_filter)
 
     def _walk(self, zone_filter=None):

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -208,9 +208,10 @@ class ObjectGroup:
         # for using cisco, which has decided to implement its own meta language.
 
         # Create network object-groups
-        for name, ips in self.addressbook.addressbook[''].items():
+        for name, addresses in self.addressbook.addressbook[''].items():
             for version in (4, 6):
-                vips = [i for i in ips if i.version == version]
+                vips = [i for i in addresses['ips'] if i.version == version]
+                vips = nacaddr.CollapseAddrList(vips)
                 if vips:
 
                     ret_str.append(f'object-group network ipv{version} {name}')

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -208,10 +208,9 @@ class ObjectGroup:
         # for using cisco, which has decided to implement its own meta language.
 
         # Create network object-groups
-        for zone, name, ips, _ in self.addressbook.WalkAddressBook():
+        for zone, name, ips, _ in self.addressbook.Walk():
             for version in (4, 6):
                 vips = [i for i in ips if i.version == version]
-                vips = nacaddr.CollapseAddrList(vips)
                 if vips:
 
                     ret_str.append(f'object-group network ipv{version} {name}')

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -208,9 +208,9 @@ class ObjectGroup:
         # for using cisco, which has decided to implement its own meta language.
 
         # Create network object-groups
-        for name, addresses in self.addressbook.addressbook[''].items():
+        for zone, name, ips, _ in self.addressbook.WalkAddressBook():
             for version in (4, 6):
-                vips = [i for i in addresses['ips'] if i.version == version]
+                vips = [i for i in ips if i.version == version]
                 vips = nacaddr.CollapseAddrList(vips)
                 if vips:
 
@@ -1086,7 +1086,7 @@ class Cisco(aclgenerator.ACLGenerator):
                     if term_str:
                         target.append(term_str)
 
-            if obj_target.addressbook.addressbook.keys():
+            if obj_target.addressbook.GetZones():
                 target = [str(obj_target)] + target
             # ensure that the header is always first
             target = target_header + target

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -1086,7 +1086,7 @@ class Cisco(aclgenerator.ACLGenerator):
                     if term_str:
                         target.append(term_str)
 
-            if obj_target.addressbook.GetZones():
+            if obj_target.addressbook.GetZoneNames():
                 target = [str(obj_target)] + target
             # ensure that the header is always first
             target = target_header + target

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -134,20 +134,19 @@ class Term(aclgenerator.Term):
         ret_str.IndentAppend(3, 'policy ' + self.term.name + ' {')
         ret_str.IndentAppend(4, 'match {')
         # SOURCE-ADDRESS
-        saddrs = sorted(set([i.parent_token for i in self.term.source_address]))
-        saddrs.extend(sorted(set([i.parent_token + FQDNSUFFIX for i in self.term.source_fqdn])))
+        saddrs = {i.parent_token for i in self.term.source_address}
+        saddrs.update({i.parent_token + FQDNSUFFIX for i in self.term.source_fqdn})
         if saddrs:
-            ret_str.IndentAppend(5, JunipersrxList('source-address', saddrs))
+            ret_str.IndentAppend(5, JunipersrxList('source-address', sorted(saddrs)))
         else:
             ret_str.IndentAppend(5, 'source-address any;')
 
         # DESTINATION-ADDRESS
-        daddrs = sorted(set([i.parent_token for i in self.term.destination_address]))
-        daddrs.extend(
-            sorted(set([i.parent_token + FQDNSUFFIX for i in self.term.destination_fqdn]))
+        daddrs = {i.parent_token for i in self.term.destination_address}
+        daddrs.update({i.parent_token + FQDNSUFFIX for i in self.term.destination_fqdn}
         )
         if daddrs:
-            ret_str.IndentAppend(5, JunipersrxList('destination-address', daddrs))
+            ret_str.IndentAppend(5, JunipersrxList('destination-address', sorted(daddrs)))
         else:
             ret_str.IndentAppend(5, 'destination-address any;')
 

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -715,9 +715,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
         ips = nacaddr.SortAddrList(ips)
         ips = nacaddr.CollapseAddrList(ips)
         for ip in ips:
-            target.IndentAppend(
-                4, 'address ' + token + '_' + str(counter) + ' ' + str(ip) + ';'
-            )
+            target.IndentAppend(4, 'address ' + token + '_' + str(counter) + ' ' + str(ip) + ';')
             counter += 1
         for fqdn in fqdns:
             target.IndentAppend(4, f'address {token}_{counter} {{')
@@ -749,9 +747,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             target.IndentAppend(2, 'global {')
             global_addressbook = addressbook.Addressbook()
             for zone, _, ips, fqdns in self.addressbook.WalkAddressBook():
-                global_addressbook.AddAddresses(
-                    'global', ips
-                    )
+                global_addressbook.AddAddresses('global', ips)
                 global_addressbook.AddFQDNs('global', fqdns)
             if 'global' in global_addressbook.GetZoneNames():
                 addrs = []

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -140,8 +140,8 @@ class Term(aclgenerator.Term):
             saddr_check = sorted(saddr_check)
             ret_str.IndentAppend(5, JunipersrxList('source-address', saddr_check))
         elif self.term.source_fqdn:
-            for ptoken in set([i.parent_token for i in self.term.source_fqdn]):
-              ret_str.IndentAppend(5, 'source-address {ptoken}')
+            sfqdn = sorted(set([i.parent_token for i in self.term.source_fqdn]))
+            ret_str.IndentAppend(5, JunipersrxList('source-address', sfqdn))
         else:
             ret_str.IndentAppend(5, 'source-address any;')
 
@@ -155,8 +155,8 @@ class Term(aclgenerator.Term):
             daddr_check.sort()
             ret_str.IndentAppend(5, JunipersrxList('destination-address', daddr_check))
         elif self.term.destination_fqdn:
-            for ptoken in set([i.parent_token for i in self.term.destination_fqdn]):
-              ret_str.IndentAppend(5, f'destination-address {ptoken}')
+            dfqdn = sorted(set([i.parent_token for i in self.term.destination_fqdn]))
+            ret_str.IndentAppend(5, JunipersrxList('destination-address', dfqdn))
         else:
             ret_str.IndentAppend(5, 'destination-address any;')
 

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -143,8 +143,7 @@ class Term(aclgenerator.Term):
 
         # DESTINATION-ADDRESS
         daddrs = {i.parent_token for i in self.term.destination_address}
-        daddrs.update({i.parent_token + FQDNSUFFIX for i in self.term.destination_fqdn}
-        )
+        daddrs.update({i.parent_token + FQDNSUFFIX for i in self.term.destination_fqdn})
         if daddrs:
             ret_str.IndentAppend(5, JunipersrxList('destination-address', sorted(daddrs)))
         else:

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -328,10 +328,12 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             'dscp_except',
             'dscp_match',
             'dscp_set',
+            'destination_fqdn',
             'destination_zone',
             'logging',
             'option',
             'owner',
+            'source_fqdn',
             'source_zone',
             'timeout',
             'verbatim',
@@ -551,7 +553,9 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     term.source_address = valid_addrs
                     if term.source_address:
                         self.addressbook.AddAddresses(self.from_zone, term.source_address)
-
+                if term.source_fqdn:
+                    self.addressbook.AddFQDN(self.from_zone, term.source_fqdn)
+                    
                 # Filter destination_address based on filter_type & add to address book
                 if term.destination_address:
                     valid_addrs = []
@@ -566,7 +570,8 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     term.destination_address = valid_addrs
                     if term.destination_address:
                         self.addressbook.AddAddresses(self.to_zone, term.destination_address)
-
+                if term.destination_fqdn:
+                    self.addressbook.AddFQDN(self.to_zone, term.destination_fqdn)
                 new_term = Term(term, self.from_zone, self.to_zone, self.expresspath, verbose)
                 new_terms.append(new_term)
 
@@ -697,41 +702,60 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             else:
                 port_list.append('%s-%s' % (str(i[0]), str(i[1])))
         return port_list
-
+    
+    def _GenerateAddresses(self, addressbook_zone: dict):
+        target = IndentList(self.INDENT)
+        tokens = sorted(addressbook_zone.keys())
+        for token in tokens:
+            counter = 0
+            ips = nacaddr.SortAddrList(addressbook_zone[token]['ips'])
+            ips = nacaddr.CollapseAddrList(ips)
+            for ip in ips:
+                target.IndentAppend(
+                    4, 'address ' + token + '_' + str(counter) + ' ' + str(ip) + ';'
+                )
+                counter += 1
+            for fqdn in addressbook_zone[token]['fqdns']:
+                target.IndentAppend(
+                    4, f'address {token}_{counter} {{'
+                )
+                target.IndentAppend(5, f'dns-name {fqdn.fqdn};')
+                target.IndentAppend(
+                    4, f'}}'
+                )
+        return target
+    def _GenerateAddressSets(self, addressbook_zone: dict) -> IndentList:
+        target = IndentList(self.INDENT)
+        for group in sorted(addressbook_zone.keys()):
+            target.IndentAppend(4, 'address-set ' + group + ' {')
+            counter = 0
+            for _ in nacaddr.CollapseAddrList(addressbook_zone[group]['ips']):
+                target.IndentAppend(5, 'address ' + group + '_' + str(counter) + ';')
+                counter += 1
+            for _ in addressbook_zone[group]['fqdns']:
+                target.IndentAppend(5, 'address ' + group + '_' + str(counter) + ';')
+                counter += 1
+            target.IndentAppend(4, '}')
+        return target
+        pass
     def _GenerateAddressBook(self) -> IndentList:
         """Creates address book."""
         target = IndentList(self.INDENT)
 
         # create address books if address-book-type set to global
         if self._GLOBAL_ADDR_BOOK in self.addr_book_type:
-            global_address_book = collections.defaultdict(list)
 
             target.IndentAppend(1, 'replace: address-book {')
             target.IndentAppend(2, 'global {')
+            global_addressbook = addressbook.Addressbook()
             for zone in self.addressbook.addressbook:
                 for group in self.addressbook.addressbook[zone]:
-                    for address in self.addressbook.addressbook[zone][group]:
-                        global_address_book[group].append(address)
-            names = sorted(global_address_book.keys())
-            for name in names:
-                counter = 0
-                ips = nacaddr.SortAddrList(global_address_book[name])
-                ips = nacaddr.CollapseAddrList(ips)
-                global_address_book[name] = ips
-                for ip in ips:
-                    target.IndentAppend(
-                        4, 'address ' + name + '_' + str(counter) + ' ' + str(ip) + ';'
-                    )
-                    counter += 1
+                    global_addressbook.AddAddresses('global', self.addressbook.addressbook[zone][group]['ips'])
 
-            for group in sorted(global_address_book.keys()):
-                target.IndentAppend(4, 'address-set ' + group + ' {')
-                counter = 0
-                for unused_addr in global_address_book[group]:
-                    target.IndentAppend(5, 'address ' + group + '_' + str(counter) + ';')
-                    counter += 1
-                target.IndentAppend(4, '}')
-
+                    global_addressbook.AddFQDN('global', self.addressbook.addressbook[zone][group]['fqdns'])
+            if 'global' in global_addressbook.addressbook.keys():
+              target.extend(self._GenerateAddresses(global_addressbook.addressbook['global']))
+              target.extend(self._GenerateAddressSets(global_addressbook.addressbook['global']))
             target.IndentAppend(2, '}')
             target.IndentAppend(1, '}')
 
@@ -740,29 +764,8 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             for zone in self.addressbook.addressbook:
                 target.IndentAppend(2, 'security-zone ' + zone + ' {')
                 target.IndentAppend(3, 'replace: address-book {')
-
-                # building individual addresses
-                groups = sorted(self.addressbook.addressbook[zone])
-                for group in groups:
-                    ips = nacaddr.SortAddrList(self.addressbook.addressbook[zone][group])
-                    ips = nacaddr.CollapseAddrList(ips)
-                    self.addressbook.addressbook[zone][group] = ips
-                    count = 0
-                    for address in self.addressbook.addressbook[zone][group]:
-                        target.IndentAppend(
-                            4, 'address ' + group + '_' + str(count) + ' ' + str(address) + ';'
-                        )
-                        count += 1
-
-                # building address-sets
-                for group in groups:
-                    target.IndentAppend(4, 'address-set ' + group + ' {')
-                    count = 0
-                    for address in self.addressbook.addressbook[zone][group]:
-                        target.IndentAppend(5, 'address ' + group + '_' + str(count) + ';')
-                        count += 1
-
-                    target.IndentAppend(4, '}')
+                target.extend(self._GenerateAddresses(self.addressbook.addressbook[zone]))
+                target.extend(self._GenerateAddressSets(self.addressbook.addressbook[zone]))
                 target.IndentAppend(3, '}')
                 target.IndentAppend(2, '}')
             target.IndentAppend(1, '}')

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -139,6 +139,9 @@ class Term(aclgenerator.Term):
                 saddr_check.add(saddr.parent_token)
             saddr_check = sorted(saddr_check)
             ret_str.IndentAppend(5, JunipersrxList('source-address', saddr_check))
+        elif self.term.source_fqdn:
+            for ptoken in set([i.parent_token for i in self.term.source_fqdn]):
+              ret_str.IndentAppend(5, 'source-address {ptoken}')
         else:
             ret_str.IndentAppend(5, 'source-address any;')
 
@@ -151,6 +154,9 @@ class Term(aclgenerator.Term):
             daddr_check = list(daddr_check)
             daddr_check.sort()
             ret_str.IndentAppend(5, JunipersrxList('destination-address', daddr_check))
+        elif self.term.destination_fqdn:
+            for ptoken in set([i.parent_token for i in self.term.destination_fqdn]):
+              ret_str.IndentAppend(5, f'destination-address {ptoken}')
         else:
             ret_str.IndentAppend(5, 'destination-address any;')
 

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -862,39 +862,6 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         # destination address are not specified (any any).
         ANY_IPV4_RANGE = "0.0.0.0-255.255.255.255"
         add_any_ipv4 = False
-        # Name to IP addresses
-        # address_book_names_dict = {}
-        # address_book_groups_dict = {}
-        # import ipdb;ipdb.set_trace()
-        # try:
-        #     groups = sorted(self.addressbook.addressbook[''].keys())
-        # except:
-        #     groups = []
-        # for group in groups:
-        # for _, group, ips, _ in self.addressbook.WalkAddressBook(''):
-        #     count = 0
-        #     for ip in ips:
-        #         name = f'{ip.parent_token}_{count}'
-        #         count = count + 1
-        #         address = ip.with_prefixlen
-        #         if name in address_book_names_dict:
-        #             if address_book_names_dict[name].supernet_of(address):
-        #                 continue
-        #         address_book_names_dict[name] = address
-
-        # building individual address-group dictionary
-        # group_names = [i for i in address_book_names_dict.keys() if nested_group in i]
-
-        # address_book_groups_dict[group] = group_names
-        # import ipdb;ipdb.set_trace()
-
-        # sort address books and address sets
-        # address_book_groups_dict = collections.OrderedDict(
-        #     sorted(address_book_groups_dict.items())
-        # )
-        # address_book_keys = sorted(
-        #     list(address_book_names_dict.keys()), key=self._SortAddressBookNumCheck
-        # )
 
         # INITAL CONFIG
         config = etree.Element("config", {"urldb": "paloaltonetworks", "version": "8.1.0"})

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -1109,7 +1109,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         addr_group = etree.SubElement(vsys_entry, "address-group")
 
         if not no_addr_obj:
-            for _, token, ips, _ in self.addressbook.WalkAddressBook(''):
+            for _, token, ips, _ in self.addressbook.Walk(''):
                 entry = etree.SubElement(addr_group, "entry", {"name": token})
                 static = etree.SubElement(entry, "static")
                 count = 0
@@ -1122,7 +1122,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         addr = etree.SubElement(vsys_entry, "address")
         if not no_addr_obj:
 
-            for _, token, ips, _ in self.addressbook.WalkAddressBook(''):
+            for _, token, ips, _ in self.addressbook.Walk(''):
                 count = 0
                 for ip in ips:
                     entry = etree.SubElement(addr, "entry", {"name": f'{token}_{count}'})

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -871,7 +871,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
             groups = []
         for group in groups:
             count = 0
-            for ip in self.addressbook.addressbook[''][group]:
+            for ip in nacaddr.CollapseAddrList(self.addressbook.addressbook[''][group]['ips']):
                 name = f'{ip.parent_token}_{count}'
                 count = count + 1
                 address = ip.with_prefixlen

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -863,36 +863,38 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         ANY_IPV4_RANGE = "0.0.0.0-255.255.255.255"
         add_any_ipv4 = False
         # Name to IP addresses
-        address_book_names_dict = {}
-        address_book_groups_dict = {}
-        try:
-            groups = sorted(self.addressbook.addressbook[''].keys())
-        except:
-            groups = []
-        for group in groups:
-            count = 0
-            for ip in self.addressbook.addressbook[''][group]['ips']:
-                name = f'{ip.parent_token}_{count}'
-                count = count + 1
-                address = ip.with_prefixlen
-                if name in address_book_names_dict:
-                    if address_book_names_dict[name].supernet_of(address):
-                        continue
-                address_book_names_dict[name] = address
+        # address_book_names_dict = {}
+        # address_book_groups_dict = {}
+        # import ipdb;ipdb.set_trace()
+        # try:
+        #     groups = sorted(self.addressbook.addressbook[''].keys())
+        # except:
+        #     groups = []
+        # for group in groups:
+        # for _, group, ips, _ in self.addressbook.WalkAddressBook(''):
+        #     count = 0
+        #     for ip in ips:
+        #         name = f'{ip.parent_token}_{count}'
+        #         count = count + 1
+        #         address = ip.with_prefixlen
+        #         if name in address_book_names_dict:
+        #             if address_book_names_dict[name].supernet_of(address):
+        #                 continue
+        #         address_book_names_dict[name] = address
 
-            # building individual address-group dictionary
-            for nested_group in groups:
-                group_names = [i for i in address_book_names_dict.keys() if nested_group in i]
+        # building individual address-group dictionary
+        # group_names = [i for i in address_book_names_dict.keys() if nested_group in i]
 
-                address_book_groups_dict[nested_group] = group_names
+        # address_book_groups_dict[group] = group_names
+        # import ipdb;ipdb.set_trace()
 
         # sort address books and address sets
-        address_book_groups_dict = collections.OrderedDict(
-            sorted(address_book_groups_dict.items())
-        )
-        address_book_keys = sorted(
-            list(address_book_names_dict.keys()), key=self._SortAddressBookNumCheck
-        )
+        # address_book_groups_dict = collections.OrderedDict(
+        #     sorted(address_book_groups_dict.items())
+        # )
+        # address_book_keys = sorted(
+        #     list(address_book_names_dict.keys()), key=self._SortAddressBookNumCheck
+        # )
 
         # INITAL CONFIG
         config = etree.Element("config", {"urldb": "paloaltonetworks", "version": "8.1.0"})
@@ -1026,9 +1028,10 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                 else:
                     for x in options["source"]:
                         if no_addr_obj:
-                            for group in address_book_groups_dict[x]:
+                            pass
+                            for ip in self.addressbook.GetAddress('', x):
                                 member = etree.SubElement(source, "member")
-                                member.text = str(address_book_names_dict[group])
+                                member.text = str(ip)
                                 max_src_dst += 1
                         else:
                             member = etree.SubElement(source, "member")
@@ -1060,9 +1063,10 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                 else:
                     for x in options["destination"]:
                         if no_addr_obj:
-                            for group in address_book_groups_dict[x]:
+                            pass
+                            for ip in self.addressbook.GetAddress('', x):
                                 member = etree.SubElement(dest, "member")
-                                member.text = str(address_book_names_dict[group])
+                                member.text = str(ip)
                                 max_src_dst += 1
                         else:
                             member = etree.SubElement(dest, "member")
@@ -1133,30 +1137,33 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
 
         # pytype: enable=key-error
 
-        if no_addr_obj:
-            address_book_groups_dict = {}
-            address_book_keys = {}
-
         # ADDRESS
         vsys_entry.append(etree.Comment(" Address Groups "))
         addr_group = etree.SubElement(vsys_entry, "address-group")
 
-        for group, address_list in address_book_groups_dict.items():
-            entry = etree.SubElement(addr_group, "entry", {"name": group})
-            static = etree.SubElement(entry, "static")
-            for name in address_list:
-                member = etree.SubElement(static, "member")
-                member.text = name
+        if not no_addr_obj:
+            for _, token, ips, _ in self.addressbook.WalkAddressBook(''):
+                entry = etree.SubElement(addr_group, "entry", {"name": token})
+                static = etree.SubElement(entry, "static")
+                count = 0
+                for ip in ips:
+                    member = etree.SubElement(static, "member")
+                    member.text = f'{ip.parent_token}_{count}'
+                    count += 1
 
         vsys_entry.append(etree.Comment(" Addresses "))
         addr = etree.SubElement(vsys_entry, "address")
+        if not no_addr_obj:
 
-        for name in address_book_keys:
-            entry = etree.SubElement(addr, "entry", {"name": name})
-            desc = etree.SubElement(entry, "description")
-            desc.text = name
-            ip = etree.SubElement(entry, "ip-netmask")
-            ip.text = str(address_book_names_dict[name])
+            for _, token, ips, _ in self.addressbook.WalkAddressBook(''):
+                count = 0
+                for ip in ips:
+                    entry = etree.SubElement(addr, "entry", {"name": f'{token}_{count}'})
+                    desc = etree.SubElement(entry, "description")
+                    desc.text = f'{token}_{count}'
+                    elem = etree.SubElement(entry, "ip-netmask")
+                    elem.text = str(ip)
+                    count += 1
 
         if add_any_ipv4:
             entry = etree.SubElement(addr, "entry", {"name": "any-ipv4"})

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -871,7 +871,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
             groups = []
         for group in groups:
             count = 0
-            for ip in nacaddr.CollapseAddrList(self.addressbook.addressbook[''][group]['ips']):
+            for ip in self.addressbook.addressbook[''][group]['ips']:
                 name = f'{ip.parent_token}_{count}'
                 count = count + 1
                 address = ip.with_prefixlen

--- a/tests/lib/addressbook_test.py
+++ b/tests/lib/addressbook_test.py
@@ -1,0 +1,23 @@
+from absl.testing import absltest
+
+from aerleon.lib.addressbook import Addressbook
+from aerleon.lib.fqdn import FQDN
+from aerleon.lib.nacaddr import IPv4
+
+
+class ACLGeneratorTest(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.ab = Addressbook()
+
+    def testFQDNs(self):
+        foo = FQDN('foo.com', 'FOO')
+        self.ab.AddFQDNs('zone', [foo])
+        self.assertEqual(
+            self.ab.GetFQDN('zone', 'FOO'), [FQDN(fqdn='foo.com', comment='', token='FOO')]
+        )
+
+    def testAddresses(self):
+        foo = IPv4('1.1.1.1/32', '', 'FOO')
+        self.ab.AddAddresses('zone', [foo])
+        self.assertEqual(self.ab.GetAddress('zone', 'FOO'), [IPv4('1.1.1.1/32', '', 'FOO')])

--- a/tests/lib/addressbook_test.py
+++ b/tests/lib/addressbook_test.py
@@ -17,6 +17,20 @@ class ACLGeneratorTest(absltest.TestCase):
             self.ab.GetFQDN('zone', 'FOO'), [FQDN(fqdn='foo.com', comment='', token='FOO')]
         )
 
+    def testMultipleZones(self):
+        foo = FQDN('foo.com', 'FOO')
+        self.ab.AddFQDNs('zone', [foo])
+        self.ab.AddFQDNs('zone2', [foo])
+        self.assertEqual(['zone', 'zone2'], self.ab.GetZoneNames())
+
+    def testGetTokens(self):
+        foo = FQDN('foo.com', 'FOO')
+        bar = IPv4('1.1.1.1/32', '', 'BAR')
+        self.ab.AddFQDNs('zone', [foo])
+        self.ab.AddAddresses('zone2', [bar])
+        self.assertEqual(['FOO'], self.ab.GetFQDNTokensInZone('zone'))
+        self.assertEqual(['BAR'], self.ab.GetAddressTokensInZone('zone2'))
+
     def testAddresses(self):
         foo = IPv4('1.1.1.1/32', '', 'FOO')
         self.ab.AddAddresses('zone', [foo])
@@ -48,6 +62,6 @@ class ACLGeneratorTest(absltest.TestCase):
             ['untrust', 'LOL', [IPv4('2.2.2.1/32', '', 'LOL'), IPv4('2.2.2.2/32', '', 'LOL')], []],
         ]
         count = 0
-        for zone, group, ips, fqdns in self.ab.WalkAddressBook():
+        for zone, group, ips, fqdns in self.ab.Walk():
             self.assertEqual([zone, group, ips, fqdns], expected[count])
             count += 1

--- a/tests/lib/addressbook_test.py
+++ b/tests/lib/addressbook_test.py
@@ -21,3 +21,33 @@ class ACLGeneratorTest(absltest.TestCase):
         foo = IPv4('1.1.1.1/32', '', 'FOO')
         self.ab.AddAddresses('zone', [foo])
         self.assertEqual(self.ab.GetAddress('zone', 'FOO'), [IPv4('1.1.1.1/32', '', 'FOO')])
+
+    def testWalkAddressbook(self):
+        self.ab.AddAddresses(
+            'trust', [IPv4('1.1.1.1/32', '', 'FOO'), IPv4('1.1.1.2/32', '', 'BAR')]
+        )
+        self.ab.AddFQDNs(
+            'trust',
+            [
+                FQDN(fqdn='foo.com', comment='', token='FOO'),
+                FQDN(fqdn='biz.com', comment='', token='BIZ'),
+            ],
+        )
+        self.ab.AddAddresses(
+            'untrust', [IPv4('2.2.2.1/32', '', 'LOL'), IPv4('2.2.2.2/32', '', 'LOL')]
+        )
+        expected = [
+            ['trust', 'BAR', [IPv4('1.1.1.2/32', '', 'BAR')], []],
+            ['trust', 'BIZ', [], [FQDN(fqdn='biz.com', comment='', token='BIZ')]],
+            [
+                'trust',
+                'FOO',
+                [IPv4('1.1.1.1/32', '', 'FOO')],
+                [FQDN(fqdn='foo.com', comment='', token='FOO')],
+            ],
+            ['untrust', 'LOL', [IPv4('2.2.2.1/32', '', 'LOL'), IPv4('2.2.2.2/32', '', 'LOL')], []],
+        ]
+        count = 0
+        for zone, group, ips, fqdns in self.ab.WalkAddressBook():
+            self.assertEqual([zone, group, ips, fqdns], expected[count])
+            count += 1

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
@@ -1,11 +1,11 @@
 security {
     replace: address-book {
         global {
-                address GOOGLE_DNS_0 {
+                address GOOGLE_DNS_FQDN_0 {
                     dns-name dns.google.com;
                 }
-                address-set GOOGLE_DNS {
-                    address GOOGLE_DNS_0;
+                address-set GOOGLE_DNS_FQDN {
+                    address GOOGLE_DNS_FQDN_0;
                 }
         }
     }
@@ -22,7 +22,7 @@ security {
             policy fqdn-term {
                 match {
                     source-address any;
-                    destination-address [ GOOGLE_DNS ];
+                    destination-address [ GOOGLE_DNS_FQDN ];
                     application any;
                 }
                 then {
@@ -36,11 +36,11 @@ delete: applications;
 security {
     replace: address-book {
         global {
-                address GOOGLE_DNS_0 {
+                address GOOGLE_DNS_FQDN_0 {
                     dns-name dns.google.com;
                 }
-                address-set GOOGLE_DNS {
-                    address GOOGLE_DNS_0;
+                address-set GOOGLE_DNS_FQDN {
+                    address GOOGLE_DNS_FQDN_0;
                 }
         }
     }
@@ -56,7 +56,7 @@ security {
         from-zone trust to-zone untrust {
             policy fqdn-term {
                 match {
-                    source-address [ GOOGLE_DNS ];
+                    source-address [ GOOGLE_DNS_FQDN ];
                     destination-address any;
                     application any;
                 }

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
@@ -22,6 +22,41 @@ security {
             policy fqdn-term {
                 match {
                     source-address any;
+                    destination-address [ GOOGLE_DNS ];
+                    application any;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}
+delete: applications;
+security {
+    replace: address-book {
+        global {
+                address GOOGLE_DNS_0 {
+                    dns-name dns.google.com;
+                }
+                address-set GOOGLE_DNS {
+                    address GOOGLE_DNS_0;
+                }
+        }
+    }
+    /*
+    $Id:$
+    $Date:$
+    $Revision:$
+    */
+    replace: policies {
+        /*
+        This is a test acl with a comment
+        */
+        from-zone trust to-zone untrust {
+            policy fqdn-term {
+                match {
+                    source-address [ GOOGLE_DNS ];
                     destination-address any;
                     application any;
                 }

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDN.stdout.ref
@@ -1,0 +1,29 @@
+security {
+    replace: address-book {
+        global {
+        }
+    }
+    /*
+    $Id:$
+    $Date:$
+    $Revision:$
+    */
+    replace: policies {
+        /*
+        This is a test acl with a comment
+        */
+        from-zone trust to-zone untrust {
+            policy fqdn-term {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}
+delete: applications;

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedInTerm.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedInTerm.stdout.ref
@@ -22,7 +22,7 @@ security {
             policy fqdn-term {
                 match {
                     source-address any;
-                    destination-address any;
+                    destination-address GOOGLE_DNS
                     application any;
                 }
                 then {

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedInTerm.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedInTerm.stdout.ref
@@ -1,11 +1,13 @@
 security {
     replace: address-book {
         global {
-                address GOOGLE_DNS_0 {
+                address GOOGLE_DNS_0 8.8.8.8/32;
+                address GOOGLE_DNS_1 {
                     dns-name dns.google.com;
                 }
                 address-set GOOGLE_DNS {
                     address GOOGLE_DNS_0;
+                    address GOOGLE_DNS_1;
                 }
         }
     }
@@ -22,7 +24,7 @@ security {
             policy fqdn-term {
                 match {
                     source-address any;
-                    destination-address GOOGLE_DNS
+                    destination-address [ GOOGLE_DNS ];
                     application any;
                 }
                 then {

--- a/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedIntraterm.stdout.ref
+++ b/tests/regression/junipersrx/JuniperSRXYAMLTest.testFQDNMixedIntraterm.stdout.ref
@@ -33,6 +33,16 @@ security {
                     permit;
                 }
             }
+            policy goog-ip-term {
+                match {
+                    source-address any;
+                    destination-address [ GOOGLE_DNS ];
+                    application any;
+                }
+                then {
+                    permit;
+                }
+            }
         }
     }
 }

--- a/tests/regression/junipersrx/junipersrx_test.py
+++ b/tests/regression/junipersrx/junipersrx_test.py
@@ -2635,9 +2635,22 @@ def _YamlParsePolicy(
         shade_check=shade_check,
     )
 
-FQDN_TERM= """
+FQDN_DST_TERM= """
   - name: fqdn-term
     destination-fqdn: GOOGLE_DNS
+    action: accept
+"""
+
+FQDN_SRC_TERM= """
+  - name: fqdn-term
+    source-fqdn: GOOGLE_DNS
+    action: accept
+"""
+
+FQDN_MIXED_TERM = """
+  - name: fqdn-term
+    destination-fqdn: GOOGLE_DNS
+    destination-address: GOOGLE_DNS
     action: accept
 """
 
@@ -2724,7 +2737,7 @@ class JuniperSRXYAMLTest(JuniperSRXTest):
             PLATFORM_EXCLUDE_ADDRESS_TERM=YAML_PLATFORM_EXCLUDE_ADDRESS_TERM,
         )
 
-    # @capture.stdout
+    @capture.stdout
     def testFQDN(self):
       definitions = naming.Naming()
       definitions.ParseYaml("""
@@ -2738,10 +2751,16 @@ services:
       protocol: udp
       """, file_name=""
       )
-      pol = junipersrx.JuniperSRX(
-            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_TERM, definitions=definitions), EXP_INFO
-        )
+      pol = str(junipersrx.JuniperSRX(
+            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_DST_TERM, definitions=definitions), EXP_INFO
+        ))
       print(pol)
+      self.assertIn('destination-address [ GOOGLE_DNS ];', pol, pol)
+      pol = str(junipersrx.JuniperSRX(
+            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_SRC_TERM, definitions=definitions), EXP_INFO
+        ))
+      print(pol)
+      self.assertIn('source-address [ GOOGLE_DNS ];', pol, pol)
     
     @capture.stdout
     def testFQDNMixedInTerm(self):
@@ -2759,7 +2778,7 @@ services:
       """, file_name=""
       )
         pol = junipersrx.JuniperSRX(
-            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_TERM, definitions=definitions), EXP_INFO
+            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_MIXED_TERM, definitions=definitions), EXP_INFO
         )
         print(pol)
 

--- a/tests/regression/junipersrx/junipersrx_test.py
+++ b/tests/regression/junipersrx/junipersrx_test.py
@@ -2635,13 +2635,14 @@ def _YamlParsePolicy(
         shade_check=shade_check,
     )
 
-FQDN_DST_TERM= """
+
+FQDN_DST_TERM = """
   - name: fqdn-term
     destination-fqdn: GOOGLE_DNS
     action: accept
 """
 
-FQDN_SRC_TERM= """
+FQDN_SRC_TERM = """
   - name: fqdn-term
     source-fqdn: GOOGLE_DNS
     action: accept
@@ -2653,6 +2654,7 @@ FQDN_MIXED_TERM = """
     destination-address: GOOGLE_DNS
     action: accept
 """
+
 
 class JuniperSRXYAMLTest(JuniperSRXTest):
     def setUp(self):
@@ -2739,8 +2741,9 @@ class JuniperSRXYAMLTest(JuniperSRXTest):
 
     @capture.stdout
     def testFQDN(self):
-      definitions = naming.Naming()
-      definitions.ParseYaml("""
+        definitions = naming.Naming()
+        definitions.ParseYaml(
+            """
 networks:
   GOOGLE_DNS:
     values:
@@ -2749,23 +2752,31 @@ services:
   WHOIS:
     - port: 43
       protocol: udp
-      """, file_name=""
-      )
-      pol = str(junipersrx.JuniperSRX(
-            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_DST_TERM, definitions=definitions), EXP_INFO
-        ))
-      print(pol)
-      self.assertIn('destination-address [ GOOGLE_DNS ];', pol, pol)
-      pol = str(junipersrx.JuniperSRX(
-            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_SRC_TERM, definitions=definitions), EXP_INFO
-        ))
-      print(pol)
-      self.assertIn('source-address [ GOOGLE_DNS ];', pol, pol)
-    
+      """,
+            file_name="",
+        )
+        pol = str(
+            junipersrx.JuniperSRX(
+                _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_DST_TERM, definitions=definitions),
+                EXP_INFO,
+            )
+        )
+        print(pol)
+        self.assertIn('destination-address [ GOOGLE_DNS ];', pol, pol)
+        pol = str(
+            junipersrx.JuniperSRX(
+                _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_SRC_TERM, definitions=definitions),
+                EXP_INFO,
+            )
+        )
+        print(pol)
+        self.assertIn('source-address [ GOOGLE_DNS ];', pol, pol)
+
     @capture.stdout
     def testFQDNMixedInTerm(self):
         definitions = naming.Naming()
-        definitions.ParseYaml("""
+        definitions.ParseYaml(
+            """
 networks:
   GOOGLE_DNS:
     values:
@@ -2775,12 +2786,14 @@ services:
   WHOIS:
     - port: 43
       protocol: udp
-      """, file_name=""
-      )
+      """,
+            file_name="",
+        )
         pol = junipersrx.JuniperSRX(
             _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_MIXED_TERM, definitions=definitions), EXP_INFO
         )
         print(pol)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/regression/junipersrx/junipersrx_test.py
+++ b/tests/regression/junipersrx/junipersrx_test.py
@@ -685,7 +685,7 @@ class JuniperSRXTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
         print(output)
 
-    # @capture.stdout
+    @capture.stdout
     def testVpnWithoutPolicy(self):
         self.naming.GetNetAddr.return_value = _IPSET
 

--- a/tests/regression/junipersrx/junipersrx_test.py
+++ b/tests/regression/junipersrx/junipersrx_test.py
@@ -2742,6 +2742,26 @@ services:
             _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_TERM, definitions=definitions), EXP_INFO
         )
       print(pol)
+    
+    @capture.stdout
+    def testFQDNMixedInTerm(self):
+        definitions = naming.Naming()
+        definitions.ParseYaml("""
+networks:
+  GOOGLE_DNS:
+    values:
+      - address: 8.8.8.8/32
+      - fqdn: dns.google.com
+services:
+  WHOIS:
+    - port: 43
+      protocol: udp
+      """, file_name=""
+      )
+        pol = junipersrx.JuniperSRX(
+            _YamlParsePolicy(YAML_GOOD_HEADER + FQDN_TERM, definitions=definitions), EXP_INFO
+        )
+        print(pol)
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -590,7 +590,7 @@ class PaloAltoFWTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
         print(output)
 
-    @capture.stdout
+    # @capture.stdout
     def testServiceMap(self):
         definitions = naming.Naming()
         definitions._ParseLine('SSH = 22/tcp', 'services')
@@ -1765,46 +1765,46 @@ term rule-1 {
   destination-address:: NET2 NET3
 """
 
-        pol = policy.ParsePolicy(POL % ("inet", T), definitions)
-        paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
-        output = str(paloalto)
-        print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET1']/static/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET1_0"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET1_0']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"10.1.0.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET2", "NET3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET2']/static/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET2_0"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET2_0']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"10.2.0.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET3']/static/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET3_0", "NET3_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_0']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"10.3.1.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_1']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"10.3.2.0/24"}, addrs, output)
+        # pol = policy.ParsePolicy(POL % ("inet", T), definitions)
+        # paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
+        # output = str(paloalto)
+        # print(output)
+        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET1"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET1']/static/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET1_0"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET1_0']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"10.1.0.0/24"}, addrs, output)
+        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET2", "NET3"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET2']/static/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET2_0"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET2_0']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"10.2.0.0/24"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET3']/static/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET3_0", "NET3_1"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_0']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"10.3.1.0/24"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_1']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # self.assertEqual({"10.3.2.0/24"}, addrs, output)
 
         # These tests check that large IP ranges are broken into equivalent subnets.
         T = """
@@ -1817,44 +1817,44 @@ term rule-1 {
         x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        self.assertEqual({"NET5"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"4000::/3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"6000::/3"}, addrs, output)
+        # self.assertEqual({"NET5"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"4000::/3"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"6000::/3"}, addrs, output)
 
         T = """
   source-address:: NET4
   destination-address:: NET5
 """
-        pol = policy.ParsePolicy(POL % ("mixed", T), definitions)
-        paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
-        output = str(paloalto)
-        print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET5"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"4000::/3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        self.assertTrue(len(x) > 0, output)
-        addrs = {elem.text for elem in x}
-        self.assertEqual({"6000::/3"}, addrs, output)
+        # pol = policy.ParsePolicy(POL % ("mixed", T), definitions)
+        # paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
+        # output = str(paloalto)
+        # print(output)
+        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"NET5"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"4000::/3"}, addrs, output)
+        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        # # self.assertTrue(len(x) > 0, output)
+        # addrs = {elem.text for elem in x}
+        # # self.assertEqual({"6000::/3"}, addrs, output)
 
 
 if __name__ == '__main__':

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -1821,15 +1821,15 @@ term rule-1 {
         x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
         x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"4000::/3"}, addrs, output)
+        self.assertEqual({"4000::/3"}, addrs, output)
         x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"6000::/3"}, addrs, output)
+        self.assertEqual({"6000::/3"}, addrs, output)
 
         T = """
   source-address:: NET4
@@ -1840,21 +1840,21 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET5"}, addrs, output)
+        self.assertEqual({"NET5"}, addrs, output)
         x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
         x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"4000::/3"}, addrs, output)
+        self.assertEqual({"4000::/3"}, addrs, output)
         x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
+        self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"6000::/3"}, addrs, output)
+        self.assertEqual({"6000::/3"}, addrs, output)
 
 
 if __name__ == '__main__':

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -590,7 +590,7 @@ class PaloAltoFWTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
         print(output)
 
-    # @capture.stdout
+    @capture.stdout
     def testServiceMap(self):
         definitions = naming.Naming()
         definitions._ParseLine('SSH = 22/tcp', 'services')

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -1765,46 +1765,46 @@ term rule-1 {
   destination-address:: NET2 NET3
 """
 
-        # pol = policy.ParsePolicy(POL % ("inet", T), definitions)
-        # paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
-        # output = str(paloalto)
-        # print(output)
-        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET1"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET1']/static/member")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET1_0"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET1_0']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"10.1.0.0/24"}, addrs, output)
-        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET2", "NET3"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET2']/static/member")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET2_0"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET2_0']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"10.2.0.0/24"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET3']/static/member")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET3_0", "NET3_1"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_0']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"10.3.1.0/24"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_1']/ip-netmask")
-        # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # self.assertEqual({"10.3.2.0/24"}, addrs, output)
+        pol = policy.ParsePolicy(POL % ("inet", T), definitions)
+        paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
+        output = str(paloalto)
+        print(output)
+        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"NET1"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET1']/static/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"NET1_0"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET1_0']/ip-netmask")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"10.1.0.0/24"}, addrs, output)
+        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"NET2", "NET3"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET2']/static/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"NET2_0"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET2_0']/ip-netmask")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"10.2.0.0/24"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET3']/static/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"NET3_0", "NET3_1"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_0']/ip-netmask")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"10.3.1.0/24"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_1']/ip-netmask")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        self.assertEqual({"10.3.2.0/24"}, addrs, output)
 
         # These tests check that large IP ranges are broken into equivalent subnets.
         T = """
@@ -1817,44 +1817,44 @@ term rule-1 {
         x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
-        # self.assertEqual({"NET5"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        self.assertEqual({"NET5"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
         # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"4000::/3"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"6000::/3"}, addrs, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"4000::/3"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"6000::/3"}, addrs, output)
 
         T = """
   source-address:: NET4
   destination-address:: NET5
 """
-        # pol = policy.ParsePolicy(POL % ("mixed", T), definitions)
-        # paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
-        # output = str(paloalto)
-        # print(output)
-        # x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"NET5"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"4000::/3"}, addrs, output)
-        # x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
-        # # self.assertTrue(len(x) > 0, output)
-        # addrs = {elem.text for elem in x}
-        # # self.assertEqual({"6000::/3"}, addrs, output)
+        pol = policy.ParsePolicy(POL % ("mixed", T), definitions)
+        paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
+        output = str(paloalto)
+        print(output)
+        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        # self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET5"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        # self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"4000::/3"}, addrs, output)
+        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        # self.assertTrue(len(x) > 0, output)
+        addrs = {elem.text for elem in x}
+        # self.assertEqual({"6000::/3"}, addrs, output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This completes the work to resolve https://github.com/aerleon/aerleon/issues/253
SRX will now be able to filter FQDN's in their terms.

FQDN's can be used in a term by using either `destination-fqdn` or `source-fqdn` the below is an example

```
  - name:  allow_dns
    destination-fqdn: CLOUDFLARE_DNS
    action: accept
```

See https://github.com/aerleon/aerleon/pull/291 for how to add FQDN's to the addressbook.