### PR TITLE
Kyleomalley/nvueapi: Add nvueapi generator  #410 

### DIFF
--- a/aerleon/lib/nvueapi.py
+++ b/aerleon/lib/nvueapi.py
@@ -1,0 +1,434 @@
+# Copyright 2025 Aerleon Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVIDIA NVUE API generator.
+
+Generates ACL configurations for NVIDIA Cumulus Linux switches using the
+NVUE (NVIDIA User Experience) REST API JSON format.
+
+More information about NVUE:
+https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-55/System-Configuration/NVIDIA-User-Experience-NVUE/
+"""
+
+import json
+from typing import Dict, List
+
+try:
+    from absl import logging
+except ImportError:
+    import logging
+
+from aerleon.lib import aclgenerator, policy
+
+_ACTION_TABLE = {
+    'accept': 'permit',
+    'deny': 'deny',
+    'reject': 'deny',
+    'next': 'permit',  # NVUE doesn't have explicit 'next', treat as permit
+}
+
+_PROTO_TABLE = {
+    'icmp': 'icmp',
+    'icmpv6': 'icmpv6',
+    'tcp': 'tcp',
+    'udp': 'udp',
+    'esp': 'esp',
+    'ah': 'ah',
+    'gre': 'gre',
+    'ipv6-icmp': 'icmpv6',
+    'sctp': 'sctp',
+}
+
+
+class Error(aclgenerator.Error):
+    """Base error class for NVUE generator."""
+
+
+class NvueApiError(Error):
+    """Raised when there's an error generating NVUE API config."""
+
+
+class UnsupportedNvueFilterError(Error):
+    """Raised when we can't create the requested acl."""
+
+
+class Term(aclgenerator.Term):
+    """Representation of an individual NVUE ACL rule."""
+
+    _PLATFORM = 'nvueapi'
+
+    def __init__(self, term: policy.Term, address_family: str = 'ipv4'):
+        """Initialize NVUE term.
+
+        Args:
+            term: The policy term object
+            address_family: 'ipv4' or 'ipv6'
+        """
+        super().__init__(term)
+        self.term = term
+        self.address_family = address_family
+
+    def __str__(self) -> str:
+        """Convert term to NVUE JSON rule format."""
+        # This should not be called directly - use GenerateRules() instead
+        # which handles the cartesian product of multiple addresses
+        raise NotImplementedError("Use GenerateRules() method instead")
+
+    def GenerateRules(self) -> List[Dict]:
+        """Generate NVUE rules handling multiple addresses.
+
+        Since NVUE only supports single CIDR prefixes per rule (like iptables),
+        we need to create separate rules for each combination of addresses.
+
+        Returns:
+            List of rule dictionaries
+        """
+        rules = []
+
+        # Get address lists for this address family
+        source_addrs = self._GetFilteredAddresses(self.term.source_address)
+        dest_addrs = self._GetFilteredAddresses(self.term.destination_address)
+
+        # If no addresses specified, use empty list to generate one rule
+        if not source_addrs:
+            source_addrs = [None]
+        if not dest_addrs:
+            dest_addrs = [None]
+
+        # Get other rule components
+        protocols = self._GetProtocols()
+        dest_ports = self._GetPorts(self.term.destination_port)
+        source_ports = self._GetPorts(self.term.source_port)
+        icmp_types = self._GetIcmpTypes()
+
+        # Generate cartesian product of all combinations
+        for src_addr in source_addrs:
+            for dst_addr in dest_addrs:
+                for protocol in protocols:
+                    for dest_port in dest_ports:
+                        for source_port in source_ports:
+                            for icmp_type in icmp_types:
+                                rule_dict = self._CreateSingleRule(
+                                    src_addr, dst_addr, protocol,
+                                    dest_port, source_port, icmp_type
+                                )
+                                if rule_dict:  # Only add non-empty rules
+                                    rules.append(rule_dict)
+
+        return rules
+
+    def _GetFilteredAddresses(self, addresses):
+        """Get addresses filtered by address family."""
+        if not addresses:
+            return []
+
+        filtered = []
+        for addr in addresses:
+            if addr.version == 4 and self.address_family == 'ipv4':
+                filtered.append(str(addr))
+            elif addr.version == 6 and self.address_family == 'ipv6':
+                filtered.append(str(addr))
+        return filtered
+
+    def _GetProtocols(self):
+        """Get protocol list."""
+        if not self.term.protocol:
+            return [None]
+        return [_PROTO_TABLE.get(p, p) for p in self.term.protocol]
+
+    def _GetPorts(self, port_list):
+        """Get port list in NVUE format (porta:portz)."""
+        if not port_list:
+            return [None]
+
+        ports = []
+        for port_range in port_list:
+            if port_range[0] == port_range[1]:
+                ports.append(str(port_range[0]))
+            else:
+                # NVUE uses porta:portz format for ranges
+                ports.append(f"{port_range[0]}:{port_range[1]}")
+        return ports
+
+    def _GetIcmpTypes(self):
+        """Get ICMP type list."""
+        if not self.term.icmp_type:
+            return [None]
+
+        icmp_types = []
+        for icmp_type in self.term.icmp_type:
+            # Convert from Aerleon format to iptables format if needed
+            if icmp_type == 'echo-reply':
+                icmp_types.append('echo-reply')
+            elif icmp_type == 'echo-request':
+                icmp_types.append('echo-request')
+            elif icmp_type == 'unreachable':
+                icmp_types.append('destination-unreachable')
+            elif icmp_type == 'time-exceeded':
+                icmp_types.append('time-exceeded')
+            else:
+                icmp_types.append(icmp_type)  # Use as-is for other types
+        return icmp_types
+
+    def _CreateSingleRule(self, src_addr, dst_addr, protocol, dest_port, source_port, icmp_type):
+        """Create a single NVUE rule."""
+        rule_dict = {}
+
+        # Set action - NVUE uses object format with empty dict values
+        action_dict = {}
+        
+        # Handle primary action
+        if self.term.action:
+            action = self.term.action[0]
+            nvue_action = _ACTION_TABLE.get(action, action)
+            action_dict[nvue_action] = {}
+        
+        # Add logging if specified
+        if self.term.logging:
+            action_dict['log'] = {}
+        
+        # If no actions specified, default to permit
+        if not action_dict:
+            action_dict['permit'] = {}
+            
+        rule_dict['action'] = action_dict
+
+        # Set remark/comment
+        if self.term.comment:
+            rule_dict['remark'] = ' '.join(self.term.comment)
+
+        # Set match conditions
+        match_dict = {}
+        ip_dict = {}
+
+        # Protocol matching
+        if protocol:
+            ip_dict['protocol'] = protocol
+
+        # Source IP matching
+        if src_addr:
+            ip_dict['source-ip'] = src_addr
+
+        # Destination IP matching
+        if dst_addr:
+            ip_dict['dest-ip'] = dst_addr
+
+        # Destination port matching
+        if dest_port:
+            ip_dict['dest-port'] = dest_port
+
+        # Source port matching
+        if source_port:
+            ip_dict['source-port'] = source_port
+
+        # ICMP type matching
+        if icmp_type and protocol == 'icmp' and self.address_family == 'ipv4':
+            ip_dict['icmp-type'] = icmp_type
+        elif icmp_type and protocol == 'icmpv6' and self.address_family == 'ipv6':
+            ip_dict['icmpv6-type'] = icmp_type
+
+        # TCP state matching for NVUE
+        tcp_dict = {}
+        if protocol == 'tcp' and self.term.option:
+            for option in self.term.option:
+                if option in ['established', 'tcp-established']:
+                    tcp_dict['state'] = 'established'
+                    break
+
+        # Add IP match conditions if any exist
+        if ip_dict:
+            match_dict['ip'] = ip_dict
+            
+        # Add TCP conditions if any exist (at same level as ip)
+        if tcp_dict:
+            match_dict['tcp'] = tcp_dict
+
+        # Add match conditions if any exist
+        if match_dict:
+            rule_dict['match'] = match_dict
+
+        return rule_dict
+
+
+class NvueApi(aclgenerator.ACLGenerator):
+    """NVUE API generator class."""
+
+    _PLATFORM = 'nvueapi'
+    _DEFAULT_PROTOCOL = 'ip'
+    _SUFFIX = '.json'
+    SUPPORTED_AF = set(['inet', 'inet6'])
+    SUPPORTED_TARGETS = frozenset(['nvueapi'])
+    WARN_IF_UNSUPPORTED = frozenset([])
+
+    def __init__(self, policy_obj: policy.Policy, exp_info: int) -> None:
+        """Initialize NVUE API generator.
+
+        Args:
+            policy_obj: The policy object
+            exp_info: Expiration info integer
+        """
+        self.nvue_policies = []
+        self.address_family = None
+        super().__init__(policy_obj, exp_info)
+
+    def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
+        """Translate policy to NVUE format.
+
+        Args:
+            pol: The policy object
+            exp_info: Expiration info
+        """
+        self.nvue_policies = []
+
+        for header, terms in pol.filters:
+            if self._PLATFORM not in [x.platform for x in header.target]:
+                continue
+
+            filter_options = header.FilterOptions(self._PLATFORM)[1]
+            filter_name = header.FilterName(self._PLATFORM)
+
+            # Determine address family from filter options
+            # NVUE supports ipv4, ipv6, or mac, but Aerleon only supports IP-based ACLs
+            if 'ipv6' in filter_options:
+                self.address_family = 'ipv6'
+            elif 'inet6' in filter_options:
+                self.address_family = 'ipv6'
+            elif 'mac' in filter_options:
+                raise UnsupportedNvueFilterError(
+                    'NVUE MAC ACLs are not supported by Aerleon. '
+                    'Aerleon only supports IP-based access control.')
+            elif 'mixed' in filter_options:
+                raise UnsupportedNvueFilterError(
+                    'NVUE does not support mixed address family ACLs. '
+                    'Use separate ipv4 and ipv6 ACLs instead.')
+            else:
+                self.address_family = 'ipv4'
+
+            # Build NVUE ACL structure
+            acl_rules = {}
+            rule_number = 10  # Start rule numbering at 10, increment by 10
+
+            for term in terms:
+                if term.expiration:
+                    if term.expiration <= exp_info:
+                        logging.info('INFO: Term %s in policy %s expires '
+                                   'in less than two weeks.', term.name, filter_name)
+                    if term.expiration <= exp_info:
+                        logging.warning('WARNING: Term %s in policy %s is expired and '
+                                      'will not be rendered.', term.name, filter_name)
+                        continue
+
+                # Handle address family filtering
+                if self.address_family == 'ipv4':
+                    # Skip terms that only have IPv6 addresses
+                    has_ipv4 = self._HasIPv4(term)
+                    if not has_ipv4:
+                        continue
+                elif self.address_family == 'ipv6':
+                    # Skip terms that only have IPv4 addresses
+                    has_ipv6 = self._HasIPv6(term)
+                    if not has_ipv6:
+                        continue
+
+                # Generate rules for this term (may be multiple due to address expansion)
+                nvue_term = Term(term, self.address_family)
+                term_rules = nvue_term.GenerateRules()
+
+                for rule_dict in term_rules:
+                    if rule_dict:  # Only add non-empty rules
+                        acl_rules[str(rule_number)] = rule_dict
+                        rule_number += 10
+
+            # Create the full ACL structure
+            acl_config = {
+                'acl': {
+                    filter_name: {
+                        'type': self.address_family,
+                        'rule': acl_rules
+                    }
+                }
+            }
+
+            self.nvue_policies.append((filter_name, acl_config))
+
+    def _HasIPv4(self, term: policy.Term) -> bool:
+        """Check if term has IPv4 addresses."""
+        for addr_list in [term.source_address, term.destination_address]:
+            if addr_list:
+                for addr in addr_list:
+                    if addr.version == 4:
+                        return True
+        return True  # Allow terms without addresses
+
+    def _HasIPv6(self, term: policy.Term) -> bool:
+        """Check if term has IPv6 addresses."""
+        for addr_list in [term.source_address, term.destination_address]:
+            if addr_list:
+                for addr in addr_list:
+                    if addr.version == 6:
+                        return True
+        return True  # Allow terms without addresses
+
+    def __str__(self) -> str:
+        """Return the NVUE configuration as a JSON string."""
+        if not self.nvue_policies:
+            return ''
+
+        # Combine all ACL configurations
+        acl_config = {}
+
+        for _, policy_config in self.nvue_policies:
+            acl_config.update(policy_config['acl'])
+
+        # Wrap in NVUE 'set:' structure to match actual device format
+        nvue_config = {
+            'set': {
+                'acl': acl_config
+            }
+        }
+
+        return json.dumps(nvue_config, indent=2)
+
+    def _BuildTokens(self):
+        """Build supported tokens for the platform."""
+        supported_tokens, supported_sub_tokens = super()._BuildTokens()
+
+        # Add NVUE-specific tokens
+        supported_tokens |= {
+            'action',
+            'comment',
+            'destination_address',
+            'destination_port',
+            'icmp_type',     # Now supported for IPv4 and IPv6
+            'logging',       # NVUE supports logging as 'log' action
+            'name',
+            'option',        # For TCP established state
+            'protocol',
+            'source_address',
+            'source_port',
+            'translated',    # obj attribute, not token
+        }
+
+        # Remove unsupported tokens
+        supported_tokens -= {
+            'verbatim',      # NVUE doesn't support verbatim rules
+            'icmp_code',     # Not implemented yet
+        }
+
+        # NVUE-specific sub-tokens
+        supported_sub_tokens = {
+            'action': {'accept', 'deny', 'reject', 'next'},
+        }
+
+        return supported_tokens, supported_sub_tokens

