### PR TITLE
Fix test suite no longer passing with python version 3.12

### DIFF
--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -18,6 +18,7 @@
 import datetime
 import re
 from unittest import mock
+from unittest.mock import call
 
 from absl.testing import absltest
 
@@ -1002,9 +1003,9 @@ class AristaTpTest(absltest.TestCase):
         )
         output = str(atp)
         self.assertNotIn("match", output, output)
-        mock_warn.has_calls(
-            "WARNING: term %s has no valid match criteria and " "will not be rendered.",
-            "missing-match",
+        call_message = "WARNING: term %s has no valid match criteria and will not be rendered."
+        mock_warn.assert_has_calls(
+            [call(call_message, "missing-match"), call(call_message, "ipv6-missing-match")]
         )
         print(output)
 


### PR DESCRIPTION
python3.12 no longer matches when using has_calls
according to https://github.com/kivy/python-for-android/issues/3002 the recommended way of writing this test is to use assert_has_calls instead

fix #391 