### PR TITLE
Generate API: add includes, include_path support

### DIFF
--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -819,7 +819,7 @@ class Naming:
 
         self.ParseDefinitionsObject(file_data, file_name)
 
-    def ParseDefinitionsObject(self, file_data: Dict[str, str], file_name: str) -> None:
+    def ParseDefinitionsObject(self, file_data: Dict[str, Any], file_name: str) -> None:
         """Load network and service definitions from a Python object.
 
         Arguments:

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -2717,7 +2717,7 @@ def _Preprocess(data: str, max_depth: int = 5, base_dir: str = '') -> List[str]:
     return rval
 
 
-def _SubpathOf(parent: str, subpath: Union[str, pathlib.PosixPath]) -> bool:
+def _SubpathOf(parent: str, subpath: Union[str, pathlib.Path]) -> bool:
     return str(pathlib.Path(subpath).resolve()).startswith(str(pathlib.Path(parent).resolve()))
 
 

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -81,6 +81,11 @@ class UserMessage:
     def __repr__(self):
         return f"UserMessage(\"{str(self)}\")"
 
+    @classmethod
+    def fromValueError(cls, error: ValueError, *, filename, line=None, include_chain=None):
+        """Create a UserMessage from a ValueError."""
+        return cls(str(error), filename=filename, line=line, include_chain=include_chain)
+
 
 def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_check=False):
     """Load a policy yaml file and return a Policy data model.
@@ -103,7 +108,8 @@ def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_che
             raise PolicyTypeError(
                 UserMessage("Unable to read file as YAML.", filename=filename)
             ) from yaml_error
-    policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
+    processor = YAMLPolicyPreprocessor(base_dir)
+    policy_dict = processor(filename, policy_dict)
     if not policy_dict:
         return
     if not policy_dict['filters']:
@@ -137,7 +143,8 @@ def ParsePolicy(
             UserMessage("Unable to read file as YAML.", filename=filename)
         ) from yaml_error
 
-    policy_dict = _preprocessYAMLPolicy(filename, base_dir, policy_dict)
+    processor = YAMLPolicyPreprocessor(base_dir)
+    policy_dict = processor(filename, policy_dict)
     if not policy_dict:
         return
     if not policy_dict['filters']:
@@ -149,261 +156,298 @@ def suffix_is_yaml(filename):
     return filename[-5:] == '.yaml' or filename[-4:] == '.yml'
 
 
-def _preprocessYAMLPolicy(
-    filename: str, base_dir: str, policy_dict: Optional[PolicyDict]
-) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
-    """Process includes and validate the file data as a PolicyDict."""
-    debug_stack = []
-    return _preprocessYAMLPolicyInner(
-        MAX_INCLUDE_DEPTH,
-        debug_stack,
-        filename=filename,
-        base_dir=base_dir,
-        policy_dict=policy_dict,
-    )
+class YAMLPolicyPreprocessor:
+    """Processes a policy dictionary, handling includes and performing validation."""
 
+    def __init__(self, base_dir: str):
+        """
+        Args:
+            base_dir: The base directory for resolving include paths.
+        """
+        self.base_dir = base_dir
 
-def _preprocessYAMLPolicyInner(
-    depth: int, debug_stack: list, filename: str, base_dir: str, policy_dict: Optional[PolicyDict]
-) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
-    # Empty files are ignored with a warning
-    if policy_dict is None or not policy_dict:
-        logging.warning(UserMessage("Ignoring empty policy file.", filename=filename))
-        return
+    def __call__(
+        self, filename: str, policy_dict: Optional[PolicyDict]
+    ) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
+        """Process includes and validate the file data as a PolicyDict.
 
-    # Malformed policy files should generate a PolicyTypeError (unless this is an include file)
-    if 'filters' in policy_dict and isinstance(policy_dict['filters'], list):
-        pass  # Normal case.
-    elif (
-        depth < MAX_INCLUDE_DEPTH
-        and 'filters_include_only' in policy_dict
-        and isinstance(policy_dict['filters_include_only'], list)
-    ):
-        # Policy files with filters_include_only: are ignored by ParsePolicy but can be included.
-        policy_dict['filters'] = policy_dict['filters_include_only']
-        del policy_dict['filters_include_only']
-    elif 'terms' in policy_dict or 'filters_include_only' in policy_dict:
-        # We are looking at an include file outside of an include and should quietly ignore it.
-        return
-    else:
-        raise PolicyTypeError(
-            UserMessage("Policy file must contain one or more filter sections.", filename=filename)
+        Args:
+            filename: The name of the policy file.
+            policy_dict: The parsed YAML policy data.
+
+        Returns:
+            The processed policy dictionary with includes expanded.
+        """
+        debug_stack = []
+        return self._preprocess_inner(
+            MAX_INCLUDE_DEPTH,
+            debug_stack,
+            filename=filename,
+            policy_dict=policy_dict,
         )
 
-    found_filters = []
+    def _preprocess_inner(
+        self, depth: int, debug_stack: list, filename: str, policy_dict: Optional[PolicyDict]
+    ) -> Optional[Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]]:
+        # Empty files are ignored with a warning
+        if policy_dict is None or not policy_dict:
+            logging.warning(UserMessage("Ignoring empty policy file.", filename=filename))
+            return
 
