### PR TITLE
Update nvueapi.py -- fix SUFFIX

### DIFF
--- a/aerleon/lib/nvueapi.py
+++ b/aerleon/lib/nvueapi.py
@@ -298,7 +298,7 @@ class NvueApi(aclgenerator.ACLGenerator):
 
     _PLATFORM = 'nvueapi'
     _DEFAULT_PROTOCOL = 'ip'
-    SUFFIX = '_nvueapi.json'
+    SUFFIX = '.nvueapi.json'
     SUPPORTED_AF = set(['inet', 'inet6'])
     SUPPORTED_TARGETS = frozenset(['nvueapi'])
     WARN_IF_UNSUPPORTED = frozenset(['translated', 'stateless_reply', 'counter', 'policer'])


### PR DESCRIPTION
aclgen.py shows a traceback "Invalid suffix" '_nvueapi.json' which is from `pathlibPath.with_suffix()` (sad trombone)

Just replacing the _ with . worked in local testing against this PR.

https://github.com/aerleon/aerleon/issues/414
