### PR TITLE
use `typing.Optional` for default `None` values

### DIFF
--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -214,6 +214,7 @@ import multiprocessing
 import pathlib
 import sys
 import typing
+from typing import Optional
 
 from absl import logging
 
@@ -238,12 +239,12 @@ from aerleon.lib import (
 def Generate(
     policies: "list[policy_builder.PolicyDict]",
     definitions: naming.Naming,
-    output_directory: pathlib.Path = None,
+    output_directory: Optional[pathlib.Path] = None,
     optimize: bool = False,
     shade_check: bool = False,
     expiration_weeks: int = 2,
-    include_path: pathlib.Path = None,
-    includes: "dict[str, policy_builder.PolicyDict]" = None,
+    include_path: Optional[pathlib.Path] = None,
+    includes: Optional["dict[str, policy_builder.PolicyDict]"] = None,
 ) -> "dict[str, str]":
     """Generate ACLs from policies.
 
@@ -304,12 +305,12 @@ def _Generate(
     policies: "list[policy_builder.PolicyDict]",
     definitions: naming.Naming,
     context: multiprocessing.context.BaseContext,
-    output_directory: pathlib.Path = None,
+    output_directory: Optional[pathlib.Path] = None,
     optimize: bool = False,
     shade_check: bool = False,
     exp_info: int = 2,
-    include_path: pathlib.Path = None,
-    includes: "dict[str, policy_builder.PolicyDict]" = None,
+    include_path: Optional[pathlib.Path] = None,
+    includes: Optional["dict[str, policy_builder.PolicyDict]"] = None,
     max_renderers: int = 1,
 ) -> "dict[str, str]":
     # thead-safe list for storing files to write
@@ -373,12 +374,12 @@ def _GenerateACL(
     definitions: naming.Naming,
     write_files: WriteList,
     generated_configs: dict,
-    output_directory: typing.Optional[pathlib.Path] = None,
+    output_directory: Optional[pathlib.Path] = None,
     optimize: bool = False,
     shade_check: bool = False,
     exp_info: int = 2,
-    include_path: pathlib.Path = None,
-    includes: "dict[str, policy_builder.PolicyDict]" = None,
+    include_path: Optional[pathlib.Path] = None,
+    includes: Optional["dict[str, policy_builder.PolicyDict]"] = None,
 ):
     filename = input_policy.get("filename")
 
@@ -474,11 +475,11 @@ def _GenerateACL(
 def AclCheck(
     input_policy: policy_builder.PolicyDict,
     definitions: naming.Naming,
-    src: str = None,
-    dst: str = None,
-    sport: str = None,
-    dport: str = None,
-    proto: str = None,
+    src: Optional[str] = None,
+    dst: Optional[str] = None,
+    sport: Optional[str] = None,
+    dport: Optional[str] = None,
+    proto: Optional[str] = None,
 ):
     filename = input_policy.get("filename")
     try:

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -21,7 +21,7 @@ import datetime
 import hashlib
 import re
 import string
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from absl import logging
 
@@ -500,7 +500,7 @@ class ACLGenerator:
         term_name: str,
         abbreviate: bool = False,
         truncate: bool = False,
-        override_max_length: int = None,
+        override_max_length: Optional[int] = None,
     ):
         """Return a term name which is equal or shorter than _TERM_MAX_LENGTH.
 
@@ -539,7 +539,7 @@ class ACLGenerator:
             'disabled.' % (new_term, term_name, override_max_length, len(new_term))
         )
 