-    for filter in policy_dict['filters']:
-        # Malformed filters should generate a PolicyTypeError
-        if not isinstance(filter, dict):
-            raise PolicyTypeError(UserMessage("Filter must be a mapping.", filename=filename))
-
-        def expand_filter(filter):
-            stack = debug_stack.copy()
-            stack.append((filter['__filename__'], filter['__line__']))
-
-            if depth <= 0:
-                raise ExcessiveRecursionError(
-                    UserMessage(
-                        f"Excessive recursion: include depth limit of {MAX_INCLUDE_DEPTH} reached.",  # noqa: E501
-                        filename=filter['__filename__'],
-                        line=filter['__line__'],
-                        include_chain=stack,
-                    )
-                )
-            if not suffix_is_yaml(filter['include']):
-                raise PolicyTypeError(
-                    UserMessage(
-                        f"Policy include source {filter['include']} must end in \".yaml\".",  # noqa: E501
-                        filename=filter['__filename__'],
-                        line=filter['__line__'],
-                        include_chain=stack,
-                    )
-                )
-            include_path = pathlib.Path(base_dir).joinpath(filter['include'])
-            if not _SubpathOf(base_dir, include_path):
-                raise BadIncludePath(
-                    f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
-                )
-            try:
-                include_file = _LoadIncludeFile(include_path)
-                include_data = yaml.load(
-                    include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
-                )
-            except YAMLError as yaml_error:
-                raise PolicyTypeError(
-                    UserMessage(
-                        "Unable to read file as YAML.",
-                        filename=str(include_path),
-                        include_chain=stack,
-                    )
-                ) from yaml_error
-            data = _preprocessYAMLPolicyInner(
-                depth - 1,
-                stack,
-                filename=include_path.name,
-                base_dir=base_dir,
-                policy_dict=include_data,
-            )
-            if not (data and data['filters']):
-                logging.warning(
-                    UserMessage(
-                        "Ignoring empty policy include source.",
-                        filename=str(include_path),
-                        include_chain=stack,
-                    )
-                )
-                return
-            found_filters.extend(data['filters'])
-
-        if 'include' in filter:
-            # This is an include directive
-            expand_filter(filter)
-            continue
-
-        if 'header' not in filter or not isinstance(filter['header'], dict):
-            raise PolicyTypeError(
-                UserMessage(
-                    "Filter must contain a header section.",
-                    filename=filename,
-                    line=filter['__line__'],
-                )
-            )
-
-        if 'terms' not in filter or not filter['terms'] or not isinstance(filter['terms'], list):
-            raise PolicyTypeError(
-                UserMessage(
-                    "Filter must contain a terms section.",
-                    filename=filename,
-                    line=filter['__line__'],
-                )
-            )
-
-        header = filter['header']
-        if 'targets' not in header or (
-            header['targets'] is not None and not isinstance(header['targets'], dict)
+        # Malformed policy files should generate a PolicyTypeError (unless this is an include file)
+        if 'filters' in policy_dict and isinstance(policy_dict['filters'], list):
+            pass  # Normal case.
+        elif (
+            depth < MAX_INCLUDE_DEPTH
+            and 'filters_include_only' in policy_dict
+            and isinstance(policy_dict['filters_include_only'], list)
         ):
+            # Policy files with filters_include_only: are ignored by ParsePolicy but can be included.
+            policy_dict['filters'] = policy_dict['filters_include_only']
+            del policy_dict['filters_include_only']
+        elif 'terms' in policy_dict or 'filters_include_only' in policy_dict:
+            # We are looking at an include file outside of an include and should quietly ignore it.
+            return
+        else:
             raise PolicyTypeError(
                 UserMessage(
-                    "Filter header must contain a targets section.",
-                    filename=filename,
-                    line=header['__line__'],
+                    "Policy file must contain one or more filter sections.", filename=filename
                 )
             )
 
-        # Filters with an empty target list can be ignored with a warning
-        elif not header['targets']:
-            raise PolicyTypeError(
-                UserMessage(
-                    "Filter header cannot be empty.",
-                    filename=filename,
-                    line=filter['__line__'],
-                )
-            )
+        found_filters = []
 
-        found_terms = []
+        for filter_item in policy_dict['filters']:
+            # Malformed filters should generate a PolicyTypeError
+            if not isinstance(filter_item, dict):
+                raise PolicyTypeError(UserMessage("Filter must be a mapping.", filename=filename))
 
-        def process_terms(depth, stack, term_items):
-            for term_item in term_items:
-                if 'include' not in term_item:
-                    found_terms.append(term_item)
-                    continue
-                new_stack = stack.copy()
-                new_stack.append((term_item['__filename__'], term_item['__line__']))
+            def expand_filter(filter_to_expand):
+                stack = debug_stack.copy()
+                stack.append((filter_to_expand['__filename__'], filter_to_expand['__line__']))
+
                 if depth <= 0:
                     raise ExcessiveRecursionError(
                         UserMessage(
                             f"Excessive recursion: include depth limit of {MAX_INCLUDE_DEPTH} reached.",  # noqa: E501
-                            filename=term_item['__filename__'],
-                            line=term_item['__line__'],
-                            include_chain=new_stack,
+                            filename=filter_to_expand['__filename__'],
+                            line=filter_to_expand['__line__'],
+                            include_chain=stack,
                         )
                     )
-                if not suffix_is_yaml(term_item['include']):
-                    raise PolicyTypeError(
-                        UserMessage(
-                            f"Policy include source {term_item['include']} must end in \".yaml\".",  # noqa: E501
-                            filename=term_item['__filename__'],
-                            line=term_item['__line__'],
-                            include_chain=new_stack,
-                        )
-                    )
-                # process_include(depth - 1, new_stack, term_item['include'])
-                include_path = pathlib.Path(base_dir).joinpath(term_item['include'])
-                if not _SubpathOf(base_dir, include_path):
-                    raise BadIncludePath(
-                        f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={base_dir}"
-                    )
-
                 try:
-                    include_file = _LoadIncludeFile(include_path)
-                    include_data = yaml.load(
-                        include_file, Loader=SpanSafeYamlLoader(filename=str(include_path))
+                    include_data, include_path = self._load_include_file(
+                        filter_to_expand['include'], stack
                     )
+                except ValueError as value_error:
+                    raise PolicyTypeError(
+                        UserMessage.fromValueError(
+                            value_error,
+                            filename=filter_to_expand['__filename__'],
+                            line=filter_to_expand['__line__'],
+                            include_chain=stack,
+                        )
+                    ) from value_error
                 except YAMLError as yaml_error:
                     raise PolicyTypeError(
                         UserMessage(
                             "Unable to read file as YAML.",
-                            filename=str(include_path),
-                            include_chain=new_stack,
+                            filename=str(
+                                pathlib.Path(self.base_dir).joinpath(filter_to_expand['include'])
+                            ),
+                            include_chain=stack,
                         )
                     ) from yaml_error
-                if not include_data or 'terms' not in include_data or not include_data['terms']:
+
+                data = self._preprocess_inner(
+                    depth - 1,
+                    stack,
+                    filename=include_path.name,
+                    policy_dict=include_data,
+                )
+                if not (data and data['filters']):
                     logging.warning(
                         UserMessage(
                             "Ignoring empty policy include source.",
                             filename=str(include_path),
-                            include_chain=new_stack,
+                            include_chain=stack,
                         )
                     )
-                    continue
-                process_terms(depth - 1, new_stack, include_data['terms'])
+                    return
+                found_filters.extend(data['filters'])
 
-        process_terms(MAX_INCLUDE_DEPTH, [], filter['terms'])
+            if 'include' in filter_item:
+                # This is an include directive
+                expand_filter(filter_item)
+                continue
 
-        if not found_terms:
-            logging.warning(
-                UserMessage(
-                    "Ignoring filter with zero terms.",
-                    filename=filename,
-                    line=filter['__line__'],
-                )
-            )
-            continue
-
-        for term_item in found_terms:
-            if 'name' not in term_item or len(term_item['name'].strip()) == 0:
+            if 'header' not in filter_item or not isinstance(filter_item['header'], dict):
                 raise PolicyTypeError(
                     UserMessage(
-                        "Term must have a name.",
-                        filename=term_item['__filename__'],
-                        line=term_item['__line__'],
+                        "Filter must contain a header section.",
+                        filename=filename,
+                        line=filter_item['__line__'],
                     )
                 )
 
-        filter['terms'] = found_terms
-        found_filters.append(filter)
+            if 'terms' not in filter_item or not filter_item['terms'] or not isinstance(filter_item['terms'], list):
+                raise PolicyTypeError(
+                    UserMessage(
+                        "Filter must contain a terms section.",
+                        filename=filename,
+                        line=filter_item['__line__'],
+                    )
+                )
 
-    policy_dict['filters'] = found_filters
+            header = filter_item['header']
+            if 'targets' not in header or (
+                header['targets'] is not None and not isinstance(header['targets'], dict)
+            ):
+                raise PolicyTypeError(
+                    UserMessage(
+                        "Filter header must contain a targets section.",
+                        filename=filename,
+                        line=header['__line__'],
+                    )
+                )
 
-    def StripDebuggingData(data):
-        if isinstance(data, list):
-            for item in data:
-                if isinstance(item, list) or isinstance(item, dict):
-                    StripDebuggingData(item)
-        elif isinstance(data, dict):
-            data.pop('__line__', None)
-            data.pop('__filename__', None)
-            for item in data.values():
-                if isinstance(item, list) or isinstance(item, dict):
-                    StripDebuggingData(item)
+            # Filters with an empty target list can be ignored with a warning
+            elif not header['targets']:
+                raise PolicyTypeError(
+                    UserMessage(
+                        "Filter header cannot be empty.",
+                        filename=filename,
+                        line=filter_item['__line__'],
+                    )
+                )
 
-    StripDebuggingData(policy_dict)
+            found_terms = []
 
-    return policy_dict
+            def process_terms(term_depth, stack, term_items):
+                for term_item in term_items:
+                    if 'include' not in term_item:
+                        found_terms.append(term_item)
+                        continue
+                    new_stack = stack.copy()
+                    new_stack.append((term_item['__filename__'], term_item['__line__']))
+                    if term_depth <= 0:
+                        raise ExcessiveRecursionError(
+                            UserMessage(
+                                f"Excessive recursion: include depth limit of {MAX_INCLUDE_DEPTH} reached.",  # noqa: E501
+                                filename=term_item['__filename__'],
+                                line=term_item['__line__'],
+                                include_chain=new_stack,
+                            )
+                        )
+                    try:
+                        include_data, include_path = self._load_include_file(
+                            term_item['include'], new_stack
+                        )
+                    except ValueError as value_error:
+                        raise PolicyTypeError(
+                            UserMessage.fromValueError(
+                                value_error,
+                                filename=term_item['__filename__'],
+                                line=term_item['__line__'],
+                                include_chain=new_stack,
+                            )
+                        ) from value_error
+                    except YAMLError as yaml_error:
+                        raise PolicyTypeError(
+                            UserMessage(
+                                "Unable to read file as YAML.",
+                                filename=str(pathlib.Path(self.base_dir).joinpath(term_item['include'])),
+                                include_chain=new_stack,
+                            )
+                        ) from yaml_error
+                    if not include_data or 'terms' not in include_data or not include_data['terms']:
+                        logging.warning(
+                            UserMessage(
+                                "Ignoring empty policy include source.",
+                                filename=str(include_path),
+                                include_chain=new_stack,
+                            )
+                        )
+                        continue
+                    process_terms(term_depth - 1, new_stack, include_data['terms'])
+
+            process_terms(MAX_INCLUDE_DEPTH, [], filter_item['terms'])
+
+            if not found_terms:
+                logging.warning(
+                    UserMessage(
+                        "Ignoring filter with zero terms.",
+                        filename=filename,
+                        line=filter_item['__line__'],
+                    )
+                )
+                continue
+
+            for term_item in found_terms:
+                if 'name' not in term_item or len(term_item['name'].strip()) == 0:
+                    raise PolicyTypeError(
+                        UserMessage(
+                            "Term must have a name.",
+                            filename=term_item['__filename__'],
+                            line=term_item['__line__'],
+                        )
+                    )
+
+            filter_item['terms'] = found_terms
+            found_filters.append(filter_item)
+
+        policy_dict['filters'] = found_filters
+
+        def StripDebuggingData(data):
+            if isinstance(data, list):
+                for item in data:
+                    if isinstance(item, list) or isinstance(item, dict):
+                        StripDebuggingData(item)
+            elif isinstance(data, dict):
+                data.pop('__line__', None)
+                data.pop('__filename__', None)
+                for item in data.values():
+                    if isinstance(item, list) or isinstance(item, dict):
+                        StripDebuggingData(item)
+
+        StripDebuggingData(policy_dict)
+
+        return policy_dict
+
+    def _load_include_file(
+        self, relative_path: str, stack: list
+    ) -> Tuple[Optional[PolicyDict], str | pathlib.Path]:
+        """Load, parse, and validate an include file path."""
+        if not suffix_is_yaml(relative_path):
+            raise ValueError(
+                f'Policy include source {relative_path} must end in ".yaml" or ".yml".'
+            )
+        include_path = pathlib.Path(self.base_dir).joinpath(relative_path)
+        if not _SubpathOf(self.base_dir, include_path):
+            raise BadIncludePath(
+                f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={self.base_dir}"
+            )
+
+        with open(include_path, 'r') as include_file:
+            include_data = yaml.load(
+                include_file.read(), Loader=SpanSafeYamlLoader(filename=str(include_path))
+            )
+        return include_data, include_path
 
 
-def _LoadIncludeFile(include_path: pathlib.PosixPath) -> str:
-    """Open an include file."""
+class GenerateAPIPolicyPreprocessor(YAMLPolicyPreprocessor):
+    """A YAMLPolicyPreprocessor that sources includes from a dictionary."""
 
-    with open(include_path, 'r') as include_file:
-        return include_file.read()
+    def __init__(self, includes: Dict[str, PolicyDict]):
+        """
+        Args:
+            includes: A read-only mapping from include name to file_dict.
+        """
+        super().__init__('')
+        self.includes = includes
+
+    def _load_include_file(
+        self, relative_path: str, stack: list
+    ) -> Tuple[Optional[PolicyDict], str | pathlib.Path]:
+        """Override to load includes from the self.includes dictionary."""
+        return self.includes.get(relative_path), relative_path

--- a/tests/lib/yaml_test.py
+++ b/tests/lib/yaml_test.py
@@ -522,7 +522,7 @@ Include stack:
         )
         self.assertEqual(
             str(user_message),
-            """Policy include source include_1.pol must end in ".yaml". File=include_1.yaml, Line=3.
+            """Policy include source include_1.pol must end in ".yaml" or ".yml". File=include_1.yaml, Line=3.
 Include stack:
 > File='policy_with_include.yaml', Line=10 (Top Level)
 > File='include_1.yaml', Line=3""",  # noqa: E501
@@ -545,7 +545,7 @@ Include stack:
         )
         self.assertEqual(
             str(user_message),
-            """Policy include source include_1.pol must end in ".yaml". File=policy_with_include.yaml, Line=3.""",  # noqa: E501
+            """Policy include source include_1.pol must end in ".yaml" or ".yml". File=policy_with_include.yaml, Line=3.""",  # noqa: E501
         )
 
     def testIncludeInvalidPath(self):

--- a/tests/regression/yaml/yaml_regression_test.py
+++ b/tests/regression/yaml/yaml_regression_test.py
@@ -181,7 +181,7 @@ filters:
 
 
 @mock.patch.object(yaml_frontend.logging, "warning")
-@mock.patch.object(yaml_frontend, "_LoadIncludeFile")
+@mock.patch('aerleon.lib.yaml.open', new_callable=mock.mock_open)
 class YAMLPolicyTermTest(absltest.TestCase):
     def setUp(self):
         super().setUp()
@@ -192,8 +192,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
     # Positive tests from policy_test.py #
     ######################################
     @capture.stdout
-    def testGoodPol(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodPol(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-1
           protocol: icmp
           action: accept
@@ -225,8 +225,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetNetAddr.assert_called_once_with('PROD_NETWORK')
 
     @capture.stdout
-    def testService(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testService(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-1
           protocol: icmp
           action: accept
@@ -257,8 +257,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SMTP', 'tcp')
 
     @capture.stdout
-    def testNumericProtocol(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testNumericProtocol(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-4
           protocol: 1
           action: accept
@@ -275,8 +275,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].protocol[0]), '1')
 
     @capture.stdout
-    def testHopLimitSingle(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testHopLimitSingle(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-v6-1
           hop-limit: 5
           action: accept
@@ -293,8 +293,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].hop_limit[0]), '5')
 
     @capture.stdout
-    def testHopLimitRange(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testHopLimitRange(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-v6-2
           hop-limit: 5-7
           action: accept
@@ -312,8 +312,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].hop_limit[2]), '7')
 
     @capture.stdout
-    def testMinimumTerm(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testMinimumTerm(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-5
           action: accept
         """
@@ -331,8 +331,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].action[0]), 'accept')
 
     @capture.stdout
-    def testMinimumTerm2(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testMinimumTerm2(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-9
           comment: |
             first comment
@@ -352,8 +352,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].comment[1]), 'second comment')
 
     @capture.stdout
-    def testLogNameTerm(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testLogNameTerm(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-37
           protocol: icmp
           log-name: my special prefix
@@ -371,8 +371,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].log_name), 'my special prefix')
 
     @capture.stdout
-    def testPortCollapsing(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testPortCollapsing(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-6
           protocol: tcp
           destination-port: MYSQL HIGH_PORTS
@@ -396,8 +396,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testPortCollapsing2(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testPortCollapsing2(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-8
           protocol: tcp udp
           destination-port: DNS
@@ -420,8 +420,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testTermEquality(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testTermEquality(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-19
           source-port: HTTP MYSQL
           destination-address: PROD_EXTERNAL_SUPER PROD_NETWORK
@@ -512,8 +512,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodDestAddrExcludes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodDestAddrExcludes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-7
           protocol: tcp
           destination-address: PROD_NETWORK
@@ -539,8 +539,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodSrcAddrExcludes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodSrcAddrExcludes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-26
           protocol: tcp
           source-address: PROD_NETWORK
@@ -566,8 +566,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodAddrExcludes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodAddrExcludes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-27
           protocol: tcp
           address: PROD_NETWORK
@@ -593,8 +593,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodAddrExcludesFlatten(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodAddrExcludesFlatten(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-27
           protocol: tcp
           address: PROD_NETWORK
@@ -638,8 +638,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodAddrExcludesFlattenMultiple(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodAddrExcludesFlattenMultiple(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-27
           protocol: tcp
           address: PROD_NETWORK
@@ -673,8 +673,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testGoodAddrExcludesFlattenAll(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGoodAddrExcludesFlattenAll(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-27
           protocol: tcp
           address: PROD_NETWORK
@@ -705,8 +705,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testLogging(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testLogging(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-10
           logging: true
           action: accept
@@ -723,8 +723,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(str(terms[0].logging[0]), 'true')
 
     @capture.stdout
-    def testICMPTypes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testICMPTypes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-10
           protocol: icmp
           icmp-type: echo-reply echo-request unreachable
@@ -742,8 +742,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].icmp_type[0], 'echo-reply')
 
     @capture.stdout
-    def testICMPTypesSorting(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testICMPTypesSorting(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-11
           protocol: icmp
           icmp-type: unreachable echo-request echo-reply
@@ -761,8 +761,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertIn(expected, str(pol))
 
     @capture.stdout
-    def testICMPCodesSorting(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testICMPCodesSorting(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-11
           icmp-type: unreachable
           icmp-code: 15 4 9 1
@@ -778,8 +778,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertIn('icmp_code: [1, 4, 9, 15]', str(pol))
 
     @capture.stdout
-    def testReservedWordTermName(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testReservedWordTermName(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: qos-good-term-12
           action: accept
           qos: af4
@@ -797,8 +797,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].name, 'qos-good-term-12')
 
     @capture.stdout
-    def testMultiPortLines(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testMultiPortLines(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-13
           source-port: GOOGLE_PUBLIC SNMP
           protocol: udp
@@ -821,8 +821,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testSourcePrefixList(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testSourcePrefixList(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-14
           source-prefix: foo_prefix_list
           action: accept
@@ -839,8 +839,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].source_prefix, ['foo_prefix_list'])
 
     @capture.stdout
-    def testDestinationPrefixList(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testDestinationPrefixList(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-15
           destination-prefix: bar_prefix_list baz_prefix_list
           action: accept
@@ -857,8 +857,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].destination_prefix, ['bar_prefix_list', 'baz_prefix_list'])
 
     @capture.stdout
-    def testSourcePrefixListExcept(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testSourcePrefixListExcept(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-38
           source-prefix-except: foo_prefix_list
           action: accept
@@ -875,8 +875,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].source_prefix_except, ['foo_prefix_list'])
 
     @capture.stdout
-    def testDestinationPrefixListExcept(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testDestinationPrefixListExcept(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-39
           destination-prefix-except: bar_prefix_list baz_prefix_list
           action: accept
@@ -895,8 +895,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
 
     @capture.stdout
-    def testSourcePrefixListMixed(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testSourcePrefixListMixed(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-38
           source-prefix: foo_prefix_list
           source-prefix-except: foo_prefix_list_except
@@ -915,8 +915,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].source_prefix_except, ['foo_prefix_list_except'])
 
     @capture.stdout
-    def testDestinationPrefixListMixed(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testDestinationPrefixListMixed(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-39
           destination-prefix: bar_prefix_list
           destination-prefix-except: bar_prefix_list_except
@@ -935,8 +935,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].destination_prefix_except, ['bar_prefix_list_except'])
 
     @capture.stdout
-    def testEtherTypes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testEtherTypes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-16
           ether-type: arp ipv4 vlan
           action: accept
@@ -955,8 +955,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].ether_type[2], 'vlan')
 
     @capture.stdout
-    def testTrafficTypes(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testTrafficTypes(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-17
           traffic-type: broadcast unknown-unicast multicast
           action: accept
@@ -975,8 +975,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].traffic_type[2], 'multicast')
 
     @capture.stdout
-    def testVerbatimTerm(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testVerbatimTerm(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-18
           comment: test verbatim output
           verbatim:
@@ -998,8 +998,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].verbatim[1][1], 'mary had another lamb')
 
     @capture.stdout
-    def testIntegerFilterName(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testIntegerFilterName(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-0
           protocol: icmp
           action: accept
@@ -1016,8 +1016,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(pol.headers[0].target[0].options[0], '50')
 
     @capture.stdout
-    def testPrecedence(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testPrecedence(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: precedence-term
           protocol: icmp
           precedence: 1
@@ -1035,8 +1035,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].precedence, [1])
 
     @capture.stdout
-    def testLossPriority(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testLossPriority(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: loss-priority-term
           source-port: SSH
           protocol: tcp
@@ -1057,8 +1057,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SSH', 'tcp')
 
     @capture.stdout
-    def testRoutingInstance(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testRoutingInstance(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: routing-instance-term
           source-port: SSH
           protocol: tcp
@@ -1079,8 +1079,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SSH', 'tcp')
 
     @capture.stdout
-    def testSourceInterface(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testSourceInterface(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: source-interface-term
           source-port: SSH
           protocol: tcp
@@ -1102,8 +1102,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetServiceByProto.assert_called_once_with('SSH', 'tcp')
 
     @capture.stdout
-    def testVpnConfigWithoutPairPolicy(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testVpnConfigWithoutPairPolicy(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-30
           protocol: tcp
           action: accept
@@ -1122,8 +1122,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual('', pol.filters[0][1][0].vpn[1])
 
     @capture.stdout
-    def testVpnConfigWithPairPolicy(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testVpnConfigWithPairPolicy(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-31
           protocol: tcp
           action: accept
@@ -1143,8 +1143,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual('policy-11', pol.filters[0][1][0].vpn[1])
 
     @capture.stdout
-    def testForwardingClassPolicy(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testForwardingClassPolicy(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-32
           forwarding-class: fritzy
           action: accept
@@ -1159,8 +1159,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(['fritzy'], pol.filters[0][1][0].forwarding_class)
 
     @capture.stdout
-    def testMultipleForwardingClassPolicy(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testMultipleForwardingClassPolicy(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-36
           forwarding-class: flashy fritzy
           action: accept
@@ -1175,8 +1175,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(['flashy', 'fritzy'], pol.filters[0][1][0].forwarding_class)
 
     @capture.stdout
-    def testForwardingClassEqual(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testForwardingClassEqual(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-32
           forwarding-class: fritzy
           action: accept
@@ -1197,8 +1197,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertNotEqual(terms[0], terms[1])
 
     @capture.stdout
-    def testTagSupportAndNetworkHeaderParsing(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testTagSupportAndNetworkHeaderParsing(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-34
           source-tag: src-tag
           destination-tag: dest-tag
@@ -1219,8 +1219,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(terms[0].destination_tag, ['dest-tag'])
 
     @capture.stdout
-    def testNextIP(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testNextIP(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-35
           source-address: PROD_NETWORK
           next-ip: NEXT_IP
@@ -1242,8 +1242,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetNetAddr.assert_has_calls([mock.call('PROD_NETWORK'), mock.call('NEXT_IP')])
 
     @capture.stdout
-    def testTermAddressByteLength(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testTermAddressByteLength(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-2
           protocol: tcp
           source-address: PROD_NETWORK
@@ -1269,8 +1269,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(10, term.AddressesByteLength())
 
     @capture.stdout
-    def testEncapsulate(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testEncapsulate(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-46
           protocol: icmp tcp udp gre esp ah sctp
           encapsulate: stuff_and_things
@@ -1285,8 +1285,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertIn('encapsulate: stuff_and_things', str(pol))
 
     @capture.stdout
-    def testPortMirror(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testPortMirror(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-47
           protocol: icmp tcp udp gre esp ah sctp
           port-mirror: true
@@ -1301,8 +1301,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertIn('port_mirror: true', str(pol))
 
     @capture.stdout
-    def testSrxGLobalZone(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testSrxGLobalZone(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-48
           protocol: icmp
           source-zone: zone1 zone2
@@ -1323,8 +1323,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertIn(expected_destination, str(pol))
 
     @capture.stdout
-    def testLogLimit(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testLogLimit(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-44
           logging: syslog
           log-limit: 999/day
@@ -1341,8 +1341,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual((u'999', u'day'), term.log_limit)
 
     @capture.stdout
-    def testTargetServiceAccount(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testTargetServiceAccount(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: good-term-45
           source-address: ANY
           action: accept
@@ -1359,8 +1359,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertEqual(['acct1@blah.com'], term.target_service_accounts)
 
     @capture.stdout
-    def testParsePolicyMultipleTargetResources(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testParsePolicyMultipleTargetResources(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: target-resource-term
           action: deny
           target-resources:
@@ -1391,23 +1391,23 @@ class YAMLPolicyTermTest(absltest.TestCase):
     # Negative tests from policy_test.py #
     ######################################
 
-    def testBadTermName(self, mock_open_include, _mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadTermName(self, mock_open, _mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term -name
           action: deny
         """
         self.assertTermRaises(TypeError)
 
-    def testBadKeyName(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadKeyName(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-2
           prootocol: tcp
           action: accept
         """
         self.assertTermWarns(mock_warn, regex="Unexpected term keyword")
 
-    def testBadPortProtocol(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadPortProtocol(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-3
           protocol: tcp
           source-port: SNMP
@@ -1416,31 +1416,31 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.naming.GetServiceByProto('SNMP', 'tcp').AndReturn([])
         self.assertTermRaises(policy.TermPortProtocolError)
 
-    def testBadPortProtocol2(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadPortProtocol2(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-4
           source-port: SNMP
           action: accept
         """
         self.assertTermRaises(policy.TermPortProtocolError)
 
-    def testBadLogging(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadLogging(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-6
           logging: unvalidloggingoption
           action: accept
         """
         self.assertTermRaises(policy.InvalidTermLoggingError)
 
-    def testBadAction(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadAction(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-7
           action: discard
         """
         self.assertTermRaises(policy.InvalidTermActionError)
 
-    def testBadProtocolEtherTypes(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadProtocolEtherTypes(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-9
           ether-type: arp
           protocol: udp
@@ -1448,8 +1448,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         """
         self.assertTermRaises(policy.TermProtocolEtherTypeError)
 
-    def testVerbatimMixed(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testVerbatimMixed(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-10
           verbatim:
             cisco: mary had a little lamb
@@ -1457,8 +1457,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         """
         self.assertTermRaises(policy.ParseError)
 
-    def testBadICMPTypes(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadICMPTypes(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-12
           protocol: icmp
           icmp-type: echo-foo packet-too-beaucoups
@@ -1466,8 +1466,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         """
         self.assertTermRaises(policy.TermInvalidIcmpType)
 
-    def testBadICMPCodes(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadICMPCodes(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-13
           protocol: icmp
           icmp-type: unreachable
@@ -1476,8 +1476,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         """
         self.assertTermRaises(policy.ICMPCodeError)
 
-    def testBadICMPCodes2(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testBadICMPCodes2(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-14
           protocol: icmp
           icmp-type: unreachable redirect
@@ -1486,16 +1486,16 @@ class YAMLPolicyTermTest(absltest.TestCase):
         """
         self.assertTermRaises(policy.ICMPCodeError)
 
-    def testInvalidTTL(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testInvalidTTL(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-15
           ttl: 300
           action: accept
         """
         self.assertTermRaises(policy.InvalidTermTTLValue)
 
-    def testGREandTCPUDPError(self, mock_open_include, mock_warn):
-        mock_open_include.return_value = """terms:
+    def testGREandTCPUDPError(self, mock_open, mock_warn):
+        mock_open.return_value.read.return_value = """terms:
         - name: bad-term-16
           destination-port: FOO
           protocol: tcp udp gre
@@ -1523,7 +1523,7 @@ class YAMLPolicyTermTest(absltest.TestCase):
         self.assertRegex(mock_warn.call_args[0][0], regex)
 
 
-@mock.patch.object(yaml_frontend, "_LoadIncludeFile")
+@mock.patch('aerleon.lib.yaml.open', new_callable=mock.mock_open)
 class YAMLRepresentationsTest(absltest.TestCase):
     """Ensure that equivalent representations produce identical policy models."""
 
@@ -1532,16 +1532,16 @@ class YAMLRepresentationsTest(absltest.TestCase):
         self.naming = mock.create_autospec(naming.Naming)
         self.base_dir = ""
 
-    def assertEqualPolicyModel(self, mock_open_include, term_list, other_term_list):
-        mock_open_include.return_value = term_list
+    def assertEqualPolicyModel(self, mock_open, term_list, other_term_list):
+        mock_open.return_value.read.return_value = term_list
         policy = yaml_frontend.ParsePolicy(
             YAML_POLICY_WITH_INCLUDE,
             filename="policy_test.pol.yaml",
             base_dir=self.base_dir,
             definitions=self.naming,
         )
-        mock_open_include.reset_mock()
-        mock_open_include.return_value = other_term_list
+        mock_open.reset_mock()
+        mock_open.return_value.read.return_value = other_term_list
         other_policy = yaml_frontend.ParsePolicy(
             YAML_POLICY_WITH_INCLUDE,
             filename="policy_test.pol.yaml",
@@ -1550,7 +1550,7 @@ class YAMLRepresentationsTest(absltest.TestCase):
         )
         self.assertEqual(policy, other_policy)
 
-    def testWordLists(self, mock_open_include):
+    def testWordLists(self, mock_open):
         src_addr_strlist = """terms:
         - name: source-addr-term
           source-addr: RESTRICTED BOGON 83.0.0.0/24
@@ -1566,7 +1566,7 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, src_addr_strlist, src_addr_list)
+        self.assertEqualPolicyModel(mock_open, src_addr_strlist, src_addr_list)
         src_addr_single = """terms:
         - name: source-addr-term
           source-addr: 83.0.0.0/24
@@ -1580,9 +1580,9 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, src_addr_single, src_addr_single_list)
+        self.assertEqualPolicyModel(mock_open, src_addr_single, src_addr_single_list)
 
-    def testYearMonthDay(self, mock_open_include):
+    def testYearMonthDay(self, mock_open):
         expiration_date = """terms:
         - name: expiration-term
           expiration: 2020-01-01
@@ -1595,9 +1595,9 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, expiration_date, expiration_str)
+        self.assertEqualPolicyModel(mock_open, expiration_date, expiration_str)
 
-    def testIntegerLists(self, mock_open_include):
+    def testIntegerLists(self, mock_open):
         precedence_strlist = """terms:
         - name: precedence-term
           precedence: 100 50
@@ -1612,7 +1612,7 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, precedence_strlist, precedence_list)
+        self.assertEqualPolicyModel(mock_open, precedence_strlist, precedence_list)
         single_int = """terms:
         - name: precedence-term
           precedence: 100
@@ -1632,10 +1632,10 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, single_int, single_str)
-        self.assertEqualPolicyModel(mock_open_include, single_int, single_list)
+        self.assertEqualPolicyModel(mock_open, single_int, single_str)
+        self.assertEqualPolicyModel(mock_open, single_int, single_list)
 
-    def testProtocol(self, mock_open_include):
+    def testProtocol(self, mock_open):
         protocol_mixed_list = """terms:
         - name: protocol-term
           protocol:
@@ -1650,7 +1650,7 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: 22 80 tcp 50
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, protocol_mixed_list, protocol_mixed_str)
+        self.assertEqualPolicyModel(mock_open, protocol_mixed_list, protocol_mixed_str)
         single_int = """terms:
         - name: protocol-term
           protocol: 22
@@ -1673,11 +1673,11 @@ class YAMLRepresentationsTest(absltest.TestCase):
           - "22"
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, single_int, single_int_list)
-        self.assertEqualPolicyModel(mock_open_include, single_int, single_int_str)
-        self.assertEqualPolicyModel(mock_open_include, single_int, single_int_list_str)
+        self.assertEqualPolicyModel(mock_open, single_int, single_int_list)
+        self.assertEqualPolicyModel(mock_open, single_int, single_int_str)
+        self.assertEqualPolicyModel(mock_open, single_int, single_int_list_str)
 
-    def testIntegerRanges(self, mock_open_include):
+    def testIntegerRanges(self, mock_open):
         hop_limit_single_int = """terms:
         - name: hop-limit-term
           hop-limit: 8
@@ -1691,7 +1691,7 @@ class YAMLRepresentationsTest(absltest.TestCase):
           action: deny
         """
         self.assertEqualPolicyModel(
-            mock_open_include, hop_limit_single_int, hop_limit_single_int_str
+            mock_open, hop_limit_single_int, hop_limit_single_int_str
         )
         hop_limit_range_nospace = """terms:
         - name: hop-limit-term
@@ -1706,10 +1706,10 @@ class YAMLRepresentationsTest(absltest.TestCase):
           action: deny
         """
         self.assertEqualPolicyModel(
-            mock_open_include, hop_limit_range_nospace, hop_limit_range_spaces
+            mock_open, hop_limit_range_nospace, hop_limit_range_spaces
         )
 
-    def testLogging(self, mock_open_include):
+    def testLogging(self, mock_open):
         logging_bool_lower = """terms:
         - name: logging-term
           logging: "true"
@@ -1722,9 +1722,9 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, logging_bool_lower, logging_bool_bool)
+        self.assertEqualPolicyModel(mock_open, logging_bool_lower, logging_bool_bool)
 
-    def testLogLimit(self, mock_open_include):
+    def testLogLimit(self, mock_open):
         log_limit_nospace = """terms:
         - name: log-limit-term
           log-limit: 1000/day
@@ -1737,9 +1737,9 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, log_limit_nospace, log_limit_spaces)
+        self.assertEqualPolicyModel(mock_open, log_limit_nospace, log_limit_spaces)
 
-    def testFlexMatchRange(self, mock_open_include):
+    def testFlexMatchRange(self, mock_open):
         flexmatch_normal = """terms:
         - name: flexible-match-range-term
           flexible-match-range:
@@ -1758,9 +1758,9 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, flexmatch_normal, flexmatch_str)
+        self.assertEqualPolicyModel(mock_open, flexmatch_normal, flexmatch_str)
 
-    def testTuples(self, mock_open_include):
+    def testTuples(self, mock_open):
         tuple_inline_list = """terms:
         - name: target-resources-term
           target-resources: ["(proj1,vpc1)","(proj2,vpc2)"]
@@ -1783,8 +1783,8 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, tuple_inline_list, tuple_splay_list)
-        self.assertEqualPolicyModel(mock_open_include, tuple_inline_list, tuple_splay_list_noparen)
+        self.assertEqualPolicyModel(mock_open, tuple_inline_list, tuple_splay_list)
+        self.assertEqualPolicyModel(mock_open, tuple_inline_list, tuple_splay_list_noparen)
 
         tuple_single_str = """terms:
         - name: target-resources-term
@@ -1805,8 +1805,8 @@ class YAMLRepresentationsTest(absltest.TestCase):
           protocol: icmp
           action: deny
         """
-        self.assertEqualPolicyModel(mock_open_include, tuple_single_str, tuple_single_inline_list)
-        self.assertEqualPolicyModel(mock_open_include, tuple_single_str, tuple_single_splay_list)
+        self.assertEqualPolicyModel(mock_open, tuple_single_str, tuple_single_inline_list)
+        self.assertEqualPolicyModel(mock_open, tuple_single_str, tuple_single_splay_list)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**New Features**

Adds support for includes in policies processed by the `Generate` API through new optional parameters: `include_path` and `includes`.
* If `include_path` is provided, `include` directives in user policies may reference YAML files within include_path. A strict subpath check is performed on user `include` directives to prevent access to files outside of include_path via symlinks or relative paths. Additionally only files ending in .yaml or .yml may be used as include targets.
* If `includes` is provided (a dictionary of names mapping to includable PolicyDicts), user `include` directives will refer to values in the `includes` dictionary only. No filesystem access is performed with this option.
* If neither option is given, the `Generate` API maintains its current behavior which is to raise an error when processing a policy with an `include` directive.
* `include_path` and `includes` are mutually exclusive.
