### PR TITLE
Fix #417 - aclcheck example_policy documentation

### DIFF
--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -47,9 +47,7 @@ cisco_example_policy = {
                 "targets": {
                     "cisco": "test-filter"
                 },
-                "kvs": {
-                    "comment": "Sample comment"
-                },
+                "comment": "Sample comment",
             },
             "terms": [
                 {

--- a/docs/aclcheck.md
+++ b/docs/aclcheck.md
@@ -71,9 +71,7 @@ example_policy = {
                 "targets": {
                     "cisco": "test-filter"
                 },
-                "kvs": {
-                    "comment": "Sample filter for AclCheck API demo"
-                },
+                "comment": "Sample filter for AclCheck API demo"
             },
             "terms": [
                 {
@@ -155,7 +153,7 @@ except Exception as e:
 *   **`input_policy` (dict):** This dictionary represents the Aerleon policy.
     *   `filename`: A string identifier for the policy (primarily for context in logs/errors).
     *   `filters`: A list of filter dictionaries. Each filter dictionary must contain:
-        *   `header`: A dictionary defining the filter's targets (e.g., `{"cisco": "filter_name"}`). At least one target must be specified for the policy to be parsed correctly, even though `AclCheck` itself is platform-agnostic. It can also contain other header options like `kvs` for comments.
+        *   `header`: A dictionary defining the filter's targets (e.g., `{"cisco": "filter_name"}`). At least one target must be specified for the policy to be parsed correctly, even though `AclCheck` itself is platform-agnostic. It can also contain other header options like `comment`.
         *   `terms`: A list of term dictionaries. Each term defines specific match criteria (like `source-address`, `destination-port`, `protocol`) and an `action` (e.g., `accept`, `deny`).
 *   **`definitions` (aerleon.lib.naming.Naming):** This object holds the definitions for all named entities (like IP addresses, networks, services/ports) referenced in the policy.
     *   You can populate it by calling `ParseDefinitionsObject` with a dictionary structured similarly to how `NETWORK.net` and `SERVICES.svc` files are formatted, or by loading actual definition files.

--- a/docs/aclcheck.md
+++ b/docs/aclcheck.md
@@ -68,10 +68,8 @@ example_policy = {
     "filters": [
         {
             "header": {
-                "targets": {
-                    "cisco": "test-filter"
-                },
-                "comment": "Sample filter for AclCheck API demo"
+                "targets": {"cisco": "test-filter"},
+                "comment": "Sample filter for AclCheck API demo",
             },
             "terms": [
                 {
@@ -80,12 +78,9 @@ example_policy = {
                     "destination-address": "WEB_SERVERS",
                     "destination-port": "HTTP",
                     "protocol": "tcp",
-                    "action": "accept"
+                    "action": "accept",
                 },
-                {
-                    "name": "deny-all-else",
-                    "action": "deny"
-                }
+                {"name": "deny-all-else", "action": "deny"},
             ],
         }
     ],
@@ -96,16 +91,10 @@ example_policy = {
 # You could call yaml.safe_load to load your YAML definitions into this format.
 definitions_data = {
     "networks": {
-        "INTERNAL_NETWORK": {
-            "values": [ {"address": "192.168.1.0/24"} ]
-        },
-        "WEB_SERVERS": {
-            "values": [ {"address": "10.0.0.10/32"}, {"address": "10.0.0.11/32"} ]
-        }
+        "INTERNAL_NETWORK": {"values": [{"address": "192.168.1.0/24"}]},
+        "WEB_SERVERS": {"values": [{"address": "10.0.0.10/32"}, {"address": "10.0.0.11/32"}]},
     },
-    "services": {
-        "HTTP": [ {"protocol": "tcp", "port": "80"} ]
-    }
+    "services": {"HTTP": [{"protocol": "tcp", "port": "80"}]},
 }
 
 # Create a Naming object and parse the definitions
@@ -141,7 +130,9 @@ try:
             for term_name, match_details in terms.items():
                 print(match_details['message'])
     else:
-        print(f"No matching terms found for traffic from {source_ip}:{source_port} to {destination_ip}:{destination_port} ({protocol}).")
+        print(
+            f"No matching terms found for traffic from {source_ip}:{source_port} to {destination_ip}:{destination_port} ({protocol})."
+        )
 
 except Exception as e:
     print(f"An error occurred: {e}")

--- a/docs/aclcheck_api.md
+++ b/docs/aclcheck_api.md
@@ -15,12 +15,8 @@ example_policy = {
     "filters": [
         {
             "header": {
-                "targets": {
-                    "cisco": "test-filter"
-                },
-                "kvs": {
-                    "comment": "Sample filter for AclCheck API demo"
-                },
+                "targets": {"cisco": "test-filter"},
+                "comment": "Sample filter for AclCheck API demo",
             },
             "terms": [
                 {
@@ -29,12 +25,9 @@ example_policy = {
                     "destination-address": "WEB_SERVERS",
                     "destination-port": "HTTP",
                     "protocol": "tcp",
-                    "action": "accept"
+                    "action": "accept",
                 },
-                {
-                    "name": "deny-all-else",
-                    "action": "deny"
-                }
+                {"name": "deny-all-else", "action": "deny"},
             ],
         }
     ],
@@ -102,7 +95,7 @@ except Exception as e:
 *   **`input_policy` (dict):** This dictionary represents the Aerleon policy.
     *   `filename`: A string identifier for the policy (primarily for context in logs/errors).
     *   `filters`: A list of filter dictionaries. Each filter dictionary must contain:
-        *   `header`: A dictionary defining the filter's targets (e.g., `{"cisco": "filter_name"}`). At least one target must be specified for the policy to be parsed correctly, even though `AclCheck` itself is platform-agnostic. It can also contain other header options like `kvs` for comments.
+        *   `header`: A dictionary defining the filter's targets (e.g., `{"cisco": "filter_name"}`). At least one target must be specified for the policy to be parsed correctly, even though `AclCheck` itself is platform-agnostic. It can also contain other header options like `comment`.
         *   `terms`: A list of term dictionaries. Each term defines specific match criteria (like `source-address`, `destination-port`, `protocol`) and an `action` (e.g., `accept`, `deny`).
 *   **`definitions` (aerleon.lib.naming.Naming):** This object holds the definitions for all named entities (like IP addresses, networks, services/ports) referenced in the policy.
     *   You can populate it by calling `ParseDefinitionsObject` with a dictionary structured similarly to how `NETWORK.net` and `SERVICES.svc` files are formatted, or by loading actual definition files.

--- a/tests/api/ApiTest.testDocsExample.stdout.ref
+++ b/tests/api/ApiTest.testDocsExample.stdout.ref
@@ -4,6 +4,7 @@
 no ip access-list extended test-filter
 ip access-list extended test-filter
  remark $Id:$
+ remark Sample comment
 
 
  remark deny-to-reserved


### PR DESCRIPTION
This fixes the example causing a warning in #417, updates the other related documentation, and changes the tests so they would catch similar generated `logging` warnings in the future.