-    def HexDigest(self, name: str, truncation_length: int = None):
+    def HexDigest(self, name: str, truncation_length: Optional[int] = None):
         """Return a hexadecimal digest of the name object.
 
         Args:

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -17,7 +17,7 @@
 
 import copy
 import re
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from absl import logging
 
@@ -151,7 +151,7 @@ class Term(aclgenerator.Term):
     }
 
     def __init__(
-        self, term: policy.Term, term_type: str, noverbose: bool, filter_type: str = None
+        self, term: policy.Term, term_type: str, noverbose: bool, filter_type: Optional[str] = None
     ) -> None:
         super().__init__(term)
         self.term = term

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -425,7 +425,7 @@ class Term(aclgenerator.Term):
         term_remark: bool = True,
         platform: str = 'cisco',
         verbose: bool = True,
-        filter_type: str = None,
+        filter_type: Optional[str] = None,
     ) -> None:
         self.term = term
         self.proto_int = proto_int

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -16,7 +16,7 @@
 
 """Juniper JCL generator."""
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from absl import logging
 
@@ -197,9 +197,9 @@ class Term(aclgenerator.Term):
         term_type: str,
         enable_dsmo: bool,
         noverbose: bool,
-        filter_direction: str = None,
-        interface_type: str = None,
-        filter_type: str = None,
+        filter_direction: Optional[str] = None,
+        interface_type: Optional[str] = None,
+        filter_type: Optional[str] = None,
     ):
         super().__init__(term)
         self.term = term

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -48,7 +48,7 @@ DNS = 53/tcp
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
 from absl import logging
@@ -135,8 +135,8 @@ class UserMessage:
         message: str,
         *,
         filename: str,
-        line: int = None,
-        include_chain: List[Tuple[str, int]] = None,
+        line: Optional[int] = None,
+        include_chain: Optional[List[Tuple[str, int]]] = None,
     ):
         self.message = message
         self.filename = filename
@@ -205,7 +205,10 @@ class Naming:
     """
 
     def __init__(
-        self, naming_dir: str = None, naming_file: str = None, naming_type: str = None
+        self,
+        naming_dir: Optional[str] = None,
+        naming_file: Optional[str] = None,
+        naming_type: Optional[str] = None,
     ) -> None:
         """Set the default values for a new Naming object.
 

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -18,7 +18,7 @@
 
 import re
 import xml
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from absl import logging
 
@@ -110,7 +110,9 @@ class NsxvDuplicateTermError(Error):
 class Term(aclgenerator.Term):
     """Creates a  single ACL Term for Nsxv."""
 
-    def __init__(self, term: policy.Term, filter_type: str, applied_to: str = None, af: int = 4):
+    def __init__(
+        self, term: policy.Term, filter_type: str, applied_to: Optional[str] = None, af: int = 4
+    ):
         self.term = term
         # Our caller should have already verified the address family.
         assert af in (4, 6)

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -70,7 +70,7 @@ class _PluginSupervisor:
     def __init__(self) -> None:
         self.is_setup = False
 
-    def Start(self, config: PluginSupervisorConfiguration = None) -> None:
+    def Start(self, config: Optional[PluginSupervisorConfiguration] = None) -> None:
         setup = _PluginSetup(config)
         self.plugins, self.generators = setup.plugins, setup.generators
         self.is_setup = True
@@ -160,9 +160,9 @@ class PluginSupervisorConfiguration:
     """
 
     disable_discovery: bool = False
-    disable_plugin: list[str] = None
-    disable_builtin: list[str] = None
-    include_path: list[list[str]] = None
+    disable_plugin: Optional[list[str]] = None
+    disable_builtin: Optional[list[str]] = None
+    include_path: Optional[list[list[str]]] = None
 
 
 class _PluginSetup:
@@ -179,11 +179,11 @@ class _PluginSetup:
     """
 
     disable_discovery: bool = False
-    disable_plugin: list[str] = None
-    disable_builtin: list[str] = None
-    include_path: list[list[str]] = None
+    disable_plugin: Optional[list[str]] = None
+    disable_builtin: Optional[list[str]] = None
+    include_path: Optional[list[list[str]]] = None
 
-    def __init__(self, config: PluginSupervisorConfiguration = None) -> None:
+    def __init__(self, config: Optional[PluginSupervisorConfiguration] = None) -> None:
         """Initialize self.generators, self.plugins."""
 
         self.generators = {}

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -2745,7 +2745,7 @@ def ParseFile(filename, definitions=None, optimize=True, base_dir='', shade_chec
 
 def ParsePolicy(
     data: str,
-    definitions: naming.Naming = None,
+    definitions: Optional[naming.Naming] = None,
     optimize: bool = True,
     base_dir: str = '',
     shade_check: bool = False,

--- a/aerleon/lib/proxmox.py
+++ b/aerleon/lib/proxmox.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, List, MutableMapping, Set, Tuple, Type, Union
+from typing import Dict, List, MutableMapping, Optional, Set, Tuple, Type, Union
 
 from aerleon.lib import aclgenerator, policy
 from aerleon.lib.nacaddr import ExcludeAddrs, IPv4, IPv6
@@ -227,8 +227,8 @@ class ProxmoxIcmp:
     def __init__(
         self,
         icmp_proto: str,
-        icmp_type: Union[str, None] = None,
-        icmp_code: Union[int, None] = None,
+        icmp_type: Optional[str] = None,
+        icmp_code: Optional[int] = None,
     ):
         self.icmp_proto = icmp_proto
         self.type = icmp_type
@@ -336,13 +336,13 @@ class Term(aclgenerator.Term):
 
     def _Format(
         self,
-        protocol: Union[str, None],
+        protocol: Optional[str],
         direction: str,
         action: str,
         source_addresses: List[Union[IPv4, IPv6]],
         destination_addresses: List[Union[IPv4, IPv6]],
-        icmp_code: Union[str, None],
-        icmp_type: Union[str, None],
+        icmp_code: Optional[str],
+        icmp_type: Optional[str],
         source_interface: str,
         source_ports: List[Union[Tuple[int, int], int]],
         destination_ports: List[Union[Tuple[int, int], int]],

--- a/aerleon/lib/recognizers.py
+++ b/aerleon/lib/recognizers.py
@@ -23,6 +23,7 @@ import enum
 import re
 import typing
 from dataclasses import dataclass
+from typing import Optional
 
 if typing.TYPE_CHECKING:
     from aerleon.lib.policy_builder import (
@@ -37,12 +38,12 @@ if typing.TYPE_CHECKING:
 @dataclass
 class RecognizerContext:
     policy: RawPolicy
-    filter: RawFilter = None
-    header: RawFilterHeader = None
-    target: RawTarget = None
-    term: RawTerm = None
-    keyword: str = None
-    value: str = None
+    filter: Optional[RawFilter] = None
+    header: Optional[RawFilterHeader] = None
+    target: Optional[RawTarget] = None
+    term: Optional[RawTerm] = None
+    keyword: Optional[str] = None
+    value: Optional[str] = None
 
 
 @dataclass
@@ -55,13 +56,13 @@ class RecognizerKeywordResult:
 class RecognizerValueResult:
     recognized: bool
     securityCritical: bool = False
-    valueKV: dict = None
+    valueKV: Optional[dict] = None
 
 
 @dataclass
 class RecognizerOptionResult:
     securityCritical: bool
-    valueKV: dict = None
+    valueKV: Optional[dict] = None
 
 
 class TValue(enum.Enum):

--- a/aerleon/utils/config.py
+++ b/aerleon/utils/config.py
@@ -3,6 +3,7 @@
 """A module to handle merging file configurations with CLI configs for Aerleon."""
 
 import pathlib
+from typing import Optional
 
 import yaml
 
@@ -29,7 +30,7 @@ class ConfigFileError(Exception):
 
 
 def load_config(
-    config_file: "str | pathlib.Path | list[str | pathlib.Path]" = None,
+    config_file: Optional["str | pathlib.Path | list[str | pathlib.Path]"] = None,
     apply_defaults: bool = True,
 ) -> dict:
     """Load Aerleon configuration file(s).


### PR DESCRIPTION
In cases where type hints are used and `None` is the default value, use `typing.Optional` to indicate that `None` is a valid option as well as the hinted type.  This will make using aerleon with type checking better.