### PR TITLE
Fix #372 converting to CIDR syntax for NXOS

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -682,9 +682,11 @@ class Term(aclgenerator.Term):
         if isinstance(addr, nacaddr.IPv4) or isinstance(addr, ipaddress.IPv4Network):
             addr = cast(self.IPV4_ADDRESS, addr)
             if addr.num_addresses > 1:
-                if self.platform == 'arista':
+                if self.platform in ('arista', 'cisconx'):
                     return addr.with_prefixlen
                 return '%s %s' % (addr.network_address, addr.hostmask)
+            if addr.num_addresses == 1 and self.platform == 'cisconx':
+                return '%s' % (addr.with_prefixlen)
             return 'host %s' % (addr.network_address)
         if isinstance(addr, nacaddr.IPv6) or isinstance(addr, ipaddress.IPv6Network):
             addr = cast(self.IPV6_ADDRESS, addr)

--- a/tests/regression/cisconx/CiscoNXTest.testStandardTermHost.stdout.ref
+++ b/tests/regression/cisconx/CiscoNXTest.testStandardTermHost.stdout.ref
@@ -9,11 +9,11 @@ ip access-list test-filter
 
 
  remark good-term-2
- permit tcp 10.1.1.0 0.0.0.255 any eq 22
+ permit tcp 10.1.1.0/24 any eq 22
 
 
  remark good-term-3
- permit tcp 10.1.1.0 0.0.0.255 any eq 6537
+ permit tcp 10.1.1.0/24 any eq 6537
 
 exit
 

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -260,9 +260,9 @@ class CiscoNXTest(absltest.TestCase):
         acl = cisconx.CiscoNX(pol, EXP_INFO)
         expected = 'ip access-list test-filter'
         self.assertIn(expected, str(acl), '[%s]' % str(acl))
-        expected = ' permit tcp 10.1.1.0 0.0.0.255 any eq 22'
+        expected = ' permit tcp 10.1.1.0/24 any eq 22'
         self.assertIn(expected, str(acl), str(acl))
-        expected = ' permit tcp 10.1.1.0 0.0.0.255 any eq 6537'
+        expected = ' permit tcp 10.1.1.0/24 any eq 6537'
         self.assertIn(expected, str(acl), str(acl))
 
         print(acl)

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.nxacl.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_multitarget.nxacl.ref
@@ -13,66 +13,66 @@ ip access-list edge-inbound
  remark this is a sample edge input filter with a very very very long and
  remark multi-line comment that
  remark also has multiple entries.
- deny ip 0.0.0.0 0.255.255.255 any
- deny ip 192.0.0.0 0.0.0.255 any
- deny ip 192.0.2.0 0.0.0.255 any
- deny ip 198.18.0.0 0.1.255.255 any
- deny ip 198.51.100.0 0.0.0.255 any
- deny ip 203.0.113.0 0.0.0.255 any
- deny ip 224.0.0.0 15.255.255.255 any
- deny ip 240.0.0.0 15.255.255.255 any
+ deny ip 0.0.0.0/8 any
+ deny ip 192.0.0.0/24 any
+ deny ip 192.0.2.0/24 any
+ deny ip 198.18.0.0/15 any
+ deny ip 198.51.100.0/24 any
+ deny ip 203.0.113.0/24 any
+ deny ip 224.0.0.0/4 any
+ deny ip 240.0.0.0/4 any
 
 
  remark deny-from-reserved
- deny ip 0.0.0.0 0.255.255.255 any
- deny ip 10.0.0.0 0.255.255.255 any
- deny ip 100.64.0.0 0.63.255.255 any
- deny ip 127.0.0.0 0.255.255.255 any
- deny ip 169.254.0.0 0.0.255.255 any
- deny ip 172.16.0.0 0.15.255.255 any
- deny ip 192.168.0.0 0.0.255.255 any
- deny ip 224.0.0.0 15.255.255.255 any
- deny ip 240.0.0.0 15.255.255.255 any
+ deny ip 0.0.0.0/8 any
+ deny ip 10.0.0.0/8 any
+ deny ip 100.64.0.0/10 any
+ deny ip 127.0.0.0/8 any
+ deny ip 169.254.0.0/16 any
+ deny ip 172.16.0.0/12 any
+ deny ip 192.168.0.0/16 any
+ deny ip 224.0.0.0/4 any
+ deny ip 240.0.0.0/4 any
 
 
  remark deny-to-rfc1918
- deny ip any 10.0.0.0 0.255.255.255
- deny ip any 172.16.0.0 0.15.255.255
- deny ip any 192.168.0.0 0.0.255.255
+ deny ip any 10.0.0.0/8
+ deny ip any 172.16.0.0/12
+ deny ip any 192.168.0.0/16
 
 
  remark permit-mail-services
- permit tcp any host 200.1.1.4 eq 25
- permit tcp any host 200.1.1.4 eq 465
- permit tcp any host 200.1.1.4 eq 587
- permit tcp any host 200.1.1.4 eq 995
- permit tcp any host 200.1.1.5 eq 25
- permit tcp any host 200.1.1.5 eq 465
- permit tcp any host 200.1.1.5 eq 587
- permit tcp any host 200.1.1.5 eq 995
+ permit tcp any 200.1.1.4/32 eq 25
+ permit tcp any 200.1.1.4/32 eq 465
+ permit tcp any 200.1.1.4/32 eq 587
+ permit tcp any 200.1.1.4/32 eq 995
+ permit tcp any 200.1.1.5/32 eq 25
+ permit tcp any 200.1.1.5/32 eq 465
+ permit tcp any 200.1.1.5/32 eq 587
+ permit tcp any 200.1.1.5/32 eq 995
 
 
  remark permit-web-services
- permit tcp any host 200.1.1.1 eq 80
- permit tcp any host 200.1.1.1 eq 443
- permit tcp any host 200.1.1.2 eq 80
- permit tcp any host 200.1.1.2 eq 443
+ permit tcp any 200.1.1.1/32 eq 80
+ permit tcp any 200.1.1.1/32 eq 443
+ permit tcp any 200.1.1.2/32 eq 80
+ permit tcp any 200.1.1.2/32 eq 443
 
 
  remark permit-tcp-established
- permit tcp any host 200.1.1.1 established
- permit tcp any host 200.1.1.2 established
- permit tcp any host 200.1.1.3 established
- permit tcp any host 200.1.1.4 established
- permit tcp any host 200.1.1.5 established
+ permit tcp any 200.1.1.1/32 established
+ permit tcp any 200.1.1.2/32 established
+ permit tcp any 200.1.1.3/32 established
+ permit tcp any 200.1.1.4/32 established
+ permit tcp any 200.1.1.5/32 established
 
 
  remark permit-udp-established
- permit udp any range 1024 65535 host 200.1.1.1
- permit udp any range 1024 65535 host 200.1.1.2
- permit udp any range 1024 65535 host 200.1.1.3
- permit udp any range 1024 65535 host 200.1.1.4
- permit udp any range 1024 65535 host 200.1.1.5
+ permit udp any range 1024 65535 200.1.1.1/32
+ permit udp any range 1024 65535 200.1.1.2/32
+ permit udp any range 1024 65535 200.1.1.3/32
+ permit udp any range 1024 65535 200.1.1.4/32
+ permit udp any range 1024 65535 200.1.1.5/32
 
 
  remark default-deny


### PR DESCRIPTION
Aligns the NXOS ACL output to the format that is commonly used in the NXOS configuration (except sequence numbers). 