### PR TITLE
Fixing #363 by adding a optional delimeter to _Group and adding a comma delimeter for ports.

### DIFF
--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -403,11 +403,11 @@ class Term(aclgenerator.Term):
 
         # source port generation
         if term.source_port:
-            port_str += " source port %s" % ",".join([str(i) for i in term.source_port])
+            port_str += " source port %s" % self._Group(term.source_port, delimeter=",")
 
         # destination port
         if term.destination_port:
-            port_str += " destination port %s" % ",".join([str(i) for i in term.destination_port])
+            port_str += " destination port %s" % self._Group(term.destination_port, delimeter=",")
 
         return port_str
 
@@ -561,7 +561,7 @@ class Term(aclgenerator.Term):
 
         return flags, misc_options
 
-    def _Group(self, group: List[Union[str, Tuple[int, int]]], lc: bool = True) -> str:
+    def _Group(self, group: List[Union[str, Tuple[int, int]]], lc: bool = True, delimeter=" ") -> str:
         """If 1 item return it, else return [item1 item2].
 
         Args:
@@ -599,7 +599,7 @@ class Term(aclgenerator.Term):
                 return "%d-%d" % (el[0], el[1])
 
         if len(group) > 1:
-            rval = " ".join([_FormattedGroup(x, lc) for x in group])
+            rval = delimeter.join([_FormattedGroup(x, lc) for x in group])
         else:
             rval = _FormattedGroup(group[0])
         return rval

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -403,11 +403,11 @@ class Term(aclgenerator.Term):
 
         # source port generation
         if term.source_port:
-            port_str += " source port %s" % self._Group(term.source_port)
+            port_str += " source port %s" % ",".join([str(i) for i in term.source_port])
 
         # destination port
         if term.destination_port:
-            port_str += " destination port %s" % self._Group(term.destination_port)
+            port_str += " destination port %s" % ",".join([str(i) for i in term.destination_port])
 
         return port_str
 

--- a/tests/regression/arista_tp/AristaTpTest.testMultiplePorts.stdout.ref
+++ b/tests/regression/arista_tp/AristaTpTest.testMultiplePorts.stdout.ref
@@ -1,0 +1,8 @@
+traffic-policies
+   no traffic-policy test-filter
+   traffic-policy test-filter
+      match good-term-1 ipv4
+         destination prefix 10.0.0.0/8
+         protocol tcp destination port 25,100-200
+      !
+

--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -475,7 +475,7 @@ term logging-term-1 {
 MULTIPLE_PORTS = """
 term good-term-1 {
   protocol:: tcp
-  destination-port:: SMTP SSH
+  destination-port:: SMTP FOO
   destination-address:: SOME_HOST
   action:: accept
 }
@@ -1396,15 +1396,15 @@ class AristaTpTest(absltest.TestCase):
     
     @capture.stdout
     def testMultiplePorts(self):
-        self.naming._ParseLine("SSH = 22/tcp", "services")
+        self.naming._ParseLine("FOO = 100-200/tcp", "services")
         self.naming._ParseLine('SOME_HOST = 10.0.0.0/8', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
         atp = arista_tp.AristaTrafficPolicy(
             policy.ParsePolicy(GOOD_HEADER + MULTIPLE_PORTS, self.naming), EXP_INFO
         )
         output = str(atp)
-        # self.assertIn("protocol 0", output, output)
-        print(atp)
+        print(output)
+        self.assertIn('protocol tcp destination port 25,100-200', output, output)
 
     @mock.patch.object(arista_tp.logging, "warning")
     @capture.stdout

--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -472,6 +472,15 @@ term logging-term-1 {
 }
 """
 
+MULTIPLE_PORTS = """
+term good-term-1 {
+  protocol:: tcp
+  destination-port:: SMTP SSH
+  destination-address:: SOME_HOST
+  action:: accept
+}
+"""
+
 SUPPORTED_TOKENS = frozenset(
     [
         "action",
@@ -1384,6 +1393,18 @@ class AristaTpTest(absltest.TestCase):
             pol,
             EXP_INFO,
         )
+    
+    @capture.stdout
+    def testMultiplePorts(self):
+        self.naming._ParseLine("SSH = 22/tcp", "services")
+        self.naming._ParseLine('SOME_HOST = 10.0.0.0/8', 'networks')
+        self.naming._ParseLine('SMTP = 25/tcp', 'services')
+        atp = arista_tp.AristaTrafficPolicy(
+            policy.ParsePolicy(GOOD_HEADER + MULTIPLE_PORTS, self.naming), EXP_INFO
+        )
+        output = str(atp)
+        # self.assertIn("protocol 0", output, output)
+        print(atp)
 
     @mock.patch.object(arista_tp.logging, "warning")
     @capture.stdout


### PR DESCRIPTION
This fixes #363 by modifying the function `_Group`. It now takes an optional delimeter used for the joining of the list. This is the default for ICMP and protocols but has been updated for port numbers to fix the issue of requiring a comma to separate each port or port range.