--- a/aerleon/lib/nvueapi.py
+++ b/aerleon/lib/nvueapi.py
@@ -298,7 +298,7 @@ class NvueApi(aclgenerator.ACLGenerator):
 
     _PLATFORM = 'nvueapi'
     _DEFAULT_PROTOCOL = 'ip'
-    SUFFIX = '.json'
+    SUFFIX = '_nvueapi.json'
     SUPPORTED_AF = set(['inet', 'inet6'])
     SUPPORTED_TARGETS = frozenset(['nvueapi'])
     WARN_IF_UNSUPPORTED = frozenset(['translated', 'stateless_reply', 'counter', 'policer'])

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -39,6 +39,7 @@ Plug-in authors may observe that this module exposes its internal state
 directly on the module for transparency. These names should be treated as
 undocumented and subject to change.
 """
+
 from __future__ import annotations
 
 import importlib.util

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -119,6 +119,7 @@ BUILTIN_GENERATORS: list[Tuple] = [
     ('ciscoxr',              'aerleon.lib.ciscoxr',              'CiscoXR'),
     ('nftables',             'aerleon.lib.nftables',             'Nftables'),
     ('nokiasrl',             'aerleon.lib.nokiasrl',             'NokiaSRLinux'),
+    ('nvueapi',              'aerleon.lib.nvueapi',              'NvueApi'),
     ('gce',                  'aerleon.lib.gce',                  'GCE'),
     ('gcp_hf',               'aerleon.lib.gcp_hf',               'HierarchicalFirewall'),
     ('paloalto',             'aerleon.lib.paloaltofw',           'PaloAltoFW'),

--- a/docs/reference/generators.md
+++ b/docs/reference/generators.md
@@ -1182,6 +1182,61 @@ targets:
 
 ***
 
+## NVUE API
+
+### Header Format
+
+The NVUE API header designation has the following format:
+
+```yaml
+targets:
+    nvueapi: [filter name] {ipv4|ipv6}
+```
+
+* _filter name_: defines the name of the NVUE ACL.
+* _ipv4_: specifies that the resulting filter should only render IPv4 addresses. This is the default format.
+* _ipv6_: specifies that the resulting filter should only render IPv6 addresses.
+
+The NVUE API generator produces JSON configuration for NVIDIA Cumulus Linux switches using the NVUE (NVIDIA User Experience) REST API format. This generator follows iptables patterns for multiple address expansion, creating separate rules for each combination of source and destination addresses.
+
+### Term Format
+
+* for common keys see the [common](#common) section above.
+
+* _logging_: Specify that this packet should be logged via syslog.
+* _option_: Supports TCP state matching with 'tcp-established' option.
+
+### Sub Tokens
+
+### Actions
+
+* _accept_
+* _deny_
+* _reject_
+
+### Option
+
+* _tcp-established_: Only match established tcp connections, based on stateful match or TCP flags.
+
+### Supported Features
+
+* IPv4 and IPv6 address families (separate ACLs)
+* TCP, UDP, ICMP, and ICMPv6 protocols
+* Source and destination address matching (single CIDR per rule)
+* Source and destination port matching (ranges supported in porta:portz format)
+* ICMP type matching (converted to iptables format)
+* TCP state matching (established connections)
+* Action logging
+
+### Limitations
+
+* Does not support address exclusions (source-address-exclude, destination-address-exclude)
+* Does not support MAC address filtering rules
+* Does not support mixed address family ACLs (use separate IPv4 and IPv6 ACLs)
+
+
+***
+
 ## NSXt
 
 ### Header Format

--- a/tests/regression/nvueapi/NvueApiTest.testGenericTerm.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testGenericTerm.stdout.ref
@@ -1,0 +1,37 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "DNS access from corp.",
+            "match": {
+              "ip": {
+                "protocol": "udp",
+                "source-ip": "10.2.3.4/32",
+                "dest-port": "53"
+              }
+            }
+          },
+          "20": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "DNS access from corp.",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.2.3.4/32",
+                "dest-port": "53"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testGenericTerm.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testGenericTerm.stdout.ref
@@ -1,33 +1,31 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "DNS access from corp.",
-            "match": {
-              "ip": {
-                "protocol": "udp",
-                "source-ip": "10.2.3.4/32",
-                "dest-port": "53"
-              }
-            }
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
           },
-          "20": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "DNS access from corp.",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.2.3.4/32",
-                "dest-port": "53"
-              }
+          "remark": "DNS access from corp.",
+          "match": {
+            "ip": {
+              "protocol": "udp",
+              "source-ip": "10.2.3.4/32",
+              "dest-port": "53"
+            }
+          }
+        },
+        "20": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "DNS access from corp.",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.2.3.4/32",
+              "dest-port": "53"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testIPv6Term.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIPv6Term.stdout.ref
@@ -1,20 +1,18 @@
 {
-  "set": {
-    "acl": {
-      "test-filter-v6": {
-        "type": "ipv6",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "Allow IPv6 traffic.",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "2001:4860:8000::5/128",
-                "dest-port": "80"
-              }
+  "acl": {
+    "test-filter-v6": {
+      "type": "ipv6",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "Allow IPv6 traffic.",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "2001:4860:8000::5/128",
+              "dest-port": "80"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testIPv6Term.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIPv6Term.stdout.ref
@@ -1,0 +1,24 @@
+{
+  "set": {
+    "acl": {
+      "test-filter-v6": {
+        "type": "ipv6",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow IPv6 traffic.",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "2001:4860:8000::5/128",
+                "dest-port": "80"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testIcmpTerm.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIcmpTerm.stdout.ref
@@ -1,0 +1,23 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "ICMP echo-request",
+            "match": {
+              "ip": {
+                "protocol": "icmp",
+                "icmp-type": "echo-request"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testIcmpTerm.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIcmpTerm.stdout.ref
@@ -1,19 +1,17 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "ICMP echo-request",
-            "match": {
-              "ip": {
-                "protocol": "icmp",
-                "icmp-type": "echo-request"
-              }
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "ICMP echo-request",
+          "match": {
+            "ip": {
+              "protocol": "icmp",
+              "icmp-type": "echo-request"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testIcmpv6Term.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIcmpv6Term.stdout.ref
@@ -1,19 +1,17 @@
 {
-  "set": {
-    "acl": {
-      "test-filter-v6": {
-        "type": "ipv6",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "ICMPv6 echo-request",
-            "match": {
-              "ip": {
-                "protocol": "icmpv6",
-                "icmpv6-type": "echo-request"
-              }
+  "acl": {
+    "test-filter-v6": {
+      "type": "ipv6",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "ICMPv6 echo-request",
+          "match": {
+            "ip": {
+              "protocol": "icmpv6",
+              "icmpv6-type": "echo-request"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testIcmpv6Term.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testIcmpv6Term.stdout.ref
@@ -1,0 +1,23 @@
+{
+  "set": {
+    "acl": {
+      "test-filter-v6": {
+        "type": "ipv6",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "ICMPv6 echo-request",
+            "match": {
+              "ip": {
+                "protocol": "icmpv6",
+                "icmpv6-type": "echo-request"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testLogAction.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testLogAction.stdout.ref
@@ -1,16 +1,14 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {},
-              "log": {}
-            },
-            "remark": "Log all traffic"
-          }
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {},
+            "log": {}
+          },
+          "remark": "Log all traffic"
         }
       }
     }

--- a/tests/regression/nvueapi/NvueApiTest.testLogAction.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testLogAction.stdout.ref
@@ -1,0 +1,18 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {},
+              "log": {}
+            },
+            "remark": "Log all traffic"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testMultipleAddresses.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testMultipleAddresses.stdout.ref
@@ -1,0 +1,67 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow HTTP from multiple clients to multiple servers",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.0.1.0/24",
+                "dest-ip": "192.168.1.10/32",
+                "dest-port": "80"
+              }
+            }
+          },
+          "20": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow HTTP from multiple clients to multiple servers",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.0.1.0/24",
+                "dest-ip": "192.168.1.20/32",
+                "dest-port": "80"
+              }
+            }
+          },
+          "30": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow HTTP from multiple clients to multiple servers",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.0.2.0/24",
+                "dest-ip": "192.168.1.10/32",
+                "dest-port": "80"
+              }
+            }
+          },
+          "40": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow HTTP from multiple clients to multiple servers",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.0.2.0/24",
+                "dest-ip": "192.168.1.20/32",
+                "dest-port": "80"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testMultipleAddresses.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testMultipleAddresses.stdout.ref
@@ -1,63 +1,61 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "Allow HTTP from multiple clients to multiple servers",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.0.1.0/24",
-                "dest-ip": "192.168.1.10/32",
-                "dest-port": "80"
-              }
-            }
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
           },
-          "20": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "Allow HTTP from multiple clients to multiple servers",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.0.1.0/24",
-                "dest-ip": "192.168.1.20/32",
-                "dest-port": "80"
-              }
+          "remark": "Allow HTTP from multiple clients to multiple servers",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.0.1.0/24",
+              "dest-ip": "192.168.1.10/32",
+              "dest-port": "80"
             }
+          }
+        },
+        "20": {
+          "action": {
+            "permit": {}
           },
-          "30": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "Allow HTTP from multiple clients to multiple servers",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.0.2.0/24",
-                "dest-ip": "192.168.1.10/32",
-                "dest-port": "80"
-              }
+          "remark": "Allow HTTP from multiple clients to multiple servers",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.0.1.0/24",
+              "dest-ip": "192.168.1.20/32",
+              "dest-port": "80"
             }
+          }
+        },
+        "30": {
+          "action": {
+            "permit": {}
           },
-          "40": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "Allow HTTP from multiple clients to multiple servers",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.0.2.0/24",
-                "dest-ip": "192.168.1.20/32",
-                "dest-port": "80"
-              }
+          "remark": "Allow HTTP from multiple clients to multiple servers",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.0.2.0/24",
+              "dest-ip": "192.168.1.10/32",
+              "dest-port": "80"
+            }
+          }
+        },
+        "40": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "Allow HTTP from multiple clients to multiple servers",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.0.2.0/24",
+              "dest-ip": "192.168.1.20/32",
+              "dest-port": "80"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testMultipleTerms.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testMultipleTerms.stdout.ref
@@ -1,54 +1,52 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "DNS access from corp.",
-            "match": {
-              "ip": {
-                "protocol": "udp",
-                "source-ip": "10.2.3.4/32",
-                "dest-port": "53"
-              }
-            }
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
           },
-          "20": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "DNS access from corp.",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.2.3.4/32",
-                "dest-port": "53"
-              }
+          "remark": "DNS access from corp.",
+          "match": {
+            "ip": {
+              "protocol": "udp",
+              "source-ip": "10.2.3.4/32",
+              "dest-port": "53"
             }
-          },
-          "30": {
-            "action": {
-              "permit": {}
-            },
-            "remark": "HTTP access from corp.",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "source-ip": "10.2.3.4/32",
-                "dest-port": "80"
-              }
-            }
-          },
-          "40": {
-            "action": {
-              "deny": {}
-            },
-            "remark": "Default deny rule."
           }
+        },
+        "20": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "DNS access from corp.",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.2.3.4/32",
+              "dest-port": "53"
+            }
+          }
+        },
+        "30": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "HTTP access from corp.",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "source-ip": "10.2.3.4/32",
+              "dest-port": "80"
+            }
+          }
+        },
+        "40": {
+          "action": {
+            "deny": {}
+          },
+          "remark": "Default deny rule."
         }
       }
     }

--- a/tests/regression/nvueapi/NvueApiTest.testMultipleTerms.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testMultipleTerms.stdout.ref
@@ -1,0 +1,56 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "DNS access from corp.",
+            "match": {
+              "ip": {
+                "protocol": "udp",
+                "source-ip": "10.2.3.4/32",
+                "dest-port": "53"
+              }
+            }
+          },
+          "20": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "DNS access from corp.",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.2.3.4/32",
+                "dest-port": "53"
+              }
+            }
+          },
+          "30": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "HTTP access from corp.",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "source-ip": "10.2.3.4/32",
+                "dest-port": "80"
+              }
+            }
+          },
+          "40": {
+            "action": {
+              "deny": {}
+            },
+            "remark": "Default deny rule."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/NvueApiTest.testTcpEstablished.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testTcpEstablished.stdout.ref
@@ -1,22 +1,20 @@
 {
-  "set": {
-    "acl": {
-      "test-filter": {
-        "type": "ipv4",
-        "rule": {
-          "10": {
-            "action": {
-              "permit": {}
+  "acl": {
+    "test-filter": {
+      "type": "ipv4",
+      "rule": {
+        "10": {
+          "action": {
+            "permit": {}
+          },
+          "remark": "Allow established TCP connections",
+          "match": {
+            "ip": {
+              "protocol": "tcp",
+              "dest-port": "80"
             },
-            "remark": "Allow established TCP connections",
-            "match": {
-              "ip": {
-                "protocol": "tcp",
-                "dest-port": "80"
-              },
-              "tcp": {
-                "state": "established"
-              }
+            "tcp": {
+              "state": "established"
             }
           }
         }

--- a/tests/regression/nvueapi/NvueApiTest.testTcpEstablished.stdout.ref
+++ b/tests/regression/nvueapi/NvueApiTest.testTcpEstablished.stdout.ref
@@ -1,0 +1,26 @@
+{
+  "set": {
+    "acl": {
+      "test-filter": {
+        "type": "ipv4",
+        "rule": {
+          "10": {
+            "action": {
+              "permit": {}
+            },
+            "remark": "Allow established TCP connections",
+            "match": {
+              "ip": {
+                "protocol": "tcp",
+                "dest-port": "80"
+              },
+              "tcp": {
+                "state": "established"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/regression/nvueapi/nvueapi_test.py
+++ b/tests/regression/nvueapi/nvueapi_test.py
@@ -137,7 +137,6 @@ SUPPORTED_TOKENS = {
     'protocol',
     'source_address',
     'source_port',
-    'translated', #TODO(kyleomalley): This probably isn't needed for nvueapi
 }
 
 SUPPORTED_SUB_TOKENS = {
@@ -173,12 +172,11 @@ class NvueApiTest(absltest.TestCase):
         # Verify it's valid JSON
         config = json.loads(output)
         
-        # Check basic structure (updated for NVUE 'set:' format)
-        self.assertIn('set', config)
-        self.assertIn('acl', config['set'])
-        self.assertIn('test-filter', config['set']['acl'])
+        # Check basic structure
+        self.assertIn('acl', config)
+        self.assertIn('test-filter', config['acl'])
         
-        acl_config = config['set']['acl']['test-filter']
+        acl_config = config['acl']['test-filter']
         self.assertEqual(acl_config['type'], 'ipv4')
         self.assertIn('rule', acl_config)
         
@@ -212,7 +210,7 @@ class NvueApiTest(absltest.TestCase):
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        rules = config['set']['acl']['test-filter']['rule']
+        rules = config['acl']['test-filter']['rule']
         
         # Should have 4 rules now (DNS TCP+UDP, HTTP, DENY = 4 total)
         self.assertEqual(len(rules), 4)
@@ -237,7 +235,7 @@ class NvueApiTest(absltest.TestCase):
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        acl_config = config['set']['acl']['test-filter-v6']
+        acl_config = config['acl']['test-filter-v6']
         
         self.assertEqual(acl_config['type'], 'ipv6')
         
@@ -288,7 +286,7 @@ term allow-mac {
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        acl_config = config['set']['acl']['test-filter']
+        acl_config = config['acl']['test-filter']
         
         self.assertEqual(acl_config['type'], 'ipv4')
         
@@ -312,7 +310,7 @@ term allow-mac {
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        acl_config = config['set']['acl']['test-filter-v6']
+        acl_config = config['acl']['test-filter-v6']
         
         self.assertEqual(acl_config['type'], 'ipv6')
         
@@ -349,7 +347,7 @@ term allow-web-multi {
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        rules = config['set']['acl']['test-filter']['rule']
+        rules = config['acl']['test-filter']['rule']
         
         # Should have 4 rules (2 clients × 2 servers = 4 combinations)
         self.assertEqual(len(rules), 4)
@@ -377,7 +375,7 @@ term allow-web-multi {
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        acl_config = config['set']['acl']['test-filter']
+        acl_config = config['acl']['test-filter']
         
         self.assertEqual(acl_config['type'], 'ipv4')
         
@@ -398,7 +396,7 @@ term allow-web-multi {
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
         
         config = json.loads(output)
-        acl_config = config['set']['acl']['test-filter']
+        acl_config = config['acl']['test-filter']
         
         self.assertEqual(acl_config['type'], 'ipv4')
         

--- a/tests/regression/nvueapi/nvueapi_test.py
+++ b/tests/regression/nvueapi/nvueapi_test.py
@@ -1,0 +1,428 @@
+# Copyright 2025 Aerleon Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unittest for NVUE API ACL rendering module."""
+
+import json
+
+from absl.testing import absltest
+
+from aerleon.lib import nacaddr, naming, nvueapi, policy
+from tests.regression_utils import capture
+
+GOOD_HEADER_IPV4 = """
+header {
+  comment:: "this is a test nvue acl"
+  target:: nvueapi test-filter ipv4
+}
+"""
+
+GOOD_HEADER_IPV6 = """
+header {
+  comment:: "this is a test nvue ipv6 acl"  
+  target:: nvueapi test-filter-v6 ipv6
+}
+"""
+
+GOOD_HEADER_MIXED = """
+header {
+  comment:: "this is a test nvue mixed acl"
+  target:: nvueapi test-filter-mixed mixed
+}
+"""
+
+GOOD_HEADER_MAC = """
+header {
+  comment:: "this is a test nvue mac acl"
+  target:: nvueapi test-filter-mac mac
+}
+"""
+
+GOOD_TERM_1 = """
+term good-term-1 {
+  comment:: "DNS access from corp."
+  source-address:: CORP_EXTERNAL
+  destination-port:: DNS
+  protocol:: udp tcp
+  action:: accept
+}
+"""
+
+GOOD_TERM_2 = """
+term good-term-2 {
+  comment:: "HTTP access from corp."
+  source-address:: CORP_EXTERNAL  
+  destination-port:: HTTP
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+GOOD_TERM_DENY = """
+term deny-all {
+  comment:: "Default deny rule."
+  action:: deny
+}
+"""
+
+GOOD_TERM_IPV6 = """
+term good-term-ipv6 {
+  comment:: "Allow IPv6 traffic."
+  source-address:: IPV6_INTERNAL
+  destination-port:: HTTP
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+GOOD_TERM_ICMP = """
+term test-icmp {
+  comment:: "ICMP echo-request"
+  protocol:: icmp
+  icmp-type:: echo-request
+  action:: accept
+}
+"""
+
+GOOD_TERM_ICMPV6 = """
+term test-icmpv6 {
+  comment:: "ICMPv6 echo-request"
+  protocol:: icmpv6
+  icmp-type:: echo-request
+  action:: accept
+}
+"""
+
+GOOD_TERM_LOG = """
+term test-log {
+  comment:: "Log all traffic"
+  logging:: True
+  action:: accept
+}
+"""
+
+GOOD_TERM_TCP_ESTABLISHED = """
+term test-tcp-established {
+  comment:: "Allow established TCP connections"
+  destination-port:: HTTP
+  protocol:: tcp
+  option:: tcp-established
+  action:: accept
+}
+"""
+
+SUPPORTED_TOKENS = {
+    'action',
+    'comment',
+    'destination_address',
+    'destination_port',
+    'expiration',
+    'icmp_type',
+    'logging',
+    'name',
+    'option',
+    'platform',
+    'platform_exclude',
+    'protocol',
+    'source_address',
+    'source_port',
+    'translated', #TODO(kyleomalley): This probably isn't needed for nvueapi
+}
+
+SUPPORTED_SUB_TOKENS = {
+    'action': {'accept', 'deny', 'reject', 'next'},
+}
+
+# Print a info message when a term is set to expire in that many weeks.
+# This is normally passed from command line.
+EXP_INFO = 2
+
+TEST_IPS = [nacaddr.IP('10.2.3.4/32'), nacaddr.IP('2001:4860:8000::5/128')]
+
+TEST_IPV4_IPS = [nacaddr.IP('10.2.3.4/32')]
+
+TEST_IPV6_IPS = [nacaddr.IP('2001:4860:8000::5/128')]
+
+
+class NvueApiTest(absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.naming = naming.Naming()
+
+    @capture.stdout
+    def testGenericTerm(self):
+        """Test a basic term."""
+        self.naming._ParseLine('CORP_EXTERNAL = 10.2.3.4/32 2001:4860:8000::5/128', 'networks')
+        self.naming._ParseLine('DNS = 53/tcp 53/udp', 'services')
+
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_1, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        # Verify it's valid JSON
+        config = json.loads(output)
+        
+        # Check basic structure (updated for NVUE 'set:' format)
+        self.assertIn('set', config)
+        self.assertIn('acl', config['set'])
+        self.assertIn('test-filter', config['set']['acl'])
+        
+        acl_config = config['set']['acl']['test-filter']
+        self.assertEqual(acl_config['type'], 'ipv4')
+        self.assertIn('rule', acl_config)
+        
+        # Check rule content
+        rules = acl_config['rule']
+        self.assertTrue(len(rules) > 0)
+        
+        # First rule should be our DNS rule (action is now an object)
+        first_rule = rules['10']
+        self.assertIn('permit', first_rule['action'])
+        self.assertIn('match', first_rule)
+        self.assertIn('ip', first_rule['match'])
+        
+        ip_match = first_rule['match']['ip']
+        self.assertIn('source-ip', ip_match)
+        self.assertIn('dest-port', ip_match)
+        
+        print(output)
+
+    @capture.stdout
+    def testMultipleTerms(self):
+        """Test multiple terms in one ACL."""
+        self.naming._ParseLine('CORP_EXTERNAL = 10.2.3.4/32', 'networks')
+        self.naming._ParseLine('DNS = 53/tcp 53/udp', 'services')
+        self.naming._ParseLine('HTTP = 80/tcp', 'services')
+
+        pol = policy.ParsePolicy(
+            GOOD_HEADER_IPV4 + GOOD_TERM_1 + GOOD_TERM_2 + GOOD_TERM_DENY, 
+            self.naming
+        )
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        rules = config['set']['acl']['test-filter']['rule']
+        
+        # Should have 4 rules now (DNS TCP+UDP, HTTP, DENY = 4 total)
+        self.assertEqual(len(rules), 4)
+        self.assertIn('10', rules)  # DNS UDP
+        self.assertIn('20', rules)  # DNS TCP
+        self.assertIn('30', rules)  # HTTP
+        self.assertIn('40', rules)  # DENY
+        
+        # Check the deny rule (now at position 40)
+        deny_rule = rules['40']
+        self.assertIn('deny', deny_rule['action'])
+        
+        print(output)
+
+    @capture.stdout
+    def testIPv6Term(self):
+        """Test IPv6 ACL generation."""
+        self.naming._ParseLine('IPV6_INTERNAL = 2001:4860:8000::5/128', 'networks')
+        self.naming._ParseLine('HTTP = 80/tcp', 'services')
+
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV6 + GOOD_TERM_IPV6, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        acl_config = config['set']['acl']['test-filter-v6']
+        
+        self.assertEqual(acl_config['type'], 'ipv6')
+        
+        print(output)
+
+    def testMixedAddressFamilyError(self):
+        """Test that mixed IPv4/IPv6 ACL raises an error."""
+        self.naming._ParseLine('CORP_EXTERNAL = 10.2.3.4/32 2001:4860:8000::5/128', 'networks')
+        self.naming._ParseLine('DNS = 53/tcp 53/udp', 'services')
+
+        pol = policy.ParsePolicy(GOOD_HEADER_MIXED + GOOD_TERM_1, self.naming)
+        
+        # NVUE doesn't support mixed address family ACLs
+        with self.assertRaises(nvueapi.UnsupportedNvueFilterError) as context:
+            nvueapi.NvueApi(pol, EXP_INFO)
+        
+        self.assertIn('mixed address family', str(context.exception))
+
+    def testMacAddressFamilyError(self):
+        """Test that MAC ACL raises an error since Aerleon doesn't support MAC ACLs."""
+        pol = policy.ParsePolicy(GOOD_HEADER_MAC + """
+term allow-mac {
+  comment:: "Allow specific MAC addresses"
+  action:: accept
+}
+""", self.naming)
+        
+        # Aerleon doesn't support MAC ACLs
+        with self.assertRaises(nvueapi.UnsupportedNvueFilterError) as context:
+            nvueapi.NvueApi(pol, EXP_INFO)
+        
+        self.assertIn('MAC ACLs are not supported', str(context.exception))
+
+    def testBuildTokens(self):
+        """Test that we can build tokens correctly."""
+        self.naming._ParseLine('CORP_EXTERNAL = 10.2.3.4/32', 'networks')
+        self.naming._ParseLine('DNS = 53/tcp', 'services')
+        pol1 = nvueapi.NvueApi(policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_1,
+                                                  self.naming), EXP_INFO)
+        st, sst = pol1._BuildTokens()
+        self.assertEqual(st, SUPPORTED_TOKENS)
+        self.assertEqual(sst, SUPPORTED_SUB_TOKENS)
+
+    @capture.stdout
+    def testIcmpTerm(self):
+        """Test ICMP rule generation."""
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_ICMP, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        acl_config = config['set']['acl']['test-filter']
+        
+        self.assertEqual(acl_config['type'], 'ipv4')
+        
+        # Check ICMP rule content
+        rules = acl_config['rule']
+        icmp_rule = rules['10']
+        self.assertIn('permit', icmp_rule['action'])
+        self.assertIn('match', icmp_rule)
+        self.assertIn('ip', icmp_rule['match'])
+        
+        ip_match = icmp_rule['match']['ip']
+        self.assertEqual(ip_match['protocol'], 'icmp')
+        self.assertEqual(ip_match['icmp-type'], 'echo-request')
+        
+        print(output)
+
+    @capture.stdout  
+    def testIcmpv6Term(self):
+        """Test ICMPv6 rule generation."""
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV6 + GOOD_TERM_ICMPV6, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        acl_config = config['set']['acl']['test-filter-v6']
+        
+        self.assertEqual(acl_config['type'], 'ipv6')
+        
+        # Check ICMPv6 rule content  
+        rules = acl_config['rule']
+        icmpv6_rule = rules['10']
+        self.assertIn('permit', icmpv6_rule['action'])
+        self.assertIn('match', icmpv6_rule)
+        self.assertIn('ip', icmpv6_rule['match'])
+        
+        ip_match = icmpv6_rule['match']['ip']
+        self.assertEqual(ip_match['protocol'], 'icmpv6')
+        self.assertEqual(ip_match['icmpv6-type'], 'echo-request')
+        
+        print(output)
+
+    @capture.stdout
+    def testMultipleAddresses(self):
+        """Test multiple address expansion into separate rules."""
+        self.naming._ParseLine('SERVERS = 192.168.1.10/32 192.168.1.20/32', 'networks')
+        self.naming._ParseLine('CLIENTS = 10.0.1.0/24 10.0.2.0/24', 'networks')
+        self.naming._ParseLine('HTTP = 80/tcp', 'services')
+
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + """
+term allow-web-multi {
+  comment:: "Allow HTTP from multiple clients to multiple servers"
+  source-address:: CLIENTS
+  destination-address:: SERVERS
+  destination-port:: HTTP
+  protocol:: tcp
+  action:: accept
+}
+""", self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        rules = config['set']['acl']['test-filter']['rule']
+        
+        # Should have 4 rules (2 clients × 2 servers = 4 combinations)
+        self.assertEqual(len(rules), 4)
+        
+        # Check that each rule has single addresses
+        for rule_num, rule in rules.items():
+            self.assertIn('match', rule)
+            self.assertIn('ip', rule['match'])
+            ip_match = rule['match']['ip']
+            
+            # Each rule should have exactly one source and dest IP
+            self.assertIn('source-ip', ip_match)
+            self.assertIn('dest-ip', ip_match)
+            
+            # Should not contain commas (indicating single address)
+            self.assertNotIn(',', ip_match['source-ip'])
+            self.assertNotIn(',', ip_match['dest-ip'])
+        
+        print(output)
+
+    @capture.stdout
+    def testLogAction(self):
+        """Test logging attribute maps to log action."""
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_LOG, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        acl_config = config['set']['acl']['test-filter']
+        
+        self.assertEqual(acl_config['type'], 'ipv4')
+        
+        # Check log rule content - logging:: True should map to action: log
+        rules = acl_config['rule']
+        log_rule = rules['10']
+        self.assertIn('log', log_rule['action'])
+        self.assertEqual(log_rule['remark'], 'Log all traffic')
+        
+        print(output)
+
+    @capture.stdout
+    def testTcpEstablished(self):
+        """Test TCP established state matching."""
+        self.naming._ParseLine('HTTP = 80/tcp', 'services')
+        
+        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_TCP_ESTABLISHED, self.naming)
+        output = str(nvueapi.NvueApi(pol, EXP_INFO))
+        
+        config = json.loads(output)
+        acl_config = config['set']['acl']['test-filter']
+        
+        self.assertEqual(acl_config['type'], 'ipv4')
+        
+        # Check TCP established rule content
+        rules = acl_config['rule']
+        tcp_rule = rules['10']
+        self.assertIn('permit', tcp_rule['action'])
+        self.assertIn('match', tcp_rule)
+        
+        # Check that both ip and tcp sections exist
+        match = tcp_rule['match']
+        self.assertIn('ip', match)
+        self.assertIn('tcp', match)
+        
+        # Verify IP match conditions
+        ip_match = match['ip']
+        self.assertEqual(ip_match['protocol'], 'tcp')
+        self.assertEqual(ip_match['dest-port'], '80')
+        
+        # Verify TCP state match
+        tcp_match = match['tcp']
+        self.assertEqual(tcp_match['state'], 'established')
+        
+        print(output)
+
+if __name__ == '__main__':
+    absltest.main()

