### PR TITLE
Update usage of icmpv6 or icmp6 in Juniper.

### DIFF
--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -231,7 +231,7 @@ class Term(aclgenerator.Term):
         # Don't render icmpv6 protocol terms under inet, or icmp under inet6
         if (self.term_type == 'inet6' and 'icmp' in self.term.protocol) or (
             self.term_type == 'inet'
-            and ('icmpv6' in self.term.protocol or 'icmpv6' in self.term.protocol)
+            and ('icmpv6' in self.term.protocol or 'icmp6' in self.term.protocol)
         ):
             logging.warning(
                 self.NO_AF_LOG_PROTO.substitute(

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -16,7 +16,7 @@
 
 """Juniper JCL generator."""
 
-
+import copy
 from typing import Dict, List, Set, Tuple, Union
 
 from absl import logging
@@ -490,29 +490,33 @@ class Term(aclgenerator.Term):
                 # https://github.com/aerleon/aerleon/issues/323
 
                 if 'icmpv6' in self.term.protocol:
-                    loc = self.term.protocol.index('icmpv6')
-                    self.term.protocol[loc] = 'icmp6'
-                if 'icmpv6' in self.term.protocol_except:
-                    loc = self.term.protocol_except.index('icmpv6')
-                    self.term.protocol_except[loc] = 'icmp6'
-                # both are supported on JunOS, but only icmp6 is supported
-                # on SRX loopback stateless filter
-                config.Append(family_keywords['protocol'] + ' ' + self._Group(self.term.protocol))
+                    protocol = copy.copy(self.term.protocol)
+                    loc = protocol.index('icmpv6')
+                    protocol[loc] = 'icmp6'
+                    config.Append(family_keywords['protocol'] + ' ' + self._Group(protocol))
+                else:
+                    # both are supported on JunOS, but only icmp6 is supported
+                    # on SRX loopback stateless filter
+                    config.Append(
+                        family_keywords['protocol'] + ' ' + self._Group(self.term.protocol)
+                    )
 
             # protocol
             if self.term.protocol_except:
                 # same as above
-                if 'icmpv6' in self.term.protocol:
-                    loc = self.term.protocol.index('icmpv6')
-                    self.term.protocol[loc] = 'icmp6'
                 if 'icmpv6' in self.term.protocol_except:
-                    loc = self.term.protocol_except.index('icmpv6')
-                    self.term.protocol_except[loc] = 'icmp6'
-                config.Append(
-                    family_keywords['protocol-except']
-                    + ' '
-                    + self._Group(self.term.protocol_except)
-                )
+                    protocol_except = copy.copy(self.term.protocol_except)
+                    loc = protocol_except.index('icmpv6')
+                    protocol_except[loc] = 'icmp6'
+                    config.Append(
+                        family_keywords['protocol-except'] + ' ' + self._Group(protocol_except)
+                    )
+                else:
+                    config.Append(
+                        family_keywords['protocol-except']
+                        + ' '
+                        + self._Group(self.term.protocol_except)
+                    )
 
             # port
             if self.term.port:

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -225,7 +225,6 @@ class Term(aclgenerator.Term):
             # some options need to modify the actions
             self.extra_actions = []
 
-
     def __str__(self):
         config = Config(indent=self._DEFAULT_INDENT)
         from_str = []
@@ -492,10 +491,10 @@ class Term(aclgenerator.Term):
 
                 if 'icmpv6' in self.term.protocol:
                     loc = self.term.protocol.index('icmpv6')
-                    self.term.protocol[loc]= 'icmp6'
+                    self.term.protocol[loc] = 'icmp6'
                 if 'icmpv6' in self.term.protocol_except:
                     loc = self.term.protocol_except.index('icmpv6')
-                    self.term.protocol_except[loc] =  'icmp6'
+                    self.term.protocol_except[loc] = 'icmp6'
                 # both are supported on JunOS, but only icmp6 is supported
                 # on SRX loopback stateless filter
                 config.Append(family_keywords['protocol'] + ' ' + self._Group(self.term.protocol))
@@ -505,10 +504,10 @@ class Term(aclgenerator.Term):
                 # same as above
                 if 'icmpv6' in self.term.protocol:
                     loc = self.term.protocol.index('icmpv6')
-                    self.term.protocol[loc]= 'icmp6'
+                    self.term.protocol[loc] = 'icmp6'
                 if 'icmpv6' in self.term.protocol_except:
                     loc = self.term.protocol_except.index('icmpv6')
-                    self.term.protocol_except[loc] =  'icmp6'
+                    self.term.protocol_except[loc] = 'icmp6'
                 config.Append(
                     family_keywords['protocol-except']
                     + ' '

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -224,6 +224,7 @@ class Term(aclgenerator.Term):
 
             # some options need to modify the actions
             self.extra_actions = []
+        self._ReplaceICMPv6()
 
     def __str__(self):
         config = Config(indent=self._DEFAULT_INDENT)
@@ -780,6 +781,19 @@ class Term(aclgenerator.Term):
                     break
 
         return include_result, exclude_result
+
+    def _ReplaceICMPv6(self):
+        """Juniper has deprecated the use ic icmpv6 in favor of icmp6.
+        https://github.com/aerleon/aerleon/issues/323
+        """
+        if 'icmpv6' in self.term.protocol:
+            i = self.term.protocol.index('icmpv6')
+            del self.term.protocol[i]
+            self.term.protocol.insert(i, 'icmp6')
+        if 'icmpv6' in self.term.protocol_except:
+            i = self.term.protocol_except.index('icmpv6')
+            del self.term.protocol_except[i]
+            self.term.protocol_except.insert(i, 'icmp6')
 
     def _Comment(
         self,

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -16,7 +16,6 @@
 
 """Juniper JCL generator."""
 
-import copy
 from typing import Dict, List, Set, Tuple, Union
 
 from absl import logging
@@ -488,35 +487,24 @@ class Term(aclgenerator.Term):
             if self.term.protocol:
                 # Juniper has deprecated the use of icmpv6 in favor of icmp6.
                 # https://github.com/aerleon/aerleon/issues/323
-
+                protocol = self.term.protocol[:]
                 if 'icmpv6' in self.term.protocol:
-                    protocol = copy.copy(self.term.protocol)
                     loc = protocol.index('icmpv6')
                     protocol[loc] = 'icmp6'
-                    config.Append(family_keywords['protocol'] + ' ' + self._Group(protocol))
-                else:
-                    # both are supported on JunOS, but only icmp6 is supported
-                    # on SRX loopback stateless filter
-                    config.Append(
-                        family_keywords['protocol'] + ' ' + self._Group(self.term.protocol)
-                    )
+                # both are supported on JunOS, but only icmp6 is supported
+                # on SRX loopback stateless filter
+                config.Append(family_keywords['protocol'] + ' ' + self._Group(protocol))
 
             # protocol
             if self.term.protocol_except:
                 # same as above
+                protocol_except = self.term.protocol_except[:]
                 if 'icmpv6' in self.term.protocol_except:
-                    protocol_except = copy.copy(self.term.protocol_except)
                     loc = protocol_except.index('icmpv6')
                     protocol_except[loc] = 'icmp6'
-                    config.Append(
-                        family_keywords['protocol-except'] + ' ' + self._Group(protocol_except)
-                    )
-                else:
-                    config.Append(
-                        family_keywords['protocol-except']
-                        + ' '
-                        + self._Group(self.term.protocol_except)
-                    )
+                config.Append(
+                    family_keywords['protocol-except'] + ' ' + self._Group(protocol_except)
+                )
 
             # port
             if self.term.port:

--- a/tests/regression/juniper/JuniperTest.testIcmpv6Except.stdout.ref
+++ b/tests/regression/juniper/JuniperTest.testIcmpv6Except.stdout.ref
@@ -10,7 +10,7 @@ firewall {
             interface-specific;
             term good-term-20-v6 {
                 from {
-                    next-header-except icmpv6;
+                    next-header-except icmp6;
                 }
                 then accept;
             }

--- a/tests/regression/juniper/JuniperTest.testInet6.stdout.ref
+++ b/tests/regression/juniper/JuniperTest.testInet6.stdout.ref
@@ -10,7 +10,7 @@ firewall {
             interface-specific;
             term good-term-1 {
                 from {
-                    next-header icmpv6;
+                    next-header icmp6;
                 }
                 then accept;
             }

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -1009,7 +1009,7 @@ class JuniperTest(parameterized.TestCase):
         self.assertIn('next-header-except tcp;', output, output)
         print(output)
 
-    # @capture.stdout
+    @capture.stdout
     def testIcmpv6Except(self):
         jcl = juniper.Juniper(
             policy.ParsePolicy(GOOD_HEADER_V6 + GOOD_TERM_20_V6, self.naming), EXP_INFO
@@ -1472,7 +1472,7 @@ class JuniperTest(parameterized.TestCase):
 
         mock_warning.assert_called_once_with(
             'Term icmptype-mismatch will not be rendered,'
-            ' as it has icmp6 match specified but '
+            ' as it has icmpv6 match specified but '
             'the ACL is of inet address family.'
         )
 

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -919,7 +919,7 @@ class JuniperTest(parameterized.TestCase):
             policy.ParsePolicy(GOOD_HEADER_V6 + GOOD_TERM_1_V6, self.naming), EXP_INFO
         )
         output = str(jcl)
-        self.assertTrue('next-header icmpv6;' in output and 'next-header tcp;' in output, output)
+        self.assertTrue('next-header icmp6;' in output and 'next-header tcp;' in output, output)
 
         self.naming.GetNetAddr.assert_called_once_with('SOME_HOST')
         self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
@@ -1009,13 +1009,13 @@ class JuniperTest(parameterized.TestCase):
         self.assertIn('next-header-except tcp;', output, output)
         print(output)
 
-    @capture.stdout
+    # @capture.stdout
     def testIcmpv6Except(self):
         jcl = juniper.Juniper(
             policy.ParsePolicy(GOOD_HEADER_V6 + GOOD_TERM_20_V6, self.naming), EXP_INFO
         )
         output = str(jcl)
-        self.assertIn('next-header-except icmpv6;', output, output)
+        self.assertIn('next-header-except icmp6;', output, output)
         print(output)
 
     @capture.stdout
@@ -1472,7 +1472,7 @@ class JuniperTest(parameterized.TestCase):
 
         mock_warning.assert_called_once_with(
             'Term icmptype-mismatch will not be rendered,'
-            ' as it has icmpv6 match specified but '
+            ' as it has icmp6 match specified but '
             'the ACL is of inet address family.'
         )
 


### PR DESCRIPTION
This fixes #323

Juniper has changed their syntax to prefer icmp6 over icmpv6. Our YAML language is agnostic of these changes but our generators should be updated to use what ever the platform prefers. This change adds a method that looks for the usage of icmpv6 in the protocol and replaces it with icmp6 for output.

@XioNoX for visibility