### PR TITLE
Removing sigtore json files from the build packages directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Remove signature # pypi will not ignore the signatures anymore and does not support them.
         run: rm -f built-packages/aerleon-*.sigstore
+      - name: Remove signature json
+        run: rm -f built-packages/aerleon-*.sigstore.json
       - name: publish
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:


### PR DESCRIPTION
These files are not allowed to be uploaded to pypi and result in an error. Removal before upload is required for the pypi stage.