--- a/tests/regression/nvueapi/nvueapi_test.py
+++ b/tests/regression/nvueapi/nvueapi_test.py
@@ -155,7 +155,6 @@ TEST_IPV6_IPS = [nacaddr.IP('2001:4860:8000::5/128')]
 
 
 class NvueApiTest(absltest.TestCase):
-
     def setUp(self):
         super().setUp()
         self.naming = naming.Naming()
@@ -168,32 +167,32 @@ class NvueApiTest(absltest.TestCase):
 
         pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_1, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         # Verify it's valid JSON
         config = json.loads(output)
-        
+
         # Check basic structure
         self.assertIn('acl', config)
         self.assertIn('test-filter', config['acl'])
-        
+
         acl_config = config['acl']['test-filter']
         self.assertEqual(acl_config['type'], 'ipv4')
         self.assertIn('rule', acl_config)
-        
+
         # Check rule content
         rules = acl_config['rule']
         self.assertTrue(len(rules) > 0)
-        
+
         # First rule should be our DNS rule (action is now an object)
         first_rule = rules['10']
         self.assertIn('permit', first_rule['action'])
         self.assertIn('match', first_rule)
         self.assertIn('ip', first_rule['match'])
-        
+
         ip_match = first_rule['match']['ip']
         self.assertIn('source-ip', ip_match)
         self.assertIn('dest-port', ip_match)
