### PR TITLE
IPTables "nochainedterms" option

### DIFF
--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -142,7 +142,7 @@ class Term(aclgenerator.Term):
 
         # Create a new term
         self._SetDefaultAction()
-        
+
         if self.chained_terms and self._TERM_FORMAT:
             ret_str.append(self._TERM_FORMAT.substitute(term=self.term_name))
         if self.chained_terms and self._PREJUMP_FORMAT:
@@ -916,7 +916,7 @@ class Iptables(aclgenerator.ACLGenerator):
                         default_action,
                         filter_type,
                         self.verbose,
-                        chained_terms
+                        chained_terms,
                     )
                 )
 

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -142,9 +142,10 @@ class Term(aclgenerator.Term):
 
         # Create a new term
         self._SetDefaultAction()
-
-        if self.chained_terms:
+        
+        if self.chained_terms and self._TERM_FORMAT:
             ret_str.append(self._TERM_FORMAT.substitute(term=self.term_name))
+        if self.chained_terms and self._PREJUMP_FORMAT:
             ret_str.append(
                 self._PREJUMP_FORMAT.substitute(filter=self.filter, term=self.term_name)
             )

--- a/policies/pol/test.yaml
+++ b/policies/pol/test.yaml
@@ -1,0 +1,10 @@
+filters:
+  - header:
+      comment: |
+        foo
+      targets:
+        speedway: OUTPUT DROP inet nochainedterms
+    terms:
+      - name: deny-all
+        protocol: tcp udp
+        action: deny

--- a/test.ipt
+++ b/test.ipt
@@ -1,0 +1,13 @@
+*filter
+# Speedway OUTPUT Policy
+# foo
+#
+# $Id:$
+# $Date:$
+# $Revision:$
+# inet
+:OUTPUT DROP
+-A OUTPUT -p tcp -j DROP
+-A OUTPUT -p udp -j DROP
+-A OUTPUT -j OUTPUT
+COMMIT

--- a/tests/regression/iptables/AclCheckTest.testNoChain.stdout.ref
+++ b/tests/regression/iptables/AclCheckTest.testNoChain.stdout.ref
@@ -1,0 +1,10 @@
+# Iptables INPUT Policy
+# this is a test acl
+#
+# $Id:$
+# $Date:$
+# $Revision:$
+# inet
+-P INPUT ACCEPT
+-A INPUT -p icmp -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+

--- a/tests/regression/iptables/AclCheckTest.testNoChain.stdout.ref
+++ b/tests/regression/iptables/AclCheckTest.testNoChain.stdout.ref
@@ -7,4 +7,5 @@
 # inet
 -P INPUT ACCEPT
 -A INPUT -p icmp -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+-A INPUT -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
 

--- a/tests/regression/iptables/AclCheckTest.testNoChainOutput.stdout.ref
+++ b/tests/regression/iptables/AclCheckTest.testNoChainOutput.stdout.ref
@@ -1,0 +1,11 @@
+# Iptables OUTPUT Policy
+# this is a test acl
+#
+# $Id:$
+# $Date:$
+# $Revision:$
+# inet
+-P OUTPUT ACCEPT
+-A OUTPUT -p icmp -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+-A OUTPUT -p tcp --sport 80 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -32,6 +32,13 @@ header {
 }
 """
 
+GOOD_HEADER_NOCHAIN = """
+header {
+  comment:: "this is a test acl"
+  target:: iptables INPUT ACCEPT nochainedterms
+}
+"""
+
 GOOD_HEADER_2 = """
 header {
   comment:: "this is a test acl"
@@ -1402,6 +1409,13 @@ class AclCheckTest(absltest.TestCase):
             "permit-icmp will not be rendered, as it has icmp, icmpv6 match specified but the ACL is of inet address family.",
             ''.join(log.output),
         )
+    @capture.stdout
+    def testNoChain(self):
+        acl = iptables.Iptables(
+            policy.ParsePolicy(GOOD_HEADER_NOCHAIN + GOOD_TERM_1, self.naming), EXP_INFO
+        )
+        result = str(acl)
+        print(acl)
 
 
 YAML_GOOD_HEADER_1 = """
@@ -1410,6 +1424,15 @@ filters:
     comment: this is a test acl
     targets:
       iptables: INPUT ACCEPT
+  terms:
+"""
+
+YAML_GOOD_HEADER_NOCHAIN = """
+filters:
+- header:
+    comment: this is a test acl
+    targets:
+      iptables: INPUT ACCEPT nochainedterms
   terms:
 """
 
@@ -1864,6 +1887,7 @@ class IPTablesYAMLTest(AclCheckTest):
     def setUpFixtures(self):
         self.fixture_patcher = mock.patch.multiple(
             'iptables_test',
+            GOOD_HEADER_NOCHAIN=YAML_GOOD_HEADER_NOCHAIN,
             GOOD_HEADER_1=YAML_GOOD_HEADER_1,
             GOOD_HEADER_2=YAML_GOOD_HEADER_2,
             GOOD_HEADER_3=YAML_GOOD_HEADER_3,

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -32,13 +32,18 @@ header {
 }
 """
 
-GOOD_HEADER_NOCHAIN = """
+GOOD_HEADER_NOCHAIN_INPUT = """
 header {
   comment:: "this is a test acl"
   target:: iptables INPUT ACCEPT nochainedterms
 }
 """
-
+GOOD_HEADER_NOCHAIN_OUTPUT = """
+header {
+  comment:: "this is a test acl"
+  target:: iptables OUTPUT ACCEPT nochainedterms
+}
+"""
 GOOD_HEADER_2 = """
 header {
   comment:: "this is a test acl"
@@ -1411,12 +1416,23 @@ class AclCheckTest(absltest.TestCase):
         )
     @capture.stdout
     def testNoChain(self):
+        self.naming.GetServiceByProto.return_value = ['80']
+        
         acl = iptables.Iptables(
-            policy.ParsePolicy(GOOD_HEADER_NOCHAIN + GOOD_TERM_1, self.naming), EXP_INFO
+            policy.ParsePolicy(GOOD_HEADER_NOCHAIN_INPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming), EXP_INFO
         )
         result = str(acl)
         print(acl)
 
+    @capture.stdout
+    def testNoChainOutput(self):
+        self.naming.GetServiceByProto.return_value = ['80']
+        
+        acl = iptables.Iptables(
+            policy.ParsePolicy(GOOD_HEADER_NOCHAIN_OUTPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming), EXP_INFO
+        )
+        result = str(acl)
+        print(acl)
 
 YAML_GOOD_HEADER_1 = """
 filters:
@@ -1427,12 +1443,21 @@ filters:
   terms:
 """
 
-YAML_GOOD_HEADER_NOCHAIN = """
+YAML_GOOD_HEADER_NOCHAIN_INPUT = """
 filters:
 - header:
     comment: this is a test acl
     targets:
       iptables: INPUT ACCEPT nochainedterms
+  terms:
+"""
+
+YAML_GOOD_HEADER_NOCHAIN_OUTPUT = """
+filters:
+- header:
+    comment: this is a test acl
+    targets:
+      iptables: OUTPUT ACCEPT nochainedterms
   terms:
 """
 
@@ -1887,7 +1912,8 @@ class IPTablesYAMLTest(AclCheckTest):
     def setUpFixtures(self):
         self.fixture_patcher = mock.patch.multiple(
             'iptables_test',
-            GOOD_HEADER_NOCHAIN=YAML_GOOD_HEADER_NOCHAIN,
+            GOOD_HEADER_NOCHAIN_INPUT=YAML_GOOD_HEADER_NOCHAIN_INPUT,
+            GOOD_HEADER_NOCHAIN_OUTPUT=YAML_GOOD_HEADER_NOCHAIN_OUTPUT,
             GOOD_HEADER_1=YAML_GOOD_HEADER_1,
             GOOD_HEADER_2=YAML_GOOD_HEADER_2,
             GOOD_HEADER_3=YAML_GOOD_HEADER_3,

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -1414,12 +1414,14 @@ class AclCheckTest(absltest.TestCase):
             "permit-icmp will not be rendered, as it has icmp, icmpv6 match specified but the ACL is of inet address family.",
             ''.join(log.output),
         )
+
     @capture.stdout
     def testNoChain(self):
         self.naming.GetServiceByProto.return_value = ['80']
-        
+
         acl = iptables.Iptables(
-            policy.ParsePolicy(GOOD_HEADER_NOCHAIN_INPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming), EXP_INFO
+            policy.ParsePolicy(GOOD_HEADER_NOCHAIN_INPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming),
+            EXP_INFO,
         )
         result = str(acl)
         print(acl)
@@ -1427,12 +1429,16 @@ class AclCheckTest(absltest.TestCase):
     @capture.stdout
     def testNoChainOutput(self):
         self.naming.GetServiceByProto.return_value = ['80']
-        
+
         acl = iptables.Iptables(
-            policy.ParsePolicy(GOOD_HEADER_NOCHAIN_OUTPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming), EXP_INFO
+            policy.ParsePolicy(
+                GOOD_HEADER_NOCHAIN_OUTPUT + GOOD_TERM_1 + GOOD_TERM_2, self.naming
+            ),
+            EXP_INFO,
         )
         result = str(acl)
         print(acl)
+
 
 YAML_GOOD_HEADER_1 = """
 filters:


### PR DESCRIPTION
This adds the "nochainedterms" option to the IPTables and Speedway generator targets.

The IPTables and Speedway generators create a sub-chain for each term in the source policy by default. This behavior is not always desired due to preference or compatibility with other tools, so an option to disable the behavior and produce one chain per filter is now available.

To use it, just add the "nochainedterms" option to the filter header:

```
filters:
- header:
    comment: this is a test acl
    targets:
      iptables: INPUT ACCEPT nochainedterms      # <--- New flag
  terms:
    ...
```