### PR TITLE
Adding packet/byte count to IPTables restore format (speedway)

### DIFF
--- a/aerleon/lib/speedway.py
+++ b/aerleon/lib/speedway.py
@@ -43,6 +43,6 @@ class Speedway(iptables.Iptables):
 
     _RENDER_PREFIX = '*filter'
     _RENDER_SUFFIX = 'COMMIT'
-    _DEFAULTACTION_FORMAT = ':%s %s'
+    _DEFAULTACTION_FORMAT = ':%s %s [0:0]'
 
     _TERM = Term

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.ipt.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.ipt.ref
@@ -7,7 +7,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:INPUT DROP
+:INPUT DROP [0:0]
 -N I_deny-from-bogons
 -A I_deny-from-bogons -m comment --comment "this is a sample edge input filter with a very very very long and"
 -A I_deny-from-bogons -m comment --comment "multi-line comment that"
@@ -69,7 +69,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:OUTPUT DROP
+:OUTPUT DROP [0:0]
 -N O_deny-to-bad-destinations
 -A O_deny-to-bad-destinations -p all -d 0.0.0.0/8 -j DROP
 -A O_deny-to-bad-destinations -p all -d 0.0.0.0/8 -j DROP

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_speedway.ipt.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_speedway.ipt.ref
@@ -8,7 +8,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:INPUT DROP
+:INPUT DROP [0:0]
 -N I_base-allow-est-in
 -A I_base-allow-est-in -p all -m state --state ESTABLISHED,RELATED -j ACCEPT
 -A INPUT -j I_base-allow-est-in
@@ -30,7 +30,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:OUTPUT DROP
+:OUTPUT DROP [0:0]
 -A OUTPUT -o lo -j ACCEPT
 -N O_base-allow-est-out
 -A O_base-allow-est-out -p all -m state --state ESTABLISHED,RELATED -j ACCEPT
@@ -56,7 +56,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:FORWARD DROP
+:FORWARD DROP [0:0]
 -N F_base-forwarding-deny
 -A F_base-forwarding-deny -p all -j REJECT --reject-with icmp-host-prohibited
 -A FORWARD -j F_base-forwarding-deny

--- a/tests/regression/speedway/SpeedwayTest.testSpeedwayOutputFormat.stdout.ref
+++ b/tests/regression/speedway/SpeedwayTest.testSpeedwayOutputFormat.stdout.ref
@@ -6,7 +6,7 @@
 # $Date:$
 # $Revision:$
 # inet
-:INPUT ACCEPT
+:INPUT ACCEPT [0:0]
 -N I_good-term-1
 -A I_good-term-1 -p icmp -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 -A INPUT -j I_good-term-1

--- a/tests/regression/speedway/speedway_test.py
+++ b/tests/regression/speedway/speedway_test.py
@@ -163,16 +163,16 @@ class SpeedwayTest(absltest.TestCase):
             result[0],
             '*filter designation does not appear at top of generated ' 'policy.',
         )
-        # self.assertIn(':INPUT ACCEPT [0:0]', result, 'input default policy of accept not set.')
-        # self.assertIn('-N I_good-term-1', result, 'did not find new chain for good-term-1.')
-        # self.assertIn(
-        #     '-A I_good-term-1 -p icmp -m state --state NEW,ESTABLISHED,RELATED' ' -j ACCEPT',
-        #     result,
-        #     'did not find append for good-term-1.',
-        # )
-        # self.assertEqual(
-        #     'COMMIT', result[len(result) - 2], 'COMMIT does not appear at end of output policy.'
-        # )
+        self.assertIn(':INPUT ACCEPT [0:0]', result, 'input default policy of accept not set.')
+        self.assertIn('-N I_good-term-1', result, 'did not find new chain for good-term-1.')
+        self.assertIn(
+            '-A I_good-term-1 -p icmp -m state --state NEW,ESTABLISHED,RELATED' ' -j ACCEPT',
+            result,
+            'did not find append for good-term-1.',
+        )
+        self.assertEqual(
+            'COMMIT', result[len(result) - 2], 'COMMIT does not appear at end of output policy.'
+        )
         print(acl)
 
     def testBuildTokens(self):

--- a/tests/regression/speedway/speedway_test.py
+++ b/tests/regression/speedway/speedway_test.py
@@ -163,16 +163,16 @@ class SpeedwayTest(absltest.TestCase):
             result[0],
             '*filter designation does not appear at top of generated ' 'policy.',
         )
-        self.assertIn(':INPUT ACCEPT', result, 'input default policy of accept not set.')
-        self.assertIn('-N I_good-term-1', result, 'did not find new chain for good-term-1.')
-        self.assertIn(
-            '-A I_good-term-1 -p icmp -m state --state NEW,ESTABLISHED,RELATED' ' -j ACCEPT',
-            result,
-            'did not find append for good-term-1.',
-        )
-        self.assertEqual(
-            'COMMIT', result[len(result) - 2], 'COMMIT does not appear at end of output policy.'
-        )
+        # self.assertIn(':INPUT ACCEPT [0:0]', result, 'input default policy of accept not set.')
+        # self.assertIn('-N I_good-term-1', result, 'did not find new chain for good-term-1.')
+        # self.assertIn(
+        #     '-A I_good-term-1 -p icmp -m state --state NEW,ESTABLISHED,RELATED' ' -j ACCEPT',
+        #     result,
+        #     'did not find append for good-term-1.',
+        # )
+        # self.assertEqual(
+        #     'COMMIT', result[len(result) - 2], 'COMMIT does not appear at end of output policy.'
+        # )
         print(acl)
 
     def testBuildTokens(self):


### PR DESCRIPTION
This fixes #321 
The packet/byte count is required for IPTables restore.