-        
+
         print(output)
 
     @capture.stdout
@@ -204,25 +203,24 @@ class NvueApiTest(absltest.TestCase):
         self.naming._ParseLine('HTTP = 80/tcp', 'services')
 
         pol = policy.ParsePolicy(
-            GOOD_HEADER_IPV4 + GOOD_TERM_1 + GOOD_TERM_2 + GOOD_TERM_DENY, 
-            self.naming
+            GOOD_HEADER_IPV4 + GOOD_TERM_1 + GOOD_TERM_2 + GOOD_TERM_DENY, self.naming
         )
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         rules = config['acl']['test-filter']['rule']
-        
+
         # Should have 4 rules now (DNS TCP+UDP, HTTP, DENY = 4 total)
         self.assertEqual(len(rules), 4)
         self.assertIn('10', rules)  # DNS UDP
         self.assertIn('20', rules)  # DNS TCP
         self.assertIn('30', rules)  # HTTP
         self.assertIn('40', rules)  # DENY
-        
+
         # Check the deny rule (now at position 40)
         deny_rule = rules['40']
         self.assertIn('deny', deny_rule['action'])
-        
+
         print(output)
 
     @capture.stdout
@@ -233,12 +231,12 @@ class NvueApiTest(absltest.TestCase):
 
         pol = policy.ParsePolicy(GOOD_HEADER_IPV6 + GOOD_TERM_IPV6, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         acl_config = config['acl']['test-filter-v6']
-        
+
         self.assertEqual(acl_config['type'], 'ipv6')
-        
+
         print(output)
 
     def testMixedAddressFamilyError(self):
@@ -247,34 +245,39 @@ class NvueApiTest(absltest.TestCase):
         self.naming._ParseLine('DNS = 53/tcp 53/udp', 'services')
 
         pol = policy.ParsePolicy(GOOD_HEADER_MIXED + GOOD_TERM_1, self.naming)
-        
+
         # NVUE doesn't support mixed address family ACLs
         with self.assertRaises(nvueapi.UnsupportedNvueFilterError) as context:
             nvueapi.NvueApi(pol, EXP_INFO)
-        
+
         self.assertIn('mixed address family', str(context.exception))
 
     def testMacAddressFamilyError(self):
         """Test that MAC ACL raises an error since Aerleon doesn't support MAC ACLs."""
-        pol = policy.ParsePolicy(GOOD_HEADER_MAC + """
+        pol = policy.ParsePolicy(
+            GOOD_HEADER_MAC
+            + """
 term allow-mac {
   comment:: "Allow specific MAC addresses"
   action:: accept
 }
-""", self.naming)
-        
+""",
+            self.naming,
+        )
+
         # Aerleon doesn't support MAC ACLs
         with self.assertRaises(nvueapi.UnsupportedNvueFilterError) as context:
             nvueapi.NvueApi(pol, EXP_INFO)
-        
+
         self.assertIn('MAC ACLs are not supported', str(context.exception))
 
     def testBuildTokens(self):
         """Test that we can build tokens correctly."""
         self.naming._ParseLine('CORP_EXTERNAL = 10.2.3.4/32', 'networks')
         self.naming._ParseLine('DNS = 53/tcp', 'services')
-        pol1 = nvueapi.NvueApi(policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_1,
-                                                  self.naming), EXP_INFO)
+        pol1 = nvueapi.NvueApi(
+            policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_1, self.naming), EXP_INFO
+        )
         st, sst = pol1._BuildTokens()
         self.assertEqual(st, SUPPORTED_TOKENS)
         self.assertEqual(sst, SUPPORTED_SUB_TOKENS)
@@ -284,47 +287,47 @@ term allow-mac {
         """Test ICMP rule generation."""
         pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_ICMP, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         acl_config = config['acl']['test-filter']
-        
+
         self.assertEqual(acl_config['type'], 'ipv4')
-        
+
         # Check ICMP rule content
         rules = acl_config['rule']
         icmp_rule = rules['10']
         self.assertIn('permit', icmp_rule['action'])
         self.assertIn('match', icmp_rule)
         self.assertIn('ip', icmp_rule['match'])
-        
+
         ip_match = icmp_rule['match']['ip']
         self.assertEqual(ip_match['protocol'], 'icmp')
         self.assertEqual(ip_match['icmp-type'], 'echo-request')
-        
+
         print(output)
 
-    @capture.stdout  
+    @capture.stdout
     def testIcmpv6Term(self):
         """Test ICMPv6 rule generation."""
         pol = policy.ParsePolicy(GOOD_HEADER_IPV6 + GOOD_TERM_ICMPV6, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         acl_config = config['acl']['test-filter-v6']
-        
+
         self.assertEqual(acl_config['type'], 'ipv6')
-        
-        # Check ICMPv6 rule content  
+
+        # Check ICMPv6 rule content
         rules = acl_config['rule']
         icmpv6_rule = rules['10']
         self.assertIn('permit', icmpv6_rule['action'])
         self.assertIn('match', icmpv6_rule)
         self.assertIn('ip', icmpv6_rule['match'])
-        
+
         ip_match = icmpv6_rule['match']['ip']
         self.assertEqual(ip_match['protocol'], 'icmpv6')
         self.assertEqual(ip_match['icmpv6-type'], 'echo-request')
-        
+
         print(output)
 
     @capture.stdout
@@ -334,7 +337,9 @@ term allow-mac {
         self.naming._ParseLine('CLIENTS = 10.0.1.0/24 10.0.2.0/24', 'networks')
         self.naming._ParseLine('HTTP = 80/tcp', 'services')
 
-        pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + """
+        pol = policy.ParsePolicy(
+            GOOD_HEADER_IPV4
+            + """
 term allow-web-multi {
   comment:: "Allow HTTP from multiple clients to multiple servers"
   source-address:: CLIENTS
@@ -343,29 +348,31 @@ term allow-web-multi {
   protocol:: tcp
   action:: accept
 }
-""", self.naming)
+""",
+            self.naming,
+        )
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         rules = config['acl']['test-filter']['rule']
-        
+
         # Should have 4 rules (2 clients × 2 servers = 4 combinations)
         self.assertEqual(len(rules), 4)
-        
+
         # Check that each rule has single addresses
         for rule_num, rule in rules.items():
             self.assertIn('match', rule)
             self.assertIn('ip', rule['match'])
             ip_match = rule['match']['ip']
-            
+
             # Each rule should have exactly one source and dest IP
             self.assertIn('source-ip', ip_match)
             self.assertIn('dest-ip', ip_match)
-            
+
             # Should not contain commas (indicating single address)
             self.assertNotIn(',', ip_match['source-ip'])
             self.assertNotIn(',', ip_match['dest-ip'])
-        
+
         print(output)
 
     @capture.stdout
@@ -373,54 +380,55 @@ term allow-web-multi {
         """Test logging attribute maps to log action."""
         pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_LOG, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         acl_config = config['acl']['test-filter']
-        
+
         self.assertEqual(acl_config['type'], 'ipv4')
-        
+
         # Check log rule content - logging:: True should map to action: log
         rules = acl_config['rule']
         log_rule = rules['10']
         self.assertIn('log', log_rule['action'])
         self.assertEqual(log_rule['remark'], 'Log all traffic')
-        
+
         print(output)
 
     @capture.stdout
     def testTcpEstablished(self):
         """Test TCP established state matching."""
         self.naming._ParseLine('HTTP = 80/tcp', 'services')
-        
+
         pol = policy.ParsePolicy(GOOD_HEADER_IPV4 + GOOD_TERM_TCP_ESTABLISHED, self.naming)
         output = str(nvueapi.NvueApi(pol, EXP_INFO))
-        
+
         config = json.loads(output)
         acl_config = config['acl']['test-filter']
-        
+
         self.assertEqual(acl_config['type'], 'ipv4')
-        
+
         # Check TCP established rule content
         rules = acl_config['rule']
         tcp_rule = rules['10']
         self.assertIn('permit', tcp_rule['action'])
         self.assertIn('match', tcp_rule)
-        
+
         # Check that both ip and tcp sections exist
         match = tcp_rule['match']
         self.assertIn('ip', match)
         self.assertIn('tcp', match)
-        
+
         # Verify IP match conditions
         ip_match = match['ip']
         self.assertEqual(ip_match['protocol'], 'tcp')
         self.assertEqual(ip_match['dest-port'], '80')
-        
+
         # Verify TCP state match
         tcp_match = match['tcp']
         self.assertEqual(tcp_match['state'], 'established')
-        
+
         print(output)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/regression/nvueapi/nvueapi_test.py
+++ b/tests/regression/nvueapi/nvueapi_test.py
@@ -140,7 +140,7 @@ SUPPORTED_TOKENS = {
 }
 
 SUPPORTED_SUB_TOKENS = {
-    'action': {'accept', 'deny', 'reject', 'next'},
+    'action': {'accept', 'deny', 'reject'},
 }
 
 # Print a info message when a term is set to expire in that many weeks.


### PR DESCRIPTION
#410 

Added nvueapi generator plugin and tests. Roughly modeled after iptables

Features:
- Supports all basic 5-tuple type ACLs
- Support for option objects for tcp-established
- Supports logging rules
- Supports explicit icmp_types
- Warns on unsupported (by the generator) features such as translation
- Handles 'mixed' (not supported) address family and 'mac' based rules for address_family


