### PR TITLE
Fixing speedway so that it does not print a jump statement when not c…

### DIFF
--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -368,7 +368,7 @@ class Term(aclgenerator.Term):
                                     )
                                 )
 
-        if self._POSTJUMP_FORMAT:
+        if self._POSTJUMP_FORMAT and self.chained_terms:
             ret_str.append(
                 self._POSTJUMP_FORMAT.substitute(filter=self.filter, term=self.term_name)
             )


### PR DESCRIPTION
The issue was that we check if there is a post jump action but not wether we are wanting to chain the terms.
@ProtonBruno can you verify if this output is what you would expect when adding the `nochainedterms` option to [sample_speedway.pol](https://github.com/aerleon/aerleon/blob/main/policies/pol/sample_speedway.pol)
```
:INPUT DROP [0:0]
-A INPUT -p all -m state --state ESTABLISHED,RELATED -j ACCEPT
-A INPUT -p icmp --icmp-type 8 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-A INPUT -p udp --sport 33434:33534 --dport 1024:65535 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-A INPUT -p tcp --dport 22 -s 10.0.0.0/8 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-A INPUT -p tcp --dport 22 -s 172.16.0.0/12 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
-A INPUT -p tcp --dport 22 -s 192.168.0.0/16 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
```