### PR TITLE
Adding warning for nokia defaults changing.

### DIFF
--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -22,6 +22,8 @@ More information about the SR Linux ACL model schema: https://yang.srlinux.dev/
 import sys
 from typing import Dict, List, Set, Tuple
 
+from absl import logging
+
 from aerleon.lib import aclgenerator, openconfig
 from aerleon.lib.policy import Term
 
@@ -247,6 +249,7 @@ class NokiaSRLinux(openconfig.OpenConfig):
     ) -> None:
         srl_acl_entries: Dict[str, List[ACLEntry]] = {'inet': [], 'inet6': []}
         afs = ['inet', 'inet6'] if address_family == 'mixed' else [address_family]
+        logging.warning("NOTICE: Default behavior for Nokia SRLinux will change in March 2025. Please see https://github.com/aerleon/aerleon/issues/383")
         for term in terms:
             for term_af in afs:
                 t = SRLTerm(term, term_af)


### PR DESCRIPTION
Nokia has changed their syntax on their SRLinux platform starting with r24.3.2. Currently our code outputs by default the old syntax and the new syntax is locked behind a filter option. This new behavior has been out for some time and the default behavior should upgrade with our user base. In March we will invert the options and the default behavior will be the new syntax.

Until then we want to provide notice to anyone using Nokia that these changes are coming so they can be prepared. This change introduces a warning that prints out anytime Nokia is used regardless so all users are notified that this change is incoming.

See https://github.com/aerleon/aerleon/issues/383 for announcement.