### PR TITLE
Improved error logging for single file or single renderer.

### DIFF
--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -223,6 +223,7 @@ def RenderFile(
             'Error parsing policy file %s:\n%s%s'
             % (input_file, sys.exc_info()[0], sys.exc_info()[1])
         ) from e
+
     platforms = set()
     for header in pol.headers:
         platforms.update(header.platforms)

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -213,7 +213,6 @@ def RenderFile(
                 optimize=optimize,
                 base_dir=base_directory,
                 shade_check=shade_check,
-                filename=input_file.name
             )
     except policy.ShadingError as e:
         logging.warning('shading errors for %s:\n%s', input_file, e)

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -442,12 +442,11 @@ def Run(
 
     with_errors = False
     logging.info('finding policies...')
-    if policy_file:
-        policies = [pathlib.Path(policy_file)]
-    else:
-        policies = DescendDirectory(base_directory, ignore_directories)
     if max_renderers == 1 or policy_file:
-        # If one renderer or single file, run sequentially
+        if policy_file:
+            policies = [pathlib.Path(policy_file)]
+        else:
+            policies = DescendDirectory(base_directory, ignore_directories)
         try:
             for pol in policies:
                 RenderFile(


### PR DESCRIPTION
Currently if running multiprocessed the results are checked and exceptions are caught. If there are errors a boolean is set along with a warning produced. The boolean is then checked and an additional log is created along with exiting with sys.exit(1).

When running with a single policy file or max renderers set to 1 exceptions are not caught properly leading to unhandled exceptions and a unfriendly stack trace.

This change adds similar handling for the single policy and single renderer paths.

Adding a bad policy file currently will render something like the following
```
poetry run aclgen -max_renderers 1 --policy_file policies/pol/sample_arista_tp.pol
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
I0131 01:37:23.647081 281472823446848 aclgen.py:444] finding policies...
E0131 01:37:23.649663 281472823446848 aclgen.py:549] Unhandled exception: Error parsing policy file policies/pol/sample_arista_tp.pol:
<class 'aerleon.lib.policy.ParseError'> ERROR on "protoasdasdcol" (type STRING, line 14, Next ':')
Traceback (most recent call last):
  File "/workspaces/aerleon_ankenyr2/aerleon/aclgen.py", line 210, in RenderFile
    pol = policy.ParsePolicy(
          ^^^^^^^^^^^^^^^^^^^
  File "/workspaces/aerleon_ankenyr2/aerleon/lib/policy.py", line 2780, in ParsePolicy
    policy = parser.parse(preprocessed_data, lexer=lexer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/aerleon_ankenyr2/.venv/lib/python3.11/site-packages/ply/yacc.py", line 333, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/aerleon_ankenyr2/.venv/lib/python3.11/site-packages/ply/yacc.py", line 1201, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/aerleon_ankenyr2/.venv/lib/python3.11/site-packages/ply/yacc.py", line 192, in call_errorfunc
    r = errorfunc(token)
        ^^^^^^^^^^^^^^^^
  File "/workspaces/aerleon_ankenyr2/aerleon/lib/policy.py", line 2630, in p_error
    raise ParseError(
aerleon.lib.policy.ParseError:  ERROR on "protoasdasdcol" (type STRING, line 14, Next ':')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspaces/aerleon_ankenyr2/aerleon/aclgen.py", line 536, in main
    Run(
  File "/workspaces/aerleon_ankenyr2/aerleon/aclgen.py", line 453, in Run
    RenderFile(
  File "/workspaces/aerleon_ankenyr2/aerleon/aclgen.py", line 222, in RenderFile
    raise ACLParserError(
aerleon.aclgen.ACLParserError: Error parsing policy file policies/pol/sample_arista_tp.pol:
<class 'aerleon.lib.policy.ParseError'> ERROR on "protoasdasdcol" (type STRING, line 14, Next ':')
```

Now it will look like
```
poetry run aclgen -max_renderers 1 --policy_file policies/pol/sample_arista_tp.pol
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
I0131 01:36:13.915369 281472946335040 aclgen.py:444] finding policies...
W0131 01:36:13.918734 281472946335040 aclgen.py:465] 

error encountered in rendering process:
Error parsing policy file policies/pol/sample_arista_tp.pol:
<class 'aerleon.lib.policy.ParseError'> ERROR on "protoasdasdcol" (type STRING, line 14, Next ':')


I0131 01:36:13.919410 281472946335040 aclgen.py:379] no files changed, not writing to disk
W0131 01:36:13.919600 281472946335040 aclgen.py:501] done, with errors.
```