### PR TITLE
Skip NO_AF_LOG_PROTO when target=mixed

### DIFF
--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -174,13 +174,14 @@ class Term(aclgenerator.Term):
         if (self.term_type == "inet6" and "icmp" in self.term.protocol) or (
             self.term_type == "inet" and "icmpv6" in self.term.protocol
         ):
-            logging.warning(
-                self.NO_AF_LOG_PROTO.substitute(
-                    term=self.term.name,
-                    proto=", ".join(self.term.protocol),
-                    af=self.term_type,
+            if self.filter_type != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_PROTO.substitute(
+                        term=self.term.name,
+                        proto=", ".join(self.term.protocol),
+                        af=self.term_type,
+                    )
                 )
-            )
             return ""
 
         # term verbatim output - this will skip over normal term creation

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -454,11 +454,12 @@ class Term(aclgenerator.Term):
             or (self.af == 4 and 'icmpv6' in self.term.protocol)
             or (self.af == 4 and self.PROTO_MAP['icmpv6'] in self.term.protocol)
         ):
-            logging.warning(
-                self.NO_AF_LOG_PROTO.substitute(
-                    term=self.term.name, proto=', '.join(self.term.protocol), af=self.text_af
+            if self.filter_type != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_PROTO.substitute(
+                        term=self.term.name, proto=', '.join(self.term.protocol), af=self.text_af
+                    )
                 )
-            )
             return ''
 
         # verbose

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -232,11 +232,12 @@ class Term(aclgenerator.Term):
             self.term_type == 'inet'
             and ('icmpv6' in self.term.protocol or 'icmp6' in self.term.protocol)
         ):
-            logging.warning(
-                self.NO_AF_LOG_PROTO.substitute(
-                    term=self.term.name, proto=', '.join(self.term.protocol), af=self.term_type
+            if self.filter_type != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_PROTO.substitute(
+                        term=self.term.name, proto=', '.join(self.term.protocol), af=self.term_type
+                    )
                 )
-            )
             return ''
 
         # comment

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -214,11 +214,12 @@ class Term(juniper.Term):
                 (has_icmpv6 and not has_icmp and suffix == 'inet')
                 or (has_icmp and not has_icmpv6 and suffix == 'inet6')
             ) and self.term_type != 'mixed':
-                logging.warning(
-                    self.NO_AF_LOG_PROTO.substitute(
-                        term=self.term.name, proto=', '.join(self.term.protocol), af=suffix
+                if self.filter_type != 'mixed':
+                    logging.warning(
+                        self.NO_AF_LOG_PROTO.substitute(
+                            term=self.term.name, proto=', '.join(self.term.protocol), af=suffix
+                        )
                     )
-                )
                 return ''
 
             # NAME

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -214,12 +214,11 @@ class Term(juniper.Term):
                 (has_icmpv6 and not has_icmp and suffix == 'inet')
                 or (has_icmp and not has_icmpv6 and suffix == 'inet6')
             ) and self.term_type != 'mixed':
-                if self.filter_type != 'mixed':
-                    logging.warning(
-                        self.NO_AF_LOG_PROTO.substitute(
-                            term=self.term.name, proto=', '.join(self.term.protocol), af=suffix
-                        )
+                logging.warning(
+                    self.NO_AF_LOG_PROTO.substitute(
+                        term=self.term.name, proto=', '.join(self.term.protocol), af=suffix
                     )
+                )
                 return ''
 
             # NAME

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -137,7 +137,9 @@ class Term(aclgenerator.Term):
             if self.filter_type != 'mixed':
                 logging.warning(
                     self.NO_AF_LOG_PROTO.substitute(
-                        term=self.term.name, proto=', '.join(self.term.protocol), af=self.filter_type
+                        term=self.term.name,
+                        proto=', '.join(self.term.protocol),
+                        af=self.filter_type,
                     )
                 )
             return ''

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -134,11 +134,12 @@ class Term(aclgenerator.Term):
         if (self.af == 6 and 'icmp' in self.term.protocol) or (
             self.af == 4 and 'icmpv6' in self.term.protocol
         ):
-            logging.warning(
-                self.NO_AF_LOG_PROTO.substitute(
-                    term=self.term.name, proto=self.term.protocol, af=self.filter_type
+            if self.filter_type != 'mixed':
+                logging.warning(
+                    self.NO_AF_LOG_PROTO.substitute(
+                        term=self.term.name, proto=self.term.protocol, af=self.filter_type
+                    )
                 )
-            )
             return ''
 
         # Term verbatim is not supported

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -137,7 +137,7 @@ class Term(aclgenerator.Term):
             if self.filter_type != 'mixed':
                 logging.warning(
                     self.NO_AF_LOG_PROTO.substitute(
-                        term=self.term.name, proto=self.term.protocol, af=self.filter_type
+                        term=self.term.name, proto=', '.join(self.term.protocol), af=self.filter_type
                     )
                 )
             return ''

--- a/tests/regression/arista_tp/AristaTpTest.testIcmpMismatchMixedInet.stdout.ref
+++ b/tests/regression/arista_tp/AristaTpTest.testIcmpMismatchMixedInet.stdout.ref
@@ -1,8 +1,0 @@
-traffic-policies
-   no traffic-policy test-filter
-   traffic-policy test-filter
-      match ipv6-icmptype-mismatch ipv6
-         !! error when icmpv6 paired with inet filter
-         protocol icmpv6 type 128,129 code all
-      !
-

--- a/tests/regression/arista_tp/AristaTpTest.testIcmpMismatchMixedInet6.stdout.ref
+++ b/tests/regression/arista_tp/AristaTpTest.testIcmpMismatchMixedInet6.stdout.ref
@@ -1,8 +1,0 @@
-traffic-policies
-   no traffic-policy test-filter
-   traffic-policy test-filter
-      match icmptype-mismatch ipv4
-         !! error when icmp paired with inet6 filter
-         protocol icmp type 0,8 code all
-      !
-

--- a/tests/regression/arista_tp/AristaTpTest.testIcmpv6InetMismatch.stdout.ref
+++ b/tests/regression/arista_tp/AristaTpTest.testIcmpv6InetMismatch.stdout.ref
@@ -1,8 +1,4 @@
 traffic-policies
    no traffic-policy test-filter
    traffic-policy test-filter
-      match ipv6-icmptype-mismatch ipv6
-         !! error when icmpv6 paired with inet filter
-         protocol icmpv6 type 128,129 code all
-      !
 

--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -929,7 +929,7 @@ class AristaTpTest(absltest.TestCase):
     @capture.stdout
     def testIcmpv6InetMismatch(self, mock_warning):
         atp = arista_tp.AristaTrafficPolicy(
-            policy.ParsePolicy(GOOD_HEADER + BAD_ICMPTYPE_TERM_1, self.naming), EXP_INFO
+            policy.ParsePolicy(GOOD_HEADER_INET + BAD_ICMPTYPE_TERM_1, self.naming), EXP_INFO
         )
         str(atp)
 
@@ -951,39 +951,6 @@ class AristaTpTest(absltest.TestCase):
 
         mock_warning.assert_called_once_with(
             "Term icmptype-mismatch will not be rendered, "
-            "as it has icmp match specified but "
-            "the ACL is of inet6 address family."
-        )
-        print(atp)
-
-    # icmptype-mismatch test for mixed filter type
-    @mock.patch.object(arista_tp.logging, "warning")
-    @capture.stdout
-    def testIcmpMismatchMixedInet(self, mock_warning):
-        atp = arista_tp.AristaTrafficPolicy(
-            policy.ParsePolicy(GOOD_HEADER + BAD_ICMPTYPE_TERM_1, self.naming),
-            EXP_INFO,
-        )
-        str(atp)
-
-        mock_warning.assert_called_once_with(
-            "Term icmptype-mismatch will not be rendered, "
-            "as it has icmpv6 match specified but "
-            "the ACL is of inet address family."
-        )
-        print(atp)
-
-    @mock.patch.object(arista_tp.logging, "warning")
-    @capture.stdout
-    def testIcmpMismatchMixedInet6(self, mock_warning):
-        atp = arista_tp.AristaTrafficPolicy(
-            policy.ParsePolicy(GOOD_HEADER + BAD_ICMPTYPE_TERM_2, self.naming),
-            EXP_INFO,
-        )
-        str(atp)
-
-        mock_warning.assert_called_once_with(
-            "Term ipv6-icmptype-mismatch will not be rendered, "
             "as it has icmp match specified but "
             "the ACL is of inet6 address family."
         )

--- a/tests/regression/nsxv/TermTest.testWarnMismatchedProtoAF.stdout.ref
+++ b/tests/regression/nsxv/TermTest.testWarnMismatchedProtoAF.stdout.ref
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<!--
+$Id:$
+$Date:$
+$Revision:$
+-->
+<section name="INET_FILTER_NAME">
+  <rule logged="false">
+    <name>allow-ntp-request</name>
+    <action>allow</action>
+    <services>
+      <service>
+        <protocol>17</protocol>
+        <sourcePort>123</sourcePort>
+        <destinationPort>123</destinationPort>
+      </service>
+    </services>
+    <notes>Allow ntp request</notes>
+  </rule>
+</section>
+
+<?xml version="1.0" ?>
+<!--
+$Id:$
+$Date:$
+$Revision:$
+-->
+<section name="INET6_FILTER_NAME">
+  <rule logged="false">
+    <name>test-icmpv6</name>
+    <action>allow</action>
+    <services>
+      <service>
+        <protocol>58</protocol>
+        <subProtocol>128</subProtocol>
+      </service>
+      <service>
+        <protocol>58</protocol>
+        <subProtocol>129</subProtocol>
+      </service>
+    </services>
+  </rule>
+</section>
+

--- a/tests/regression/nsxv/nsxv_test.py
+++ b/tests/regression/nsxv/nsxv_test.py
@@ -1149,6 +1149,30 @@ class TermTest(absltest.TestCase):
         pol = policy.ParsePolicy(POLICY_INCORRECT_FILTERTYPE, self.naming)
         self.assertRaises(nsxv.UnsupportedNsxvAccessListError, nsxv.Nsxv, pol, 2)
 
+    @capture.stdout
+    def testWarnMismatchedProtoAF(self):
+        self.naming.GetServiceByProto.return_value = ['123']
+
+        pol = policy.ParsePolicy(INET_FILTER + INET6_TERM, self.naming)
+        with mock.patch.object(nsxv.logging, "warning") as mock_warning:
+            fw = nsxv.Nsxv(pol, EXP_INFO)
+            print(str(fw))
+            mock_warning.assert_called_with(
+                "Term test-icmpv6 will not be rendered, "
+                "as it has icmpv6 match specified but "
+                "the ACL is of inet address family."
+            )
+
+        pol = policy.ParsePolicy(INET6_FILTER + TERM, self.naming)
+        with mock.patch.object(nsxv.logging, "warning") as mock_warning:
+            fw = nsxv.Nsxv(pol, EXP_INFO)
+            print(str(fw))
+            mock_warning.assert_called_with(
+                "Term accept-icmp will not be rendered, "
+                "as it has icmp match specified but "
+                "the ACL is of inet6 address family."
+            )
+
 
 if __name__ == '__main__':
     absltest.main()


### PR DESCRIPTION
Fixes #324 (again). Similar to PR #329, issuing the warning NO_AF_LOG_PROTO is incorrect when target=mixed. It states that the term in question will not be rendered, when in fact target=mixed uses a two-pass process and the term will be rendered by one of the two passes (assuming no other issues).

@XioNoX FYI