### PR TITLE
`pyupgrade` Python 3.9 syntax upgrade

### DIFF
--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -260,9 +260,7 @@ def RenderFile(
                 RenderACL(str(acl_obj), acl_obj.SUFFIX, output_directory, input_file, write_files)
 
         except aclgenerator.Error as e:
-            raise ACLGeneratorError(
-                f'Error generating target ACL for {input_file}:\n{e}'
-            ) from e
+            raise ACLGeneratorError(f'Error generating target ACL for {input_file}:\n{e}') from e
 
 
 def RenderACL(

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -19,7 +19,8 @@ import copy
 import multiprocessing
 import pathlib
 import sys
-from typing import Iterator, List, Tuple
+from typing import List, Tuple
+from collections.abc import Iterator
 
 from absl import app, flags, logging
 
@@ -27,7 +28,7 @@ from aerleon.lib import aclgenerator, naming, plugin_supervisor, policy, yaml
 from aerleon.utils import config
 
 FLAGS = flags.FLAGS
-WriteList = List[Tuple[pathlib.Path, str]]
+WriteList = list[tuple[pathlib.Path, str]]
 
 
 def SetupFlags():
@@ -191,7 +192,7 @@ def RenderFile(
         with open(input_file) as f:
             conf = f.read()
             logging.debug('opened and read %s', input_file)
-    except IOError as e:
+    except OSError as e:
         logging.warning('bad file: \n%s', e)
         raise
 
@@ -261,7 +262,7 @@ def RenderFile(
 
         except aclgenerator.Error as e:
             raise ACLGeneratorError(
-                'Error generating target ACL for %s:\n%s' % (input_file, e)
+                f'Error generating target ACL for {input_file}:\n{e}'
             ) from e
 
 
@@ -270,7 +271,7 @@ def RenderACL(
     acl_suffix: str,
     output_directory: pathlib.Path,
     input_file: pathlib.Path,
-    write_files: List[Tuple[pathlib.Path, str]],
+    write_files: list[tuple[pathlib.Path, str]],
     binary: bool = False,
 ):
     """Write the ACL string out to file if appropriate.
@@ -311,7 +312,7 @@ def FilesUpdated(file_name: pathlib.Path, new_text: str, binary: bool) -> bool:
     try:
         with open(file_name, readmode) as f:
             conf: str = str(f.read())
-    except IOError:
+    except OSError:
         return True
     if not binary:
         p4_id = '$I d:'.replace(' ', '')
@@ -327,7 +328,7 @@ def FilesUpdated(file_name: pathlib.Path, new_text: str, binary: bool) -> bool:
     return conf != new_text
 
 
-def DescendDirectory(input_dirname: str, ignore_directories: List[str]) -> List[pathlib.Path]:
+def DescendDirectory(input_dirname: str, ignore_directories: list[str]) -> list[pathlib.Path]:
     """Descend from input_dirname looking for policy files to render.
 
     Args:
@@ -339,7 +340,7 @@ def DescendDirectory(input_dirname: str, ignore_directories: List[str]) -> List[
     """
     input_dir = pathlib.Path(input_dirname)
 
-    policy_files: List[pathlib.Path] = []
+    policy_files: list[pathlib.Path] = []
     policy_directories: Iterator[pathlib.Path] = filter(
         lambda path: path.is_dir(), input_dir.glob('**/pol')
     )
@@ -395,7 +396,7 @@ def _WriteFile(output_file: pathlib.Path, file_contents: str):
         with open(output_file, 'w') as output:
             logging.info('writing file: %s', output_file)
             output.write(file_contents)
-    except IOError:
+    except OSError:
         logging.warning('error while writing file: %s', output_file)
         raise
 
@@ -407,7 +408,7 @@ def Run(
     output_directory: str,
     exp_info: int,
     max_renderers: int,
-    ignore_directories: List[str],
+    ignore_directories: list[str],
     optimize: bool,
     shade_check: bool,
     context: multiprocessing.context.BaseContext,
@@ -466,7 +467,7 @@ def Run(
         # render all files in parallel
         policies = DescendDirectory(base_directory, ignore_directories)
         pool = context.Pool(processes=max_renderers)
-        results: List[multiprocessing.pool.AsyncResult] = []
+        results: list[multiprocessing.pool.AsyncResult] = []
         for pol in policies:
             results.append(
                 pool.apply_async(

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -19,7 +19,6 @@ import copy
 import multiprocessing
 import pathlib
 import sys
-from typing import List, Tuple
 from collections.abc import Iterator
 
 from absl import app, flags, logging

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -419,7 +419,7 @@ def _GenerateACL(
         return
     except (policy.Error, naming.Error) as e:
         raise ACLParserError(
-            'Error parsing policy %s:\n%s%s' % (filename, sys.exc_info()[0], sys.exc_info()[1])
+            f'Error parsing policy {filename}:\n{sys.exc_info()[0]}{sys.exc_info()[1]}'
         ) from e
 
     platforms = set()
@@ -432,7 +432,7 @@ def _GenerateACL(
     def EmitACL(
         acl_text: str,
         acl_suffix: str,
-        write_files: typing.List[typing.Tuple[pathlib.Path, str]],
+        write_files: list[tuple[pathlib.Path, str]],
         binary: bool = False,
     ):
         if output_directory:
@@ -468,7 +468,7 @@ def _GenerateACL(
 
         except aclgenerator.Error as e:
             raise ACLGeneratorError(
-                'Error generating target ACL for %s:\n%s' % (filename, e)
+                f'Error generating target ACL for {filename}:\n{e}'
             ) from e
 
 
@@ -489,5 +489,5 @@ def AclCheck(
         return check.Summarize()
     except (policy.Error, naming.Error) as e:
         raise ACLParserError(
-            'Error parsing policy %s:\n%s%s' % (filename, sys.exc_info()[0], sys.exc_info()[1])
+            f'Error parsing policy {filename}:\n{sys.exc_info()[0]}{sys.exc_info()[1]}'
         ) from e

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -466,9 +466,7 @@ def _GenerateACL(
                 EmitACL(str(acl_obj), acl_obj.SUFFIX, write_files)
 
         except aclgenerator.Error as e:
-            raise ACLGeneratorError(
-                f'Error generating target ACL for {filename}:\n{e}'
-            ) from e
+            raise ACLGeneratorError(f'Error generating target ACL for {filename}:\n{e}') from e
 
 
 def AclCheck(

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -213,7 +213,6 @@ import copy
 import multiprocessing
 import pathlib
 import sys
-import typing
 from typing import Optional
 
 from absl import logging

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -115,8 +115,8 @@ class Term:
     #  mapping.
     ALWAYS_PROTO_NUM = ['ipip']
     # provide flipped key/value dicts
-    PROTO_MAP_BY_NUMBER = dict([(v, k) for (k, v) in PROTO_MAP.items()])
-    AF_MAP_BY_NUMBER = dict([(v, k) for (k, v) in AF_MAP.items()])
+    PROTO_MAP_BY_NUMBER = {v: k for (k, v) in PROTO_MAP.items()}
+    AF_MAP_BY_NUMBER = {v: k for (k, v) in AF_MAP.items()}
 
     NO_AF_LOG_ADDR = string.Template(
         'Term $term will not be rendered, as it has'
@@ -171,8 +171,8 @@ class Term:
         return af
 
     def NormalizeIcmpTypes(
-        self, icmp_types: List[str], protocols: List[str], af: int
-    ) -> List[int]:
+        self, icmp_types: list[str], protocols: list[str], af: int
+    ) -> list[int]:
         """Return verified list of appropriate icmp-types.
 
         Args:
@@ -198,7 +198,7 @@ class Term:
             and protocols != [self.PROTO_MAP['icmpv6']]
         ):
             raise UnsupportedFilterError(
-                '%s %s' % ('icmp-types specified for non-icmp protocols in term: ', self.term.name)
+                '{} {}'.format('icmp-types specified for non-icmp protocols in term: ', self.term.name)
             )
         # make sure we have a numeric address family (4 or 6)
         af = self.NormalizeAddressFamily(af)
@@ -360,7 +360,7 @@ class ACLGenerator:
         """Translate policy contents to platform specific data structures."""
         raise Error('%s does not implement _TranslatePolicies()' % self._PLATFORM)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Provide a default for supported tokens and sub tokens.
 
         Returns:
@@ -413,7 +413,7 @@ class ACLGenerator:
         }
         return supported_tokens, supported_sub_tokens
 
-    def _GetSupportedTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _GetSupportedTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build our supported tokens and sub tokens.
 
         Returns:
@@ -459,7 +459,7 @@ class ACLGenerator:
         if term.protocol:
             protocols = set(term.protocol)
         else:
-            protocols = set((self._DEFAULT_PROTOCOL,))
+            protocols = {self._DEFAULT_PROTOCOL}
 
         # Check that the address family matches the protocols.
         if af not in self._SUPPORTED_AF:
@@ -479,7 +479,7 @@ class ACLGenerator:
         # Many renders expect high ports for terms with the established option.
         for opt in [str(x) for x in term.option]:
             if opt.find('established') == 0:
-                unstateful_protocols = protocols.difference(set(('tcp', 'udp')))
+                unstateful_protocols = protocols.difference({'tcp', 'udp'})
                 if not unstateful_protocols:
                     # TCP/UDP: add in high ports then collapse to eliminate overlaps.
                     mod = copy.deepcopy(term)
@@ -489,7 +489,7 @@ class ACLGenerator:
                 elif not all_protocols_stateful:
                     errmsg = 'Established option supplied with inappropriate protocol(s)'
                     raise EstablishedError(
-                        '%s %s %s %s' % (errmsg, unstateful_protocols, 'in term', term.name)
+                        '{} {} {} {}'.format(errmsg, unstateful_protocols, 'in term', term.name)
                     )
                 break
 
@@ -556,7 +556,7 @@ class ACLGenerator:
         name_bytes = name.encode('UTF-8')
         return hashlib.sha256(name_bytes).hexdigest()[:truncation_length]
 
-    def _FilteredTerms(self, header: policy.Header, terms: List[policy.Term], exp_info: int):
+    def _FilteredTerms(self, header: policy.Header, terms: list[policy.Term], exp_info: int):
         new_terms = []
         filter_name = header.FilterName(self._PLATFORM)
         current_date = datetime.datetime.utcnow().date()
@@ -589,8 +589,8 @@ class ACLGenerator:
 
 
 def ProtocolNameToNumber(
-    protocols: List[str], proto_to_num: List[str], name_to_num_map: Dict[str, int]
-) -> List[Union[str, int]]:
+    protocols: list[str], proto_to_num: list[str], name_to_num_map: dict[str, int]
+) -> list[Union[str, int]]:
     """Convert a protocol name to a numeric value.
 
     Args:
@@ -618,7 +618,7 @@ def AddRepositoryTags(
     date: bool = True,
     revision: bool = True,
     wrap: bool = False,
-) -> List[str]:
+) -> list[str]:
     """Add repository tagging into the output.
 
     Args:
@@ -635,19 +635,19 @@ def AddRepositoryTags(
 
     # Format print the '$' into the RCS tags in order prevent the tags from
     # being interpolated here.
-    p4_id = '%s%sId:%s%s' % (wrapper, '$', '$', wrapper)
-    p4_date = '%s%sDate:%s%s' % (wrapper, '$', '$', wrapper)
-    p4_revision = '%s%sRevision:%s%s' % (wrapper, '$', '$', wrapper)
+    p4_id = '{}{}Id:{}{}'.format(wrapper, '$', '$', wrapper)
+    p4_date = '{}{}Date:{}{}'.format(wrapper, '$', '$', wrapper)
+    p4_revision = '{}{}Revision:{}{}'.format(wrapper, '$', '$', wrapper)
     if rid:
-        tags.append('%s%s' % (prefix, p4_id))
+        tags.append(f'{prefix}{p4_id}')
     if date:
-        tags.append('%s%s' % (prefix, p4_date))
+        tags.append(f'{prefix}{p4_date}')
     if revision:
-        tags.append('%s%s' % (prefix, p4_revision))
+        tags.append(f'{prefix}{p4_revision}')
     return tags
 
 
-def WrapWords(textlist: List[str], size: int, joiner: str = '\n'):
+def WrapWords(textlist: list[str], size: int, joiner: str = '\n'):
     r"""Insert breaks into the listed strings at specified width.
 
     Args:

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -198,7 +198,9 @@ class Term:
             and protocols != [self.PROTO_MAP['icmpv6']]
         ):
             raise UnsupportedFilterError(
-                '{} {}'.format('icmp-types specified for non-icmp protocols in term: ', self.term.name)
+                '{} {}'.format(
+                    'icmp-types specified for non-icmp protocols in term: ', self.term.name
+                )
             )
         # make sure we have a numeric address family (4 or 6)
         af = self.NormalizeAddressFamily(af)

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -21,7 +21,7 @@ import datetime
 import hashlib
 import re
 import string
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 
 from absl import logging
 

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -2,7 +2,7 @@ import collections
 import heapq
 import ipaddress
 import itertools
-from typing import List, Union
+from typing import Union
 
 from aerleon.lib.fqdn import FQDN
 from aerleon.lib.nacaddr import IPv4, IPv6

--- a/aerleon/lib/addressbook.py
+++ b/aerleon/lib/addressbook.py
@@ -13,7 +13,7 @@ class Addressbook:
         self._fqdn_addressbook = collections.OrderedDict()
         self._ip_addressbook = collections.OrderedDict()
 
-    def GetZoneNames(self) -> List:
+    def GetZoneNames(self) -> list:
         """Get each zone name contained within the address book.
 
         Returns:
@@ -74,7 +74,7 @@ class Addressbook:
         """
         return [i for i in self._fqdn_addressbook[zone]]
 
-    def AddFQDNs(self, zone: str, fqdn_list: List[FQDN], suffix=''):
+    def AddFQDNs(self, zone: str, fqdn_list: list[FQDN], suffix=''):
         """Adds a list of FQDNs to the addressbook.
         Args:
           zone: The zone in which to add the FQDNs.
@@ -97,7 +97,7 @@ class Addressbook:
         """
         return self._ip_addressbook[zone][name]
 
-    def AddAddresses(self, zone: str, address_list: List[Union[IPv4, IPv6]]):
+    def AddAddresses(self, zone: str, address_list: list[Union[IPv4, IPv6]]):
         """Create the address book configuration entries.
 
         Args:
@@ -112,7 +112,7 @@ class Addressbook:
         when new networks are added.
         """
 
-        def _drop_subnets(address_list: List[Union[IPv4, IPv6]]):
+        def _drop_subnets(address_list: list[Union[IPv4, IPv6]]):
             """Remove any network contained by another network in this list.
 
             Args:

--- a/aerleon/lib/arista.py
+++ b/aerleon/lib/arista.py
@@ -16,8 +16,6 @@
 
 """Arista generator."""
 
-from typing import List
-
 from aerleon.lib import cisco
 
 

--- a/aerleon/lib/arista.py
+++ b/aerleon/lib/arista.py
@@ -43,7 +43,7 @@ class Arista(cisco.Cisco):
     _PROTO_INT = False
 
     # Arista omits the "extended" access-list argument.
-    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> List[str]:
+    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> list[str]:
         """Takes in the filter name and type and appends headers.
 
         Args:
@@ -74,6 +74,6 @@ class Arista(cisco.Cisco):
             target.append('ipv6 access-list %s' % filter_name)
         else:
             raise UnsupportedEosAccessListError(
-                'access list type %s not supported by %s' % (filter_type, self._PLATFORM)
+                f'access list type {filter_type} not supported by {self._PLATFORM}'
             )
         return target

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -208,7 +208,7 @@ class Term(aclgenerator.Term):
         family_keywords = self._TERM_TYPE.get(self.term_type)
 
         term_block.append(
-            [TERM_INDENT, "match %s %s" % (self.term.name, family_keywords["addr_fam"]), False]
+            [TERM_INDENT, "match {} {}".format(self.term.name, family_keywords["addr_fam"]), False]
         )
 
         term_af = self.AF_MAP.get(self.term_type)
@@ -411,7 +411,7 @@ class Term(aclgenerator.Term):
 
         return port_str
 
-    def _processICMP(self, term: policy.Term) -> Tuple[str, str]:
+    def _processICMP(self, term: policy.Term) -> tuple[str, str]:
         icmp_types = [""]
         icmp_code_str = ""
         icmp_type_str = " type "
@@ -434,7 +434,7 @@ class Term(aclgenerator.Term):
 
         return icmp_type_str, icmp_code_str
 
-    def _processProtocol(self, term_type: str, term: policy.Term, flags: List[str]) -> str:
+    def _processProtocol(self, term_type: str, term: policy.Term, flags: list[str]) -> str:
         anet_proto_map = {
             "inet": {
                 # <1-255> protocol  values(s) or range(s) of protocol  values
@@ -490,7 +490,7 @@ class Term(aclgenerator.Term):
 
         return protocol_str
 
-    def _processProtocolExcept(self, term_type: str, term: policy.Term, flags: List[str]) -> str:
+    def _processProtocolExcept(self, term_type: str, term: policy.Term, flags: list[str]) -> str:
         # EOS does not have a protocol-except keyword. it does, however, support
         # lists of protocol-ids. given a term this function will generate the
         # appropriate list of protocol-id's which *will* be permited. within the
@@ -527,8 +527,8 @@ class Term(aclgenerator.Term):
         return protocol_str
 
     def _processTermOptions(
-        self, term: policy.Term, options: List[str]
-    ) -> Tuple[List[str], List[str]]:
+        self, term: policy.Term, options: list[str]
+    ) -> tuple[list[str], list[str]]:
         flags = []
         misc_options = []
 
@@ -561,7 +561,7 @@ class Term(aclgenerator.Term):
 
         return flags, misc_options
 
-    def _Group(self, group: List[Union[str, Tuple[int, int]]], lc: bool = True) -> str:
+    def _Group(self, group: list[Union[str, tuple[int, int]]], lc: bool = True) -> str:
         """If 1 item return it, else return [item1 item2].
 
         Args:
@@ -624,7 +624,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
 
     SUFFIX = ".atp"
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """returns: tuple of supported tokens and sub tokens."""
         supported_tokens, supported_sub_tokens = super()._BuildTokens()
 
@@ -673,8 +673,8 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
         return supported_tokens, supported_sub_tokens
 
     def _MinimizePrefixes(
-        self, include: List[Union[IPv4, IPv6]], exclude: List[Union[IPv4, IPv6]]
-    ) -> Union[Tuple[List[IPv4], List[IPv4]], Tuple[List[IPv6], List[IPv6]]]:
+        self, include: list[Union[IPv4, IPv6]], exclude: list[Union[IPv4, IPv6]]
+    ) -> Union[tuple[list[IPv4], list[IPv4]], tuple[list[IPv6], list[IPv6]]]:
         """Calculate a minimal set of prefixes for match conditions.
 
         Args:
@@ -711,8 +711,8 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
         self,
         direction: str,
         name: str,
-        pfxs: List[Union[IPv4, IPv6]],
-        ex_pfxs: List[Union[IPv4, IPv6]],
+        pfxs: list[Union[IPv4, IPv6]],
+        ex_pfxs: list[Union[IPv4, IPv6]],
         af: str,
     ) -> str:
         field_list = ""

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -17,7 +17,7 @@
 
 import copy
 import re
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 
 from absl import logging
 

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -82,7 +82,7 @@ class Term(aclgenerator.Term):
         if self.term.verbatim:
             for next_verbatim in self.term.verbatim:
                 if next_verbatim[0] == self._PLATFORM and next_verbatim[1]:
-                    ret_str.append('%s%s' % (self._IDENT, next_verbatim[1]))
+                    ret_str.append(f'{self._IDENT}{next_verbatim[1]}')
 
             return '\n'.join(t for t in ret_str if t)
         if self.verbose:
@@ -93,7 +93,7 @@ class Term(aclgenerator.Term):
 
             if comments:
                 for line in aclgenerator.WrapWords(comments, self._COMMENT_LINE_LENGTH):
-                    ret_str.append('%s%s %s' % (self._IDENT, _COMMENT_MARKER, line))
+                    ret_str.append(f'{self._IDENT}{_COMMENT_MARKER} {line}')
 
         src_addr_token = ''
         dst_addr_token = ''
@@ -106,8 +106,8 @@ class Term(aclgenerator.Term):
                 if not src_addr:
                     return ''
 
-                src_netdest_id = '%s%s' % (self.term.name.lower(), self._SRC_NETDEST_SUF)
-                src_addr_token = '%s %s' % (self._ALIAS_STR, src_netdest_id)
+                src_netdest_id = f'{self.term.name.lower()}{self._SRC_NETDEST_SUF}'
+                src_addr_token = f'{self._ALIAS_STR} {src_netdest_id}'
                 netdestinations.append(self._GenerateNetdest(src_netdest_id, src_addr, term_af))
 
             else:
@@ -121,8 +121,8 @@ class Term(aclgenerator.Term):
                 if not dst_addr:
                     return ''
 
-                dst_netdest_id = '%s%s' % (self.term.name.lower(), self._DST_NETDEST_SUF)
-                dst_addr_token = '%s %s' % (self._ALIAS_STR, dst_netdest_id)
+                dst_netdest_id = f'{self.term.name.lower()}{self._DST_NETDEST_SUF}'
+                dst_addr_token = f'{self._ALIAS_STR} {dst_netdest_id}'
                 netdestinations.append(self._GenerateNetdest(dst_netdest_id, dst_addr, term_af))
             else:
                 dst_addr_token = self._ANY_STR
@@ -170,10 +170,10 @@ class Term(aclgenerator.Term):
         # Aruba does not use IP version identifier for IPv4.
         addr_family = '6' if af == 6 else ''
 
-        ret_str.append('%s %s' % (self._NET_DEST_STR + addr_family, addr_netdestid))
+        ret_str.append(f'{self._NET_DEST_STR + addr_family} {addr_netdestid}')
 
         for address in addresses:
-            ret_str.append('%s%s' % (self._IDENT, self._GenerateNetworkOrHostTokens(address)))
+            ret_str.append(f'{self._IDENT}{self._GenerateNetworkOrHostTokens(address)}')
 
         ret_str.append('%s\n' % _TERMINATOR_MARKER)
 
@@ -189,14 +189,14 @@ class Term(aclgenerator.Term):
           Aruba ACLs.
         """
         if address.num_addresses == 1:
-            return '%s %s' % (self._HOST_STRING, address.network_address)
+            return f'{self._HOST_STRING} {address.network_address}'
 
         if address.version == 6:
-            return '%s %s/%s' % (self._NETWORK_STRING, address.network_address, address.prefixlen)
+            return f'{self._NETWORK_STRING} {address.network_address}/{address.prefixlen}'
 
-        return '%s %s %s' % (self._NETWORK_STRING, address.network_address, address.netmask)
+        return f'{self._NETWORK_STRING} {address.network_address} {address.netmask}'
 
-    def _GeneratePortTokens(self, protocols: List[str], ports: List[Tuple[int, int]]) -> List[str]:
+    def _GeneratePortTokens(self, protocols: list[str], ports: list[tuple[int, int]]) -> list[str]:
         """Generates string tokens for ports.
 
         Args:
@@ -232,7 +232,7 @@ class Aruba(aclgenerator.ACLGenerator):
 
     _ACL_LINE_HEADER = 'ip access-list session'
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -300,7 +300,7 @@ class Aruba(aclgenerator.ACLGenerator):
                 netdestinations.extend(term.netdestinations)
 
             target.extend(netdestinations)
-            target.append('%s %s' % (self._ACL_LINE_HEADER, filter_name))
+            target.append(f'{self._ACL_LINE_HEADER} {filter_name}')
             target.extend(term_strings)
             target.extend(_TERMINATOR_MARKER)
 

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -16,7 +16,7 @@
 
 """Aruba generator."""
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 from aerleon.lib import aclgenerator, policy
 from aerleon.lib.nacaddr import IPv4, IPv6

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -17,7 +17,7 @@
 """Cisco generator."""
 
 import ipaddress
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 from absl import logging
 

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -222,7 +222,7 @@ class ObjectGroup:
             for port in term.source_port + term.destination_port:
                 if not port:
                     continue
-                port_key = '%s-%s' % (port[0], port[1])
+                port_key = f'{port[0]}-{port[1]}'
                 if port_key not in ports:
                     ports[port_key] = True
                     ret_str.append('object-group port %s' % port_key)
@@ -531,7 +531,7 @@ class Term(aclgenerator.Term):
         else:
             # source address not set
             source_address = [nacaddr.IPv4('0.0.0.0/0', token='any')]
-        fixed_src_addresses = set([x for x in source_address])
+        fixed_src_addresses = {x for x in source_address}
 
         # destination address
         if self.term.destination_address:
@@ -557,7 +557,7 @@ class Term(aclgenerator.Term):
             # destination address not set
             destination_address = [nacaddr.IPv4('0.0.0.0/0', token='any')]
 
-        fixed_dst_addresses = set([x for x in destination_address])
+        fixed_dst_addresses = {x for x in destination_address}
 
         # ports
         source_port = [()]
@@ -605,7 +605,7 @@ class Term(aclgenerator.Term):
                 )
             nexthop = self.term.next_ip[0].network_address
             nexthop_protocol = 'ipv4' if nexthop.version == 4 else 'ipv6'
-            self.options.append('nexthop1 %s %s' % (nexthop_protocol, nexthop))
+            self.options.append(f'nexthop1 {nexthop_protocol} {nexthop}')
             action = _ACTION_TABLE.get('accept')
 
         # action
@@ -684,7 +684,7 @@ class Term(aclgenerator.Term):
             if addr.num_addresses > 1:
                 if self.platform in ('arista', 'cisconx'):
                     return addr.with_prefixlen
-                return '%s %s' % (addr.network_address, addr.hostmask)
+                return f'{addr.network_address} {addr.hostmask}'
             if addr.num_addresses == 1 and self.platform == 'cisconx':
                 return '%s' % (addr.with_prefixlen)
             return 'host %s' % (addr.network_address)
@@ -695,7 +695,7 @@ class Term(aclgenerator.Term):
             return 'host %s' % (addr.network_address)
         return addr
 
-    def _FormatPort(self, port: Union[Tuple[()], Tuple[int, int]], proto: Union[int, str]) -> str:
+    def _FormatPort(self, port: Union[tuple[()], tuple[int, int]], proto: Union[int, str]) -> str:
         """Returns a formatted port string for the range.
 
         Args:
@@ -714,12 +714,12 @@ class Term(aclgenerator.Term):
             port1 = PortMap.GetProtocol(port1, proto, self.platform)
 
         if port[0] != port[1]:
-            return 'range %s %s' % (port0, port1)
+            return f'range {port0} {port1}'
         return 'eq %s' % (port0)
 
     def _FixOptions(
-        self, proto: Union[int, str], option: List[Union[str, Any]]
-    ) -> List[Union[str, Any]]:
+        self, proto: Union[int, str], option: list[Union[str, Any]]
+    ) -> list[Union[str, Any]]:
         """Returns a set of options suitable for the given protocol.
 
         Fix done:
@@ -748,8 +748,8 @@ class Term(aclgenerator.Term):
         dport: str,
         icmp_type: Union[int, str],
         icmp_code: Union[int, str],
-        option: List[str],
-    ) -> List[str]:
+        option: list[str],
+    ) -> list[str]:
         """Take the various compenents and turn them into a cisco acl line.
 
         Args:
@@ -786,7 +786,7 @@ class Term(aclgenerator.Term):
         non_empty_elements = [x for x in all_elements if x]
         return [' ' + ' '.join(non_empty_elements)]
 
-    def _FixConsecutivePorts(self, port_list: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    def _FixConsecutivePorts(self, port_list: list[tuple[int, int]]) -> list[tuple[int, int]]:
         """Takes a list of tuples and expands the tuple if the range is two.
 
             http://www.cisco.com/warp/public/cc/pd/si/casi/ca6000/tech/65acl_wp.pdf
@@ -826,7 +826,7 @@ class ObjectGroupTerm(Term):
     in the acl.
     """
 
-    def _FormatPort(self, port: Union[Tuple[()], Tuple[int, int]], proto: str) -> str:
+    def _FormatPort(self, port: Union[tuple[()], tuple[int, int]], proto: str) -> str:
         """Returns a formatted port string for the range.
 
         Args:
@@ -863,7 +863,7 @@ class Cisco(aclgenerator.ACLGenerator):
     _PROTO_INT = True
     _TERM_REMARK = True
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -1005,7 +1005,7 @@ class Cisco(aclgenerator.ACLGenerator):
         """Returns an ObjectGroupTerm object."""
         return ObjectGroupTerm(term, verbose=verbose)
 
-    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> List[str]:
+    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> list[str]:
         """Takes in the filter name and type and appends headers.
 
         Args:
@@ -1036,13 +1036,13 @@ class Cisco(aclgenerator.ACLGenerator):
             target.append('ipv6 access-list %s' % filter_name)
         else:
             raise UnsupportedCiscoAccessListError(
-                'access list type %s not supported by %s' % (filter_type, self._PLATFORM)
+                f'access list type {filter_type} not supported by {self._PLATFORM}'
             )
         return target
 
     def _RepositoryTagsHelper(
-        self, target: Optional[List[str]] = None, filter_type: str = '', filter_name: str = ''
-    ) -> List[str]:
+        self, target: Optional[list[str]] = None, filter_type: str = '', filter_name: str = ''
+    ) -> list[str]:
         if target is None:
             target = []
         if filter_type == 'standard' and filter_name.isdigit():
@@ -1082,7 +1082,7 @@ class Cisco(aclgenerator.ACLGenerator):
                                 and filter_type == 'standard'
                                 and filter_name.isdigit()
                             ):
-                                target.append('access-list %s remark %s' % (filter_name, line))
+                                target.append(f'access-list {filter_name} remark {line}')
                             else:
                                 target.append(' remark %s' % line)
 

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -18,7 +18,7 @@
 
 import ipaddress
 import re
-from typing import Any, Dict, List, Set, Tuple, Union, cast
+from typing import Union, cast
 
 from absl import logging
 

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -76,12 +76,12 @@ class Term(cisco.ExtendedTerm):
             ret_str.append('remark not rendered due to protocol/AF mismatch.')
             return '\n'.join(ret_str)
 
-        ret_str.append('access-list %s remark %s' % (self.filter_name, self.term.name))
+        ret_str.append(f'access-list {self.filter_name} remark {self.term.name}')
         if self.term.owner:
             self.term.comment.append('Owner: %s' % self.term.owner)
         for comment in self.term.comment:
             for line in comment.split('\n'):
-                ret_str.append('access-list %s remark %s' % (self.filter_name, str(line)[:100]))
+                ret_str.append(f'access-list {self.filter_name} remark {str(line)[:100]}')
 
         # Term verbatim output - this will skip over normal term creation
         # code by returning early.  Warnings provided in policy.py.
@@ -202,12 +202,12 @@ class Term(cisco.ExtendedTerm):
         action: str,
         proto: str,
         saddr: Union[str, IPv4, IPv6],
-        sport: Union[Tuple[()], Tuple[int, int]],
+        sport: Union[tuple[()], tuple[int, int]],
         daddr: Union[str, IPv4, IPv6],
-        dport: Union[Tuple[()], Tuple[int, int]],
+        dport: Union[tuple[()], tuple[int, int]],
         icmp_type: str,
-        option: List[str],
-    ) -> List[str]:
+        option: list[str],
+    ) -> list[str]:
         """Take the various compenents and turn them into a cisco acl line.
 
         Args:
@@ -228,13 +228,13 @@ class Term(cisco.ExtendedTerm):
         if isinstance(saddr, nacaddr.IPv4) or isinstance(saddr, ipaddress.IPv4Network):
             saddr = cast(self.IPV4_ADDRESS, saddr)
             if saddr.num_addresses > 1:
-                saddr = '%s %s' % (saddr.network_address, saddr.netmask)
+                saddr = f'{saddr.network_address} {saddr.netmask}'
             else:
                 saddr = 'host %s' % (saddr.network_address)
         if isinstance(daddr, nacaddr.IPv4) or isinstance(daddr, ipaddress.IPv4Network):
             daddr = cast(self.IPV4_ADDRESS, daddr)
             if daddr.num_addresses > 1:
-                daddr = '%s %s' % (daddr.network_address, daddr.netmask)
+                daddr = f'{daddr.network_address} {daddr.netmask}'
             else:
                 daddr = 'host %s' % (daddr.network_address)
         if isinstance(saddr, summarizer.DSMNet):
@@ -246,13 +246,13 @@ class Term(cisco.ExtendedTerm):
         if isinstance(saddr, nacaddr.IPv6) or isinstance(saddr, ipaddress.IPv6Network):
             saddr = cast(self.IPV6_ADDRESS, saddr)
             if saddr.num_addresses > 1:
-                saddr = '%s/%s' % (saddr.network_address, saddr.prefixlen)
+                saddr = f'{saddr.network_address}/{saddr.prefixlen}'
             else:
                 saddr = 'host %s' % (saddr.network_address)
         if isinstance(daddr, nacaddr.IPv6) or isinstance(daddr, ipaddress.IPv6Network):
             daddr = cast(self.IPV6_ADDRESS, daddr)
             if daddr.num_addresses > 1:
-                daddr = '%s/%s' % (daddr.network_address, daddr.prefixlen)
+                daddr = f'{daddr.network_address}/{daddr.prefixlen}'
             else:
                 daddr = 'host %s' % (daddr.network_address)
 
@@ -260,7 +260,7 @@ class Term(cisco.ExtendedTerm):
         if not sport:
             sport = ''
         elif sport[0] != sport[1]:
-            sport = ' range %s %s' % (
+            sport = ' range {} {}'.format(
                 cisco.PortMap.GetProtocol(sport[0], proto),
                 cisco.PortMap.GetProtocol(sport[1], proto),
             )
@@ -270,7 +270,7 @@ class Term(cisco.ExtendedTerm):
         if not dport:
             dport = ''
         elif dport[0] != dport[1]:
-            dport = ' range %s %s' % (
+            dport = ' range {} {}'.format(
                 cisco.PortMap.GetProtocol(dport[0], proto),
                 cisco.PortMap.GetProtocol(dport[1], proto),
             )
@@ -317,7 +317,7 @@ class CiscoASA(aclgenerator.ACLGenerator):
     _DEFAULT_PROTOCOL = 'ip'
     SUFFIX = '.asa'
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -363,7 +363,7 @@ class CiscoASA(aclgenerator.ACLGenerator):
             # add a header comment if one exists
             for comment in header.comment:
                 for line in comment.split('\n'):
-                    target.append('access-list %s remark %s' % (filter_name, line))
+                    target.append(f'access-list {filter_name} remark {line}')
 
             # now add the terms
             for term in terms:

--- a/aerleon/lib/cisconx.py
+++ b/aerleon/lib/cisconx.py
@@ -15,7 +15,7 @@
 #
 """CiscoNX generator."""
 
-from typing import List, Optional
+from typing import Optional
 
 from aerleon.lib import aclgenerator, cisco
 

--- a/aerleon/lib/cisconx.py
+++ b/aerleon/lib/cisconx.py
@@ -41,15 +41,15 @@ class CiscoNX(cisco.Cisco):
     _PROTO_INT = False
 
     def _RepositoryTagsHelper(
-        self, target: Optional[List[str]] = None, filter_type: str = '', filter_name: str = ''
-    ) -> List[str]:
+        self, target: Optional[list[str]] = None, filter_type: str = '', filter_name: str = ''
+    ) -> list[str]:
         if target is None:
             target = []
         target.extend(aclgenerator.AddRepositoryTags(' remark ', rid=False, wrap=True))
         return target
 
     # CiscoNX omits the "extended" access-list argument.
-    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> List[str]:
+    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> list[str]:
         """Takes in the filter name and type and appends headers.
 
         Args:
@@ -74,6 +74,6 @@ class CiscoNX(cisco.Cisco):
             target.append('ipv6 access-list %s' % filter_name)
         else:
             raise UnsupportedNXosAccessListError(
-                'access list type %s not supported by %s' % (filter_type, self._PLATFORM)
+                f'access list type {filter_type} not supported by {self._PLATFORM}'
             )
         return target

--- a/aerleon/lib/ciscoxr.py
+++ b/aerleon/lib/ciscoxr.py
@@ -31,7 +31,7 @@ class CiscoXR(cisco.Cisco):
     SUFFIX = '.xacl'
     _PROTO_INT = False
 
-    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> List[str]:
+    def _AppendTargetByFilterType(self, filter_name: str, filter_type: str) -> list[str]:
         """Takes in the filter name and type and appends headers.
 
         Args:
@@ -50,7 +50,7 @@ class CiscoXR(cisco.Cisco):
             target.append('ipv4 access-list %s' % filter_name)
         return target
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/ciscoxr.py
+++ b/aerleon/lib/ciscoxr.py
@@ -17,8 +17,6 @@
 """Cisco IOS-XR filter renderer."""
 from __future__ import annotations
 
-from typing import Dict, List, Set, Tuple
-
 from aerleon.lib import cisco
 from aerleon.lib.policy import Term
 

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -31,9 +31,13 @@ class UnsupportedFilterTypeError(Error):
 
 class RuleMatchConfig(TypedDict):
     srcIpRanges: 'list[str]'
+
+
 class RuleMatch(TypedDict):
     config: RuleMatchConfig
     versionedExpr: str
+
+
 class PolicyRule(TypedDict):
     action: str
     description: str

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -16,10 +16,7 @@ from absl import logging
 
 from aerleon.lib import aclgenerator, policy
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 
 # Generic error class
@@ -35,12 +32,17 @@ class UnsupportedFilterTypeError(Error):
     """Raised when unsupported filter type (i.e address family) is specified."""
 
 
-RuleMatchConfig = TypedDict("RuleMatchConfig", {"srcIpRanges": "list[str]"})
-RuleMatch = TypedDict("RuleMatch", {"config": RuleMatchConfig, "versionedExpr": str})
-PolicyRule = TypedDict(
-    "PolicyRule",
-    {"action": str, "description": str, "match": RuleMatch, "preview": bool, "priority": int},
-)
+class RuleMatchConfig(TypedDict):
+    srcIpRanges: 'list[str]'
+class RuleMatch(TypedDict):
+    config: RuleMatchConfig
+    versionedExpr: str
+class PolicyRule(TypedDict):
+    action: str
+    description: str
+    match: RuleMatch
+    preview: bool
+    priority: int
 
 
 class Term(aclgenerator.Term):
@@ -64,7 +66,7 @@ class Term(aclgenerator.Term):
     def __str__(self) -> str:
         return ''
 
-    def ConvertToDict(self, priority_index: int) -> List[PolicyRule]:
+    def ConvertToDict(self, priority_index: int) -> list[PolicyRule]:
         """Converts term to dictionary representation of CloudArmor's JSON format.
 
         Takes all of the attributes associated with a term (match, action, etc) and
@@ -167,7 +169,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
 
     _PLATFORM = 'cloudarmor'
     SUFFIX = '.gca'
-    _SUPPORTED_AF = set(('inet', 'inet6', 'mixed'))
+    _SUPPORTED_AF = {'inet', 'inet6', 'mixed'}
 
     # Maximum number of rules that a CloudArmor policy can contain
     _MAX_RULES_PER_POLICY = 200
@@ -178,7 +180,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
     # Maps indiviudal filter options to their index positions in the POL header
     _FILTER_OPTIONS_MAP = {'filter_type': 0}
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -9,14 +9,11 @@ https://cloud.google.com/armor/docs/
 
 import copy
 import json
-import sys
-from typing import Dict, List, Set, Tuple
+from typing import TypedDict
 
 from absl import logging
 
 from aerleon.lib import aclgenerator, policy
-
-from typing import TypedDict
 
 
 # Generic error class

--- a/aerleon/lib/demo.py
+++ b/aerleon/lib/demo.py
@@ -176,7 +176,7 @@ class Demo(aclgenerator.ACLGenerator):
     _SUFFIX = '.demo'
 
     _OPTIONAL_SUPPORTED_KEYWORDS = {
-            'expiration',
+        'expiration',
     }
 
     def _TranslatePolicy(self, pol, exp_info):

--- a/aerleon/lib/demo.py
+++ b/aerleon/lib/demo.py
@@ -175,11 +175,9 @@ class Demo(aclgenerator.ACLGenerator):
     _PLATFORM = 'demo'
     _SUFFIX = '.demo'
 
-    _OPTIONAL_SUPPORTED_KEYWORDS = set(
-        [
+    _OPTIONAL_SUPPORTED_KEYWORDS = {
             'expiration',
-        ]
-    )
+    }
 
     def _TranslatePolicy(self, pol, exp_info):
         self.demo_policies = []

--- a/aerleon/lib/fortigate.py
+++ b/aerleon/lib/fortigate.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List, MutableMapping, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
+from collections.abc import MutableMapping
 
 from absl import logging
 
@@ -58,7 +59,7 @@ class FortigateObjectGroup:
 
 
 class FortigateIcmpService(FortigateObjectGroup):
-    def __init__(self, name: str, icmp_types: List[int]):
+    def __init__(self, name: str, icmp_types: list[int]):
         self.name = f'{name}-icmp'
         self.icmp_types = [str(i) for i in icmp_types]
 
@@ -76,8 +77,8 @@ class FortigateIPService(FortigateObjectGroup):
     def __init__(
         self,
         name: str,
-        source_port: List[Tuple[int, int]],
-        destination_port: List[Tuple[int, int]],
+        source_port: list[tuple[int, int]],
+        destination_port: list[tuple[int, int]],
         protocols: list[str],
     ):
         self.name = name
@@ -135,7 +136,7 @@ class FortinetAddress(FortigateObjectGroup):
 
 
 class FortigateExcludeGroup(FortigateObjectGroup):
-    def __init__(self, name: str, members: List[str], exclude: List[str]):
+    def __init__(self, name: str, members: list[str], exclude: list[str]):
         """
         Initializes the FortigateExcludeGroup object.
         Args:
@@ -169,7 +170,7 @@ class FortigateAddressGroup(FortigateObjectGroup):
             name: The name of the address group.
         """
         self.name = name
-        self._cached_fortigate_addrs: List[FortinetAddress] = []
+        self._cached_fortigate_addrs: list[FortinetAddress] = []
         self._members = set()
         self._is_dirty = True
 
@@ -180,7 +181,7 @@ class FortigateAddressGroup(FortigateObjectGroup):
             self._is_dirty = True
 
     @property
-    def fortigate_addrs(self) -> List[FortinetAddress]:
+    def fortigate_addrs(self) -> list[FortinetAddress]:
         if self._is_dirty or not self._cached_fortigate_addrs:
             self._cached_fortigate_addrs = []
             sorted_ips = sorted(list(self._members))
@@ -303,7 +304,7 @@ class Term(aclgenerator.Term):
                 self.logtraffic_start = 'log_traffic_start_session'
 
     def _TranslateExcludes(
-        self, base_name: str, addrs: List[nacaddr.IP], excludes: List[nacaddr.IP]
+        self, base_name: str, addrs: list[nacaddr.IP], excludes: list[nacaddr.IP]
     ) -> None:
         member_tokens_v4 = [i.token for i in addrs if i.version == 4]
         member_tokens_v6 = [i.token for i in addrs if i.version == 6]
@@ -327,7 +328,7 @@ class Term(aclgenerator.Term):
             )
             self.address_groups_v6[v6_exclude_group_name] = exclude_addrgrp_v6
 
-    def _TranslateAddresses(self, addrs: List[nacaddr.IP]) -> None:
+    def _TranslateAddresses(self, addrs: list[nacaddr.IP]) -> None:
         """Inserts tokens into versioned addressbook and sets their members to the IPs."""
         for addr in addrs:
             if addr.version == 4:
@@ -587,7 +588,7 @@ class Fortigate(aclgenerator.ACLGenerator):
             BooleanKeywordOption("inet", config),
         ]
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -751,7 +752,7 @@ def FormatFortinetPortRange(low: int, high: int) -> str:
 
 
 def GenerateFortinetServiceString(
-    source_ranges: List[Tuple[int, int]], destination_ranges: List[Tuple[int, int]]
+    source_ranges: list[tuple[int, int]], destination_ranges: list[tuple[int, int]]
 ) -> str:
     """
     Generates a Fortinet service port range string by combining destination and source ranges.

--- a/aerleon/lib/fortigate.py
+++ b/aerleon/lib/fortigate.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Any, Dict, List, Set, Tuple
 from collections.abc import MutableMapping
+from dataclasses import dataclass
+from typing import Any
 
 from absl import logging
 

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -32,10 +32,7 @@ from absl import logging
 
 from aerleon.lib import gcp, nacaddr, policy
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 
 class Error(gcp.Error):
@@ -50,25 +47,24 @@ class ExceededAttributeCountError(Error):
     """Raised when the total attribute count of a policy is above the maximum."""
 
 
-LogConfig = TypedDict("LogConfig", {"enable": bool})
-L4Matcher = TypedDict("L4Matcher", {"IPProtocol": str, "ports": "list[str]"})
-FirewallRule = TypedDict(
-    "FirewallRule",
-    {
-        "name": str,
-        "description": str,
-        "network": str,
-        "priority": int,
-        "sourceRanges": "list[str]",
-        "destinationRanges": "list[str]",
-        "sourceTags": "list[str]",
-        "targetTags": "list[str]",
-        "allowed": "list[L4Matcher]",
-        "denied": "list[L4Matcher]",
-        "direction": str,  # Actually Enum
-        "logConfig": LogConfig,
-    },
-)
+class LogConfig(TypedDict):
+    enable: bool
+class L4Matcher(TypedDict):
+    IPProtocol: str
+    ports: 'list[str]'
+class FirewallRule(TypedDict):
+    name: str
+    description: str
+    network: str
+    priority: int
+    sourceRanges: 'list[str]'
+    destinationRanges: 'list[str]'
+    sourceTags: 'list[str]'
+    targetTags: 'list[str]'
+    allowed: 'list[L4Matcher]'
+    denied: 'list[L4Matcher]'
+    direction: str  # Actually Enum
+    logConfig: LogConfig
 
 
 def IsDefaultDeny(term: policy.Term) -> bool:
@@ -220,7 +216,7 @@ class Term(gcp.Term):
             if self.term.destination_tag:
                 raise GceFirewallError('GCE Egress rule cannot have destination tag.')
 
-    def ConvertToDict(self) -> List[FirewallRule]:
+    def ConvertToDict(self) -> list[FirewallRule]:
         """Convert term to a dictionary.
 
         This is used to get a dictionary describing this term which can be
@@ -242,7 +238,7 @@ class Term(gcp.Term):
         }
         if self.term.network:
             term_dict['network'] = self.term.network
-            term_dict['name'] = '%s-%s' % (self.term.network.split('/')[-1], term_dict['name'])
+            term_dict['name'] = '{}-{}'.format(self.term.network.split('/')[-1], term_dict['name'])
         # Identify if this is inet6 processing for a term under a mixed policy.
         mixed_policy_inet6_term = False
         if self.policy_inet_version == 'mixed' and self.inet_version == 'inet6':
@@ -447,9 +443,9 @@ class GCE(gcp.GCP):
     # is rendered (which can add proto and a counter).
     _TERM_MAX_LENGTH = 53
     _GOOD_DIRECTION = ['INGRESS', 'EGRESS']
-    _OPTIONAL_SUPPORTED_KEYWORDS = set(['expiration', 'destination_tag', 'source_tag'])
+    _OPTIONAL_SUPPORTED_KEYWORDS = {'expiration', 'destination_tag', 'source_tag'}
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -588,7 +584,7 @@ class GCE(gcp.GCP):
         return out
 
 
-def GetAttributeCount(dict_term: Dict[str, Union[List, str]]) -> int:
+def GetAttributeCount(dict_term: dict[str, Union[list, str]]) -> int:
     """Calculate the attribute count of a term in its dictionary form.
 
     The attribute count of a rule is the sum of the number of ports, protocols, IP

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -25,14 +25,11 @@ import copy
 import ipaddress
 import json
 import re
-import sys
-from typing import Dict, List, Set, Tuple, Union
+from typing import TypedDict, Union
 
 from absl import logging
 
 from aerleon.lib import gcp, nacaddr, policy
-
-from typing import TypedDict
 
 
 class Error(gcp.Error):

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -46,9 +46,13 @@ class ExceededAttributeCountError(Error):
 
 class LogConfig(TypedDict):
     enable: bool
+
+
 class L4Matcher(TypedDict):
     IPProtocol: str
     ports: 'list[str]'
+
+
 class FirewallRule(TypedDict):
     name: str
     description: str

--- a/aerleon/lib/gcp.py
+++ b/aerleon/lib/gcp.py
@@ -37,7 +37,7 @@ class Term(aclgenerator.Term):
     # 'all' is needed for the dedault deny, it should not be used in a pol file.
     _ALLOW_PROTO_NAME = frozenset(['tcp', 'udp', 'icmp', 'esp', 'ah', 'ipip', 'sctp', 'all'])
 
-    def _GetPorts(self) -> List[str]:
+    def _GetPorts(self) -> list[str]:
         """Return a port or port range in string format."""
         ports = []
         for start, end in self.term.destination_port:
@@ -167,4 +167,4 @@ def GetIpv6TermName(term_name: str) -> str:
       string: The IPv6 requivalent term name.
     """
 
-    return '%s-%s' % (term_name, 'v6')
+    return '{}-{}'.format(term_name, 'v6')

--- a/aerleon/lib/gcp.py
+++ b/aerleon/lib/gcp.py
@@ -7,7 +7,6 @@ Base class for GCP firewalling products.
 
 import json
 import re
-from typing import List
 
 from aerleon.lib import aclgenerator
 from aerleon.lib.policy import Term

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -48,11 +48,17 @@ class ApiVersionSyntaxMap:
 class L4Matcher(TypedDict):
     IPProtocol: str
     ports: 'list[str]'
+
+
 class MatchConfig(TypedDict):
     destIpRanges: 'list[str]'
     srcIpRanges: 'list[str]'
     layer4Configs: 'list[L4Matcher]'
+
+
 RuleMatch = TypedDict("PropertyMap", {"config": MatchConfig, "versionedExpr": str})
+
+
 class OrganizationalPolicyRule(TypedDict):
     action: str
     match: RuleMatch
@@ -61,6 +67,8 @@ class OrganizationalPolicyRule(TypedDict):
     direction: str
     enableLogging: bool
     targetResources: 'list[str]'
+
+
 class OrganizationPolicy(TypedDict):
     displayName: str
     type: str

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -7,14 +7,11 @@ Hierarchical Firewalls (HF) are represented in a SecurityPolicy GCP resouce.
 
 import copy
 import re
-import sys
-from typing import Dict, List, Set, Tuple, Union
+from typing import TypedDict, Union
 
 from absl import logging
 
 from aerleon.lib import gcp, nacaddr, policy
-
-from typing import TypedDict
 
 
 class ExceededCostError(gcp.Error):

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -14,10 +14,7 @@ from absl import logging
 
 from aerleon.lib import gcp, nacaddr, policy
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 
 class ExceededCostError(gcp.Error):
@@ -51,28 +48,26 @@ class ApiVersionSyntaxMap:
     }
 
 
-L4Matcher = TypedDict("L4Matcher", {"IPProtocol": str, "ports": "list[str]"})
-MatchConfig = TypedDict(
-    "MatchConfig",
-    {"destIpRanges": "list[str]", "srcIpRanges": "list[str]", "layer4Configs": "list[L4Matcher]"},
-)
+class L4Matcher(TypedDict):
+    IPProtocol: str
+    ports: 'list[str]'
+class MatchConfig(TypedDict):
+    destIpRanges: 'list[str]'
+    srcIpRanges: 'list[str]'
+    layer4Configs: 'list[L4Matcher]'
 RuleMatch = TypedDict("PropertyMap", {"config": MatchConfig, "versionedExpr": str})
-OrganizationalPolicyRule = TypedDict(
-    "OrganizationalPolicyRule",
-    {
-        "action": str,
-        "match": RuleMatch,
-        "priority": int,
-        "description": str,
-        "direction": str,
-        "enableLogging": bool,
-        "targetResources": "list[str]",
-    },
-)
-OrganizationPolicy = TypedDict(
-    "OrganizationPolicy",
-    {"displayName": str, "type": str, "rules": "list[OrganizationalPolicyRule]"},
-)
+class OrganizationalPolicyRule(TypedDict):
+    action: str
+    match: RuleMatch
+    priority: int
+    description: str
+    direction: str
+    enableLogging: bool
+    targetResources: 'list[str]'
+class OrganizationPolicy(TypedDict):
+    displayName: str
+    type: str
+    rules: 'list[OrganizationalPolicyRule]'
 
 
 class Term(gcp.Term):
@@ -166,7 +161,7 @@ class Term(gcp.Term):
                 % self.term.name
             )
 
-    def ConvertToDict(self, priority_index: int) -> List[OrganizationPolicy]:
+    def ConvertToDict(self, priority_index: int) -> list[OrganizationPolicy]:
         """Converts term to dict representation of SecurityPolicy.Rule JSON format.
 
         Takes all of the attributes associated with a term (match, action, etc) and
@@ -374,7 +369,7 @@ class HierarchicalFirewall(gcp.GCP):
     _SUPPORTED_API_VERSION = frozenset(['beta', 'ga'])
     _DEFAULT_MAXIMUM_COST = 100
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -572,7 +567,7 @@ class HierarchicalFirewall(gcp.GCP):
             logging.info('Policy %s quota cost: %d', policy[display_name], total_cost)
 
 
-def GetRuleTupleCount(dict_term: Dict[str, Union[List, str]], api_version: str) -> int:
+def GetRuleTupleCount(dict_term: dict[str, Union[list, str]], api_version: str) -> int:
     """Calculate the tuple count of a rule in its dictionary form.
 
     Quota is charged based on how complex the rules are rather than simply

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -22,7 +22,7 @@ performace of iptables firewall.
 """
 
 import string
-from typing import Any, List, Tuple, Union
+from typing import Any, Union
 
 from aerleon.lib import iptables, nacaddr
 from aerleon.lib.nacaddr import IPv4, IPv6

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -53,15 +53,15 @@ class Term(iptables.Term):
 
     def _CalculateAddresses(
         self,
-        src_addr_list: List[Union[IPv4, IPv6]],
-        src_addr_exclude_list: List[Union[IPv4, IPv6]],
-        dst_addr_list: List[Union[IPv4, IPv6]],
-        dst_addr_exclude_list: List[Union[IPv4, IPv6]],
-    ) -> Tuple[
-        List[Union[IPv4, IPv6]],
-        List[Union[IPv4, IPv6]],
-        List[Union[IPv4, IPv6]],
-        List[Union[IPv4, IPv6]],
+        src_addr_list: list[Union[IPv4, IPv6]],
+        src_addr_exclude_list: list[Union[IPv4, IPv6]],
+        dst_addr_list: list[Union[IPv4, IPv6]],
+        dst_addr_exclude_list: list[Union[IPv4, IPv6]],
+    ) -> tuple[
+        list[Union[IPv4, IPv6]],
+        list[Union[IPv4, IPv6]],
+        list[Union[IPv4, IPv6]],
+        list[Union[IPv4, IPv6]],
     ]:
         """Calculates source and destination address list for a term.
 
@@ -103,11 +103,11 @@ class Term(iptables.Term):
 
     def _CalculateAddrList(
         self,
-        addr_list: List[Union[IPv4, IPv6]],
-        addr_exclude_list: List[Any],
+        addr_list: list[Union[IPv4, IPv6]],
+        addr_exclude_list: list[Any],
         target_af: int,
         direction: str,
-    ) -> List[Union[IPv4, IPv6]]:
+    ) -> list[Union[IPv4, IPv6]]:
         """Calculates and stores address list for target AF and direction.
 
         Args:
@@ -136,7 +136,7 @@ class Term(iptables.Term):
             addr_list = [self._all_ips]
         return addr_list
 
-    def _GenerateAddressStatement(self, src_addr: IPv4, dst_addr: IPv4) -> Tuple[str, str]:
+    def _GenerateAddressStatement(self, src_addr: IPv4, dst_addr: IPv4) -> tuple[str, str]:
         """Returns the address section of an individual iptables rule.
 
         See _CalculateAddresses documentation. Three cases are possible here,
@@ -180,7 +180,7 @@ class Term(iptables.Term):
         if len(term_name) + len(suffix) + 1 > self._SET_MAX_LENGTH:
             set_name_max_lenth = self._SET_MAX_LENGTH - len(suffix) - 1
             term_name = term_name[:set_name_max_lenth]
-        return '%s-%s' % (term_name, suffix)
+        return f'{term_name}-{suffix}'
 
 
 class Ipset(iptables.Iptables):
@@ -207,7 +207,7 @@ class Ipset(iptables.Iptables):
         output.append(iptables_output)
         return '\n'.join(output)
 
-    def _GenerateSetConfig(self, term: Term) -> List[str]:
+    def _GenerateSetConfig(self, term: Term) -> list[str]:
         """Generates set configuration for supplied term.
 
         Args:
@@ -232,5 +232,5 @@ class Ipset(iptables.Iptables):
                 % (c_str, set_name, self._SET_TYPE, term.af, set_hashsize, set_maxelem)
             )
             for address in addr_list:
-                output.append('%s %s %s' % (a_str, set_name, address))
+                output.append(f'{a_str} {set_name} {address}')
         return output

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -713,13 +713,17 @@ class Term(aclgenerator.Term):
                 count += 2
             if count >= max_ports:
                 count = 0
-                portstrings.append('-m multiport --{}ports {}'.format(direction, ','.join(norm_ports)))
+                portstrings.append(
+                    '-m multiport --{}ports {}'.format(direction, ','.join(norm_ports))
+                )
                 norm_ports = []
         if norm_ports:
             if len(norm_ports) == 1:
                 portstrings.append(f'--{direction}port {norm_ports[0]}')
             else:
-                portstrings.append('-m multiport --{}ports {}'.format(direction, ','.join(norm_ports)))
+                portstrings.append(
+                    '-m multiport --{}ports {}'.format(direction, ','.join(norm_ports))
+                )
         return portstrings
 
     def _SetDefaultAction(self) -> None:

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -114,7 +114,7 @@ class Term(aclgenerator.Term):
             self._all_ips = nacaddr.IPv4('0.0.0.0/0')
             self._action_table['reject'] = '-j REJECT --reject-with ' 'icmp-host-prohibited'
         if self.chained_terms:
-            self.term_name = '%s_%s' % (self.filter[:1], self.term.name)
+            self.term_name = f'{self.filter[:1]}_{self.term.name}'
         else:
             self.term_name = self.filter
 
@@ -181,7 +181,7 @@ class Term(aclgenerator.Term):
         # skip the rule.  In other cases, we blow up (raise an exception)
         # to ensure that this is not considered valid configuration.
         if self.term.source_prefix or self.term.destination_prefix:
-            if str(self.term.action[0]) not in set(['accept', 'next']):
+            if str(self.term.action[0]) not in {'accept', 'next'}:
                 raise UnsupportedFilterError(
                     '%s %s %s %s %s %s %s %s'
                     % (
@@ -377,34 +377,34 @@ class Term(aclgenerator.Term):
 
     def _CalculateAddresses(
         self,
-        term_saddr: List[Union[IPv4, IPv6]],
-        exclude_saddr: List[Union[IPv4, IPv6]],
-        term_daddr: List[Union[IPv4, IPv6]],
-        exclude_daddr: List[Union[IPv4, IPv6]],
+        term_saddr: list[Union[IPv4, IPv6]],
+        exclude_saddr: list[Union[IPv4, IPv6]],
+        term_daddr: list[Union[IPv4, IPv6]],
+        exclude_daddr: list[Union[IPv4, IPv6]],
     ) -> Union[
-        Tuple[
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
+        tuple[
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
         ],
-        Tuple[
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
+        tuple[
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
         ],
-        Tuple[
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
+        tuple[
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
         ],
-        Tuple[
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
-            List[Union[IPv4, IPv6]],
+        tuple[
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
+            list[Union[IPv4, IPv6]],
         ],
     ]:
         """Calculate source and destination address list for a term.
@@ -485,19 +485,19 @@ class Term(aclgenerator.Term):
         self,
         protocol: str,
         saddr: Union[IPv6, IPv4, str],
-        sport: Union[List[Tuple[int, int]], str],
+        sport: Union[list[tuple[int, int]], str],
         daddr: Union[IPv6, IPv4, str],
-        dport: Union[List[Tuple[int, int]], str],
-        options: Union[str, List[str]],
-        tcp_flags: Union[str, List[str]],
+        dport: Union[list[tuple[int, int]], str],
+        options: Union[str, list[str]],
+        tcp_flags: Union[str, list[str]],
         icmp_type: Union[int, str],
         code: Union[int, str],
-        track_flags: Union[Tuple[List[str], List[str]], str],
+        track_flags: Union[tuple[list[str], list[str]], str],
         sint: str,
         dint: str,
         log_hits: Union[str, bool],
         action: str,
-    ) -> List[str]:
+    ) -> list[str]:
         """Compose one iteration of the term parts into a string.
 
         Args:
@@ -577,7 +577,7 @@ class Term(aclgenerator.Term):
         if tcp_flags or (track_flags and track_flags[0]):
             check_fields = ','.join(sorted(set(tcp_flags + track_flags[0])))
             set_fields = ','.join(sorted(set(tcp_flags + track_flags[1])))
-            flags = '--tcp-flags %s %s' % (check_fields, set_fields)
+            flags = f'--tcp-flags {check_fields} {set_fields}'
         else:
             flags = ''
 
@@ -642,7 +642,7 @@ class Term(aclgenerator.Term):
 
     def _GenerateAddressStatement(
         self, saddr: Union[IPv6, IPv4], daddr: Union[IPv6, IPv4]
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """Return the address section of an individual iptables rule.
 
         Args:
@@ -667,8 +667,8 @@ class Term(aclgenerator.Term):
         return (src, dst)
 
     def _GeneratePortStatement(
-        self, ports: List[Tuple[int, int]], source: bool = False, dest: bool = False
-    ) -> List[str]:
+        self, ports: list[tuple[int, int]], source: bool = False, dest: bool = False
+    ) -> list[str]:
         """Return the 'port' section of an individual iptables rule.
 
         Args:
@@ -713,13 +713,13 @@ class Term(aclgenerator.Term):
                 count += 2
             if count >= max_ports:
                 count = 0
-                portstrings.append('-m multiport --%sports %s' % (direction, ','.join(norm_ports)))
+                portstrings.append('-m multiport --{}ports {}'.format(direction, ','.join(norm_ports)))
                 norm_ports = []
         if norm_ports:
             if len(norm_ports) == 1:
-                portstrings.append('--%sport %s' % (direction, norm_ports[0]))
+                portstrings.append(f'--{direction}port {norm_ports[0]}')
             else:
-                portstrings.append('-m multiport --%sports %s' % (direction, ','.join(norm_ports)))
+                portstrings.append('-m multiport --{}ports {}'.format(direction, ','.join(norm_ports)))
         return portstrings
 
     def _SetDefaultAction(self) -> None:
@@ -748,7 +748,7 @@ class Iptables(aclgenerator.ACLGenerator):
         self.iptables_policies = []
         super().__init__(pol, exp_info)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -940,14 +940,14 @@ class Iptables(aclgenerator.ACLGenerator):
 
     def __str__(self) -> str:
         target = []
-        pretty_platform = '%s%s' % (self._PLATFORM[0].upper(), self._PLATFORM[1:])
+        pretty_platform = f'{self._PLATFORM[0].upper()}{self._PLATFORM[1:]}'
 
         if self._RENDER_PREFIX:
             target.append(self._RENDER_PREFIX)
 
         for header, filter_name, filter_type, default_action, terms in self.iptables_policies:
             # Add comments for this filter
-            target.append('# %s %s Policy' % (pretty_platform, header.FilterName(self._PLATFORM)))
+            target.append(f'# {pretty_platform} {header.FilterName(self._PLATFORM)} Policy')
 
             # reformat long text comments, if needed
             comments = aclgenerator.WrapWords(header.comment, 70)

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -18,7 +18,7 @@
 
 import re
 from string import Template  # pylint: disable=g-importing-member
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 
 from absl import logging
 

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -16,7 +16,7 @@
 
 """Juniper JCL generator."""
 
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 
 from absl import logging
 

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -314,7 +314,7 @@ class Term(aclgenerator.Term):
             term_prefix = ''
 
         # term name
-        config.Append('%s term %s {' % (term_prefix, self.term.name))
+        config.Append(f'{term_prefix} term {self.term.name} {{')
 
         # The "filter" keyword is not compatible with from or then
         if self.term.filter_term:
@@ -586,7 +586,7 @@ class Term(aclgenerator.Term):
             if self.term.flexible_match_range:
                 config.Append('flexible-match-range {')
                 for fm_opt in self.term.flexible_match_range:
-                    config.Append('%s %s;' % (fm_opt[0], fm_opt[1]))
+                    config.Append(f'{fm_opt[0]} {fm_opt[1]};')
                 config.Append('}')
 
             config.Append('}')  # end from { ... }
@@ -730,7 +730,7 @@ class Term(aclgenerator.Term):
         return str(config)
 
     @staticmethod
-    def NextIpCheck(next_ip: List[Union[nacaddr.IPv4, nacaddr.IPv6]], term_name: str):
+    def NextIpCheck(next_ip: list[Union[nacaddr.IPv4, nacaddr.IPv6]], term_name: str):
         if len(next_ip) > 1:
             raise JuniperNextIpError(
                 'The following term has more ' 'than one next IP value: %s' % term_name
@@ -753,8 +753,8 @@ class Term(aclgenerator.Term):
 
     def _MinimizePrefixes(
         self,
-        include: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
-        exclude: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
+        include: list[Union[nacaddr.IPv4, nacaddr.IPv6]],
+        exclude: list[Union[nacaddr.IPv4, nacaddr.IPv6]],
     ):
         """Calculate a minimal set of prefixes for Juniper match conditions.
 
@@ -884,7 +884,7 @@ class Term(aclgenerator.Term):
             logging.warning('Ignoring non IPv4 or IPv6 address: %s', addr)
         return rval
 
-    def _Group(self, group: List[str], lc: bool = True):
+    def _Group(self, group: list[str], lc: bool = True):
         """If 1 item return it, else return [ item1 item2 ].
 
         Args:
@@ -897,7 +897,7 @@ class Term(aclgenerator.Term):
                 or with just ';' appended if len(group) == 1
         """
 
-        def _FormattedGroup(el: List[str], lc: bool = True):
+        def _FormattedGroup(el: list[str], lc: bool = True):
             """Return the actual formatting of an individual element.
 
             Args:
@@ -944,7 +944,7 @@ class Juniper(aclgenerator.ACLGenerator):
     _TERM = Term
     SUFFIX = '.jcl'
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -378,7 +378,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
         self.applications = {}
         super().__init__(pol, exp_info)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -408,7 +408,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
         )
         return supported_tokens, supported_sub_tokens
 
-    def _BuildPort(self, ports: List[Tuple[int, int]]):
+    def _BuildPort(self, ports: list[tuple[int, int]]):
         """Transform specified ports into list and ranges.
 
         Args:
@@ -422,7 +422,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
             if p[0] == p[1]:
                 port_list.append(str(p[0]))
             else:
-                port_list.append('%s-%s' % (str(p[0]), str(p[1])))
+                port_list.append(f'{str(p[0])}-{str(p[1])}')
         return port_list
 
     def _GenerateApplications(self, filter_name: str):
@@ -459,10 +459,10 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                             if proto == 'icmp':
                                 target.append('application-protocol %s;' % proto)
                             target.append('protocol %s;' % proto)
-                            target.append('%s-type %s;' % (proto, str(code)))
+                            target.append(f'{proto}-type {str(code)};')
                             if app['icmp-code']:
                                 target.append(
-                                    '%s-code %s;' % (proto, self._Group(app['icmp-code']))
+                                    '{}-code {};'.format(proto, self._Group(app['icmp-code']))
                                 )
                             if int(timeout):
                                 target.append('inactivity-timeout %s;' % int(timeout))
@@ -582,7 +582,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                         term.name,
                     )
                     continue
-                if set(['established', 'tcp-established']).intersection(term.option):
+                if {'established', 'tcp-established'}.intersection(term.option):
                     logging.warning(
                         'Skipping established term %s because MSMPC is stateful.', term.name
                     )
@@ -654,7 +654,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                 (header, filter_name, filter_direction, new_terms, apply_groups)
             )
 
-    def _Group(self, group: List[str], lc: bool = True):
+    def _Group(self, group: list[str], lc: bool = True):
         """If 1 item return it, else return [ item1 item2 ].
 
         Args:
@@ -667,7 +667,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                 or with just ';' appended if len(group) == 1
         """
 
-        def _FormattedGroup(el: List[str], lc: bool = True):
+        def _FormattedGroup(el: list[str], lc: bool = True):
             """Return the actual formatting of an individual element.
 
             Args:

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -15,8 +15,6 @@
 #
 """Juniper MS-MPC  generator for Aerleon."""
 
-from typing import Dict, List, Set, Tuple
-
 from absl import logging
 
 from aerleon.lib import aclgenerator, juniper, nacaddr, policy

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -419,9 +419,9 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     'be specified per header "%s"' % ' '.join(filter_options)
                 )
             else:
-                address_book_type = {
-                    self._ZONE_ADDR_BOOK, self._GLOBAL_ADDR_BOOK
-                }.intersection(extra_options)
+                address_book_type = {self._ZONE_ADDR_BOOK, self._GLOBAL_ADDR_BOOK}.intersection(
+                    extra_options
+                )
                 if not address_book_type:
                     address_book_type = {self._GLOBAL_ADDR_BOOK}
                 self.addr_book_type.update(address_book_type)

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -21,7 +21,7 @@
 import collections
 import copy
 import itertools
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 from absl import logging
 

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -32,7 +32,7 @@ FQDNSUFFIX = '_FQDN'
 
 
 def JunipersrxList(name, data):
-    return '%s [ %s ];' % (name, ' '.join(data))
+    return '{} [ {} ];'.format(name, ' '.join(data))
 
 
 class Error(aclgenerator.Error):
@@ -77,7 +77,7 @@ class IndentList(list):
         super().__init__(*args, **kwargs)
 
     def IndentAppend(self, size, data):
-        self.append('%s%s' % (self._indent * size, data))
+        self.append(f'{self._indent * size}{data}')
 
 
 class Term(aclgenerator.Term):
@@ -232,7 +232,7 @@ class Term(aclgenerator.Term):
 
         return '\n'.join(ret_str)
 
-    def _Group(self, group: List[str]):
+    def _Group(self, group: list[str]):
         """If 1 item return it, else return [ item1 item2 ].
 
         Args:
@@ -244,7 +244,7 @@ class Term(aclgenerator.Term):
                 or with just ';' appended if len(group) == 1
         """
 
-        def _FormattedGroup(el: List[str]):
+        def _FormattedGroup(el: list[str]):
             """Return the actual formatting of an individual element.
 
             Args:
@@ -283,13 +283,13 @@ class JuniperSRX(aclgenerator.ACLGenerator):
 
     _PLATFORM = 'srx'
     SUFFIX = '.srx'
-    _SUPPORTED_AF = set(('inet', 'inet6', 'mixed'))
+    _SUPPORTED_AF = {'inet', 'inet6', 'mixed'}
     _ZONE_ADDR_BOOK = 'address-book-zone'
     _GLOBAL_ADDR_BOOK = 'address-book-global'
-    _ADDRESSBOOK_TYPES = set((_ZONE_ADDR_BOOK, _GLOBAL_ADDR_BOOK))
+    _ADDRESSBOOK_TYPES = {_ZONE_ADDR_BOOK, _GLOBAL_ADDR_BOOK}
     _EXPRESSPATH = 'expresspath'
     _NOVERBOSE = 'noverbose'
-    _SUPPORTED_TARGET_OPTIONS = set((_ZONE_ADDR_BOOK, _GLOBAL_ADDR_BOOK, _EXPRESSPATH, _NOVERBOSE))
+    _SUPPORTED_TARGET_OPTIONS = {_ZONE_ADDR_BOOK, _GLOBAL_ADDR_BOOK, _EXPRESSPATH, _NOVERBOSE}
 
     _AF_MAP = {'inet': (4,), 'inet6': (6,), 'mixed': (4, 6)}
     _AF_ICMP_MAP = {'icmp': 'inet', 'icmpv6': 'inet6'}
@@ -311,7 +311,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
         self.addr_book_type = set()
         super().__init__(pol, exp_info)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -419,9 +419,9 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     'be specified per header "%s"' % ' '.join(filter_options)
                 )
             else:
-                address_book_type = set(
-                    [self._ZONE_ADDR_BOOK, self._GLOBAL_ADDR_BOOK]
-                ).intersection(extra_options)
+                address_book_type = {
+                    self._ZONE_ADDR_BOOK, self._GLOBAL_ADDR_BOOK
+                }.intersection(extra_options)
                 if not address_book_type:
                     address_book_type = {self._GLOBAL_ADDR_BOOK}
                 self.addr_book_type.update(address_book_type)
@@ -480,7 +480,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                         self.to_zone,
                     )
                     continue
-                if set(['established', 'tcp-established']).intersection(term.option):
+                if {'established', 'tcp-established'}.intersection(term.option):
                     logging.warning(
                         'Skipping established term %s because SRX is stateful.', term.name
                     )
@@ -621,7 +621,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
 
             self.srx_policies.append((header, new_terms, filter_options))
 
-    def _FixLargePolices(self, terms: List[policy.Term], address_family: str):
+    def _FixLargePolices(self, terms: list[policy.Term], address_family: str):
         """Loops over all terms finding terms exceeding SRXs policy limit.
 
         Args:
@@ -633,7 +633,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
         general/address-address-sets-limitations.html
         """
 
-        def Chunks(addresses: List[Union[nacaddr.IPv4, nacaddr.IPv6]]):
+        def Chunks(addresses: list[Union[nacaddr.IPv4, nacaddr.IPv6]]):
             """Splits a list of IP addresses into smaller lists based on byte size."""
             return_list = [[]]
             counter = 0
@@ -683,7 +683,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             del terms[:]
             terms.extend(expanded_terms)
 
-    def _BuildPort(self, ports: List[Tuple[int, int]]):
+    def _BuildPort(self, ports: list[tuple[int, int]]):
         """Transform specified ports into list and ranges.
 
         Args:
@@ -697,7 +697,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             if i[0] == i[1]:
                 port_list.append(str(i[0]))
             else:
-                port_list.append('%s-%s' % (str(i[0]), str(i[1])))
+                port_list.append(f'{str(i[0])}-{str(i[1])}')
         return port_list
 
     def _GenerateAddresses(self, token: str, ips, fqdns):

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -22,16 +22,13 @@ https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/
 
 import copy
 import re
-import sys
-from typing import Dict, Set, Tuple
+from typing import TypedDict
 
 import yaml
 from absl import logging
 
 from aerleon.lib import aclgenerator
 from aerleon.lib.policy import Policy, Term
-
-from typing import TypedDict
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -47,33 +47,53 @@ class MatchExpression(TypedDict):
     key: str
     operator: str
     values: 'list[str]'
+
+
 LabelSelector = TypedDict(
     "PodSelector", {"matchLabels": dict[str, str], "matchExpression": MatchExpression}
 )
+
+
 class IPBlock(TypedDict):
     cidr: str
     exceot: 'list[str]'
+
+
 class PolicyPeer(TypedDict):
     podSelector: LabelSelector
     namespaceSelector: LabelSelector
     ipBlock: IPBlock
+
+
 class PolicyPort(TypedDict):
     protocol: str
     port: int
     endPort: int
+
+
 class Egress(TypedDict):
     ports: 'list[PolicyPort]'
     to: 'list[PolicyPeer]'
+
+
 Ingress = TypedDict("Ingress", {"ports": "list[PolicyPort]", "from": "list[PolicyPeer]"})
+
+
 class Spec(TypedDict):
     podSelector: LabelSelector
     policyTypes: 'list[str]'
+
+
 class Annotations(TypedDict):
     comment: str
     owner: str
+
+
 class Metadata(TypedDict):
     name: str
     annotations: Annotations
+
+
 class NetworkPolicy(TypedDict):
     apiVersion: str
     kind: str

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -31,10 +31,7 @@ from absl import logging
 from aerleon.lib import aclgenerator
 from aerleon.lib.policy import Policy, Term
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 
 class Error(aclgenerator.Error):
@@ -49,26 +46,42 @@ class ExceededAttributeCountError(Error):
     """Raised when the total attribute count of a policy is above the maximum."""
 
 
-MatchExpression = TypedDict(
-    "MatchExpression", {"key": str, "operator": str, "values": "list[str]"}
-)
+class MatchExpression(TypedDict):
+    key: str
+    operator: str
+    values: 'list[str]'
 LabelSelector = TypedDict(
-    "PodSelector", {"matchLabels": Dict[str, str], "matchExpression": MatchExpression}
+    "PodSelector", {"matchLabels": dict[str, str], "matchExpression": MatchExpression}
 )
-IPBlock = TypedDict("IPBlock", {"cidr": str, "exceot": "list[str]"})
-PolicyPeer = TypedDict(
-    "PolicyPeer",
-    {"podSelector": LabelSelector, "namespaceSelector": LabelSelector, "ipBlock": IPBlock},
-)
-PolicyPort = TypedDict("PolicyPort", {"protocol": str, "port": int, "endPort": int})
-Egress = TypedDict("Egress", {"ports": "list[PolicyPort]", "to": "list[PolicyPeer]"})
+class IPBlock(TypedDict):
+    cidr: str
+    exceot: 'list[str]'
+class PolicyPeer(TypedDict):
+    podSelector: LabelSelector
+    namespaceSelector: LabelSelector
+    ipBlock: IPBlock
+class PolicyPort(TypedDict):
+    protocol: str
+    port: int
+    endPort: int
+class Egress(TypedDict):
+    ports: 'list[PolicyPort]'
+    to: 'list[PolicyPeer]'
 Ingress = TypedDict("Ingress", {"ports": "list[PolicyPort]", "from": "list[PolicyPeer]"})
-Spec = TypedDict("Spec", {'podSelector': LabelSelector, 'policyTypes': "list[str]"})
-Annotations = TypedDict("Annotations", {"comment": str, "owner": str})
-Metadata = TypedDict("Metadata", {"name": str, "annotations": Annotations})
-NetworkPolicy = TypedDict(
-    "NetworkPolicy", {"apiVersion": str, "kind": str, "metadata": Metadata, "spec": Spec}
-)
+class Spec(TypedDict):
+    podSelector: LabelSelector
+    policyTypes: 'list[str]'
+class Annotations(TypedDict):
+    comment: str
+    owner: str
+class Metadata(TypedDict):
+    name: str
+    annotations: Annotations
+class NetworkPolicy(TypedDict):
+    apiVersion: str
+    kind: str
+    metadata: Metadata
+    spec: Spec
 
 
 def IsDefaultDeny(term: Term) -> bool:
@@ -311,11 +324,11 @@ class K8s(aclgenerator.ACLGenerator):
     _RESOURCE_KIND = 'NetworkPolicyList'
     _PLATFORM = 'k8s'
     SUFFIX = '.yml'
-    _SUPPORTED_AF = frozenset(('mixed'))
+    _SUPPORTED_AF = frozenset('mixed')
     _GOOD_DIRECTION = ['INGRESS', 'EGRESS']
     _OPTIONAL_SUPPORTED_KEYWORDS = frozenset(['expiration'])
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -59,9 +59,7 @@ def IP(
 
 # TODO(robankeny) remove once at 3.7
 @staticmethod
-def _is_subnet_of(
-    a: IPv4 | IPv6, b: IPv4 | IPv6
-) -> bool:  # pylint: disable=invalid-name
+def _is_subnet_of(a: IPv4 | IPv6, b: IPv4 | IPv6) -> bool:  # pylint: disable=invalid-name
     try:
         # Always false if one is v4 and the other is v6.
         if a.version != b.version:
@@ -311,8 +309,7 @@ def _SafeToMerge(
     address: IPv4 | IPv6,
     merge_target: IPv4 | IPv6,
     check_addresses: (
-        dict[ipaddress.IPv4Address, list[IPv4]] |
-        dict[ipaddress.IPv6Address, list[IPv6]]
+        dict[ipaddress.IPv4Address, list[IPv4]] | dict[ipaddress.IPv6Address, list[IPv6]]
     ),
 ) -> bool:
     """Determine if it's safe to merge address into merge target.
@@ -339,8 +336,7 @@ def _SafeToMerge(
 def _CollapseAddrListInternal(
     addresses: list[IPv4 | IPv6],
     complements_by_network: (
-        dict[ipaddress.IPv4Address, list[IPv4]] |
-        dict[ipaddress.IPv6Address, list[IPv6]]
+        dict[ipaddress.IPv4Address, list[IPv4]] | dict[ipaddress.IPv6Address, list[IPv6]]
     ),
 ) -> list[IPv4 | IPv6]:
     """Collapses consecutive netblocks until reaching a fixed point.
@@ -450,9 +446,7 @@ def SortAddrList(addresses: list[IPv6 | IPv4]) -> list[IPv6 | IPv4]:
     return sorted(addresses, key=ipaddress.get_mixed_type_key)
 
 
-def RemoveAddressFromList(
-    superset: list[IPv4 | IPv6], exclude: IPv4 | IPv6
-) -> list[IPv6 | IPv4]:
+def RemoveAddressFromList(superset: list[IPv4 | IPv6], exclude: IPv4 | IPv6) -> list[IPv6 | IPv4]:
     """Remove a single address from a list of addresses.
 
     Args:

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -27,11 +27,11 @@ import aerleon.utils.iputils as iputils
 
 
 def IP(
-    ip: Union[ipaddress.IPv4Network, ipaddress.IPv6Network, str],
+    ip: ipaddress.IPv4Network | ipaddress.IPv6Network | str,
     comment: str = '',
     token: str = '',
     strict: bool = True,
-) -> Union[IPv4, IPv6]:
+) -> IPv4 | IPv6:
     """Take an ip string and return an object of the correct type.
 
     Args:
@@ -60,17 +60,17 @@ def IP(
 # TODO(robankeny) remove once at 3.7
 @staticmethod
 def _is_subnet_of(
-    a: Union[IPv4, IPv6], b: Union[IPv4, IPv6]
+    a: IPv4 | IPv6, b: IPv4 | IPv6
 ) -> bool:  # pylint: disable=invalid-name
     try:
         # Always false if one is v4 and the other is v6.
         if a.version != b.version:
-            raise TypeError('%s and %s are not of the same version' % (a, b))
+            raise TypeError(f'{a} and {b} are not of the same version')
         return (
             b.network_address <= a.network_address and b.broadcast_address >= a.broadcast_address
         )
     except AttributeError:
-        raise TypeError('Unable to test subnet containment between %s and %s' % (a, b))
+        raise TypeError(f'Unable to test subnet containment between {a} and {b}')
 
 
 class IPv4(ipaddress.IPv4Network):
@@ -78,8 +78,8 @@ class IPv4(ipaddress.IPv4Network):
 
     def __init__(
         self,
-        ip_string: Union[ipaddress.IPv4Network, Tuple[int, int], str, IPv4],
-        comment: Union[str, IPv4] = '',
+        ip_string: ipaddress.IPv4Network | tuple[int, int] | str | IPv4,
+        comment: str | IPv4 = '',
         token: str = '',
         strict: bool = True,
     ) -> None:
@@ -104,7 +104,7 @@ class IPv4(ipaddress.IPv4Network):
             return False
         return self._is_subnet_of(self, other)
 
-    def supernet_of(self, other: Union[IPv4, IPv6]) -> bool:
+    def supernet_of(self, other: IPv4 | IPv6) -> bool:
         """Return True if this network is a supernet of other."""
         if self.version != other.version:
             return False
@@ -131,7 +131,7 @@ class IPv4(ipaddress.IPv4Network):
         else:
             self.text = comment
 
-    def supernet(self, prefixlen_diff: int = 1) -> "IPv4":
+    def supernet(self, prefixlen_diff: int = 1) -> IPv4:
         """Override ipaddress.IPv4 supernet so we can maintain comments.
 
         See ipaddress.IPv4.Supernet for complete documentation.
@@ -169,7 +169,7 @@ class IPv6(ipaddress.IPv6Network):
 
     def __init__(
         self,
-        ip_string: Union[str, ipaddress.IPv6Network, Tuple[int, int], IPv6],
+        ip_string: str | ipaddress.IPv6Network | tuple[int, int] | IPv6,
         comment: str = '',
         token: str = '',
         strict: bool = True,
@@ -208,7 +208,7 @@ class IPv6(ipaddress.IPv6Network):
         result.parent_token = self.parent_token
         return result
 
-    def supernet(self, prefixlen_diff: int = 1) -> "IPv6":
+    def supernet(self, prefixlen_diff: int = 1) -> IPv6:
         """Override ipaddress.IPv6Network supernet so we can maintain comments.
 
         See ipaddress.IPv6Network.Supernet for complete documentation.
@@ -257,7 +257,7 @@ class IPv6(ipaddress.IPv6Network):
 IPType = Union[IPv4, IPv6]
 
 
-def _InNetList(adders: List[ipaddress._BaseNetwork], ip: ipaddress._BaseNetwork) -> bool:
+def _InNetList(adders: list[ipaddress._BaseNetwork], ip: ipaddress._BaseNetwork) -> bool:
     """Returns True if ip is contained in adders."""
     for addr in adders:
         if ip.subnet_of(addr):
@@ -266,7 +266,7 @@ def _InNetList(adders: List[ipaddress._BaseNetwork], ip: ipaddress._BaseNetwork)
 
 
 def IsSuperNet(
-    supernets: List[ipaddress._BaseNetwork], subnets: List[ipaddress._BaseNetwork]
+    supernets: list[ipaddress._BaseNetwork], subnets: list[ipaddress._BaseNetwork]
 ) -> bool:
     """Returns True if subnets are fully consumed by supernets."""
     for net in subnets:
@@ -275,7 +275,7 @@ def IsSuperNet(
     return True
 
 
-def CollapseAddrListPreserveTokens(addresses: List[Union[IPv4, IPv6]]) -> List[Union[IPv4, IPv6]]:
+def CollapseAddrListPreserveTokens(addresses: list[IPv4 | IPv6]) -> list[IPv4 | IPv6]:
     """Collapse an array of IPs only when their tokens are the same.
 
     Args:
@@ -308,12 +308,12 @@ def CollapseAddrListPreserveTokens(addresses: List[Union[IPv4, IPv6]]) -> List[U
 
 
 def _SafeToMerge(
-    address: Union[IPv4, IPv6],
-    merge_target: Union[IPv4, IPv6],
-    check_addresses: Union[
-        Dict[ipaddress.IPv4Address, List[IPv4]],
-        Dict[ipaddress.IPv6Address, List[IPv6]],
-    ],
+    address: IPv4 | IPv6,
+    merge_target: IPv4 | IPv6,
+    check_addresses: (
+        dict[ipaddress.IPv4Address, list[IPv4]] |
+        dict[ipaddress.IPv6Address, list[IPv6]]
+    ),
 ) -> bool:
     """Determine if it's safe to merge address into merge target.
 
@@ -337,12 +337,12 @@ def _SafeToMerge(
 
 
 def _CollapseAddrListInternal(
-    addresses: List[Union[IPv4, IPv6]],
-    complements_by_network: Union[
-        Dict[ipaddress.IPv4Address, List[IPv4]],
-        Dict[ipaddress.IPv6Address, List[IPv6]],
-    ],
-) -> List[Union[IPv4, IPv6]]:
+    addresses: list[IPv4 | IPv6],
+    complements_by_network: (
+        dict[ipaddress.IPv4Address, list[IPv4]] |
+        dict[ipaddress.IPv6Address, list[IPv6]]
+    ),
+) -> list[IPv4 | IPv6]:
     """Collapses consecutive netblocks until reaching a fixed point.
 
      Example:
@@ -407,9 +407,9 @@ def _CollapseAddrListInternal(
 
 
 def CollapseAddrList(
-    addresses: List[Union[IPv4, IPv6]],
-    complement_addresses: Optional[Union[List[IPv4], List[IPv6]]] = None,
-) -> List[Union[IPv4, IPv6]]:
+    addresses: list[IPv4 | IPv6],
+    complement_addresses: list[IPv4] | list[IPv6] | None = None,
+) -> list[IPv4 | IPv6]:
     """Collapse an array of IP objects.
 
     Example:  CollapseAddrList(
@@ -436,7 +436,7 @@ def CollapseAddrList(
       list of ipaddress.IPNetwork objects
     """
     complements_dict = collections.defaultdict(list)
-    address_set = set([a.network_address for a in addresses])
+    address_set = {a.network_address for a in addresses}
     for ca in complement_addresses or []:
         if ca.network_address in address_set:
             complements_dict[ca.network_address].append(ca)
@@ -445,14 +445,14 @@ def CollapseAddrList(
     )
 
 
-def SortAddrList(addresses: List[Union[IPv6, IPv4]]) -> List[Union[IPv6, IPv4]]:
+def SortAddrList(addresses: list[IPv6 | IPv4]) -> list[IPv6 | IPv4]:
     """Return a sorted list of nacaddr objects."""
     return sorted(addresses, key=ipaddress.get_mixed_type_key)
 
 
 def RemoveAddressFromList(
-    superset: List[Union[IPv4, IPv6]], exclude: Union[IPv4, IPv6]
-) -> List[Union[IPv6, IPv4]]:
+    superset: list[IPv4 | IPv6], exclude: IPv4 | IPv6
+) -> list[IPv6 | IPv4]:
     """Remove a single address from a list of addresses.
 
     Args:
@@ -476,10 +476,10 @@ def RemoveAddressFromList(
 
 
 def AddressListExclude(
-    superset: List[Union[IPv4, IPv6]],
-    excludes: List[Union[IPv4, IPv6]],
+    superset: list[IPv4 | IPv6],
+    excludes: list[IPv4 | IPv6],
     collapse_addrs: bool = True,
-) -> List[Union[IPv4, IPv6]]:
+) -> list[IPv4 | IPv6]:
     """Remove a list of addresses from another list of addresses.
 
     Args:

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import collections
 import ipaddress
 import itertools
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Union
 
 import aerleon.utils.iputils as iputils
 

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -48,7 +48,7 @@ DNS = 53/tcp
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import yaml
 from absl import logging

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -136,7 +136,7 @@ class UserMessage:
         *,
         filename: str,
         line: Optional[int] = None,
-        include_chain: Optional[List[Tuple[str, int]]] = None,
+        include_chain: Optional[list[tuple[str, int]]] = None,
     ):
         self.message = message
         self.filename = filename
@@ -236,10 +236,10 @@ class Naming:
                 if naming_type:
                     logging.warning('Naming object: ignoring unexpected naming_type.')
 
-                with open(file_path, 'r') as file_handle:
+                with open(file_path) as file_handle:
                     self.ParseYaml(file_handle, file_path.name)
             elif naming_type:
-                with open(file_path, 'r') as file_handle:
+                with open(file_path) as file_handle:
                     self._ParseFile(file_handle, naming_type)
 
         elif naming_dir:
@@ -270,7 +270,7 @@ class Naming:
                     )
                 )
 
-    def GetIpParents(self, query: str) -> List[str]:
+    def GetIpParents(self, query: str) -> list[str]:
         """Return network tokens that contain IP in query.
 
         Args:
@@ -323,7 +323,7 @@ class Naming:
                     recursive_parents.append(bp)
         return sorted(list(set(recursive_parents)))
 
-    def GetServiceParents(self, query: str) -> List[str]:
+    def GetServiceParents(self, query: str) -> list[str]:
         """Given a query token, return list of services definitions with that token.
 
         Args:
@@ -333,7 +333,7 @@ class Naming:
         """
         return self._GetParents(query, self.services)
 
-    def GetNetParents(self, query: str) -> List[str]:
+    def GetNetParents(self, query: str) -> list[str]:
         """Given a query token, return list of network definitions with that token.
 
         Args:
@@ -343,7 +343,7 @@ class Naming:
         """
         return self._GetParents(query, self.networks)
 
-    def _GetParents(self, query: str, query_group: Dict[str, _ItemUnit]) -> List[str]:
+    def _GetParents(self, query: str, query_group: dict[str, _ItemUnit]) -> list[str]:
         """Given a naming item dict, return any tokens containing the value.
 
         Args:
@@ -371,7 +371,7 @@ class Naming:
                 recursive_parents.append(bp)
         return recursive_parents
 
-    def GetNetChildren(self, query: str) -> List[str]:
+    def GetNetChildren(self, query: str) -> list[str]:
         """Given a query token, return list of network definitions tokens within provided token.
 
         This will only return children, not descendants of provided token.
@@ -384,7 +384,7 @@ class Naming:
         """
         return self._GetChildren(query, self.networks)
 
-    def _GetChildren(self, query: str, query_group: Dict[str, _ItemUnit]) -> List[str]:
+    def _GetChildren(self, query: str, query_group: dict[str, _ItemUnit]) -> list[str]:
         """Given a naming item dict, return tokens (not IPs) contained within this value.
 
         Args:
@@ -422,11 +422,11 @@ class Naming:
         except ValueError:
             return False
 
-    def GetServiceNames(self) -> List[str]:
+    def GetServiceNames(self) -> list[str]:
         """Returns the list of all known service names."""
         return list(self.services.keys())
 
-    def GetService(self, query: str) -> List[str]:
+    def GetService(self, query: str) -> list[str]:
         """Given a service name, return a list of associated ports and protocols.
 
         Args:
@@ -461,12 +461,12 @@ class Naming:
                         expandset.update(self.GetService(service))
                     except UndefinedServiceError as e:
                         # One of the services in query is undefined, refine the error msg.
-                        raise UndefinedServiceError('%s (in %s)' % (e, query))
+                        raise UndefinedServiceError(f'{e} (in {query})')
             else:
                 expandset.add(service)
         return sorted(expandset)
 
-    def GetPortParents(self, query: str, proto: str) -> List[str]:
+    def GetPortParents(self, query: str, proto: str) -> list[str]:
         """Returns a list of all service tokens containing the port/protocol pair.
 
         Args:
@@ -515,10 +515,10 @@ class Naming:
                     matches.add(bp)
         # error if the port/protocol pair is not found.
         if not matches:
-            raise UndefinedPortError('%s/%s is not found in any service tokens' % (query, proto))
+            raise UndefinedPortError(f'{query}/{proto} is not found in any service tokens')
         return sorted(matches)
 
-    def GetServiceByProto(self, query: str, proto: str) -> List[str]:
+    def GetServiceByProto(self, query: str, proto: str) -> list[str]:
         """Given a service name, return list of ports in the service by protocol.
 
         Args:
@@ -538,7 +538,7 @@ class Naming:
         data = query.split('#')  # Get the token keyword and remove any comment
         servicename = data[0].split()[0]  # strip and cast from list to string
         if servicename not in self.services:
-            raise UndefinedServiceError('%s %s' % ('\nNo such service,', servicename))
+            raise UndefinedServiceError('{} {}'.format('\nNo such service,', servicename))
 
         for service in self.GetService(servicename):
             if service and '/' in service:
@@ -547,7 +547,7 @@ class Naming:
                     services_set.add(parts[0])
         return sorted(services_set)
 
-    def GetFQDN(self, query: str) -> List[str]:
+    def GetFQDN(self, query: str) -> list[str]:
         """Expand a network token into a list of FQDN objects.
 
         Args:
@@ -565,7 +565,7 @@ class Naming:
             raise EmptyDefinitionError(f"No FQDN values found for network: {query}")
         return results
 
-    def _GetFQDN(self, query: str, level=0) -> List[str]:
+    def _GetFQDN(self, query: str, level=0) -> list[str]:
         returnlist = []
         data = query.split('#')
         token = data[0].split()[0]
@@ -593,11 +593,11 @@ class Naming:
             i.parent_token = token
         return returnlist
 
-    def GetNetAddr(self, query: str) -> List[Union[IPv4, IPv6]]:
+    def GetNetAddr(self, query: str) -> list[Union[IPv4, IPv6]]:
         """Alias of Naming.GetNet"""
         return self.GetNet(query)
 
-    def GetNet(self, query: str) -> List[Union[IPv4, IPv6]]:
+    def GetNet(self, query: str) -> list[Union[IPv4, IPv6]]:
         """Expand a network token into a list of nacaddr.IPv4 or nacaddr.IPv6 objects.
 
         Args:
@@ -615,7 +615,7 @@ class Naming:
             raise EmptyDefinitionError(f"No IP addresses found for network: {query}")
         return results
 
-    def _GetNet(self, query: str) -> List[Union[IPv4, IPv6]]:
+    def _GetNet(self, query: str) -> list[Union[IPv4, IPv6]]:
         returnlist = []
         data = query.split('#')
         token = data[0].split()[0]
@@ -671,20 +671,20 @@ class Naming:
                 continue
 
             try:
-                with open(path, 'r') as file:
+                with open(path) as file:
                     if def_type == 'yaml':
                         self.ParseYaml(file, path.name)
                     else:
                         self._ParseFile(file, def_type)
 
-            except IOError as error_info:
+            except OSError as error_info:
                 raise NoDefinitionsError('%s' % error_info)
 
-    def _ParseFile(self, file_handle: List[str], def_type: str) -> None:
+    def _ParseFile(self, file_handle: list[str], def_type: str) -> None:
         for line in file_handle:
             self._ParseLine(line, def_type)
 
-    def ParseServiceList(self, data: List[str]) -> None:
+    def ParseServiceList(self, data: list[str]) -> None:
         """Take an array of service data and import into class.
 
         This method allows us to pass an array of data that contains service
@@ -696,7 +696,7 @@ class Naming:
         for line in data:
             self._ParseLine(line, DEF_TYPE_SERVICES)
 
-    def ParseNetworkList(self, data: List[str]) -> None:
+    def ParseNetworkList(self, data: list[str]) -> None:
         """Take an array of network data and import into class.
 
         This method allows us to pass an array of data that contains network
@@ -729,7 +729,7 @@ class Naming:
 
         if definition_type not in ['services', 'networks']:
             raise UnexpectedDefinitionTypeError(
-                '%s %s' % ('Received an unexpected definition type:', definition_type)
+                '{} {}'.format('Received an unexpected definition type:', definition_type)
             )
         line = line.strip()
         if not line or line.startswith('#'):  # Skip comments and blanks.
@@ -752,7 +752,7 @@ class Naming:
                 for port in line_parts[1].strip().split():
                     if not self.port_re.match(port):
                         raise NamingSyntaxError(
-                            '%s: %s' % ('The following line has a syntax error', line)
+                            '{}: {}'.format('The following line has a syntax error', line)
                         )
                 if self.current_symbol in self.services:
                     raise NamespaceCollisionError(
@@ -822,7 +822,7 @@ class Naming:
 
         self.ParseDefinitionsObject(file_data, file_name)
 
-    def ParseDefinitionsObject(self, file_data: Dict[str, Any], file_name: str) -> None:
+    def ParseDefinitionsObject(self, file_data: dict[str, Any], file_name: str) -> None:
         """Load network and service definitions from a Python object.
 
         Arguments:
@@ -838,7 +838,7 @@ class Naming:
         # Check for at least one essential key, ignore with warning
         essential_keys = ['networks', 'services']
 
-        if not any((key in file_data for key in essential_keys)):
+        if not any(key in file_data for key in essential_keys):
             logging.warning(
                 UserMessage("File contains no network or service data.", filename=file_name)
             )
@@ -850,7 +850,7 @@ class Naming:
         if 'services' in file_data:
             self._ParseYamlServices(file_data, file_name)
 
-    def _ParseYamlNetworks(self, file_data: Dict[str, Any], file_name: str) -> None:
+    def _ParseYamlNetworks(self, file_data: dict[str, Any], file_name: str) -> None:
         if 'networks' in file_data and not isinstance(file_data['networks'], dict):
             logging.warning(
                 UserMessage(
@@ -940,7 +940,7 @@ class Naming:
                     if network_ref not in self.unseen_networks:
                         self.unseen_networks[network_ref] = True
 
-    def _ParseYamlServices(self, file_data: Dict[str, Any], file_name: str) -> None:
+    def _ParseYamlServices(self, file_data: dict[str, Any], file_name: str) -> None:
         if 'services' in file_data and not isinstance(file_data['services'], dict):
             logging.warning(
                 UserMessage(

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -17,7 +17,7 @@
 
 import collections
 import copy
-from typing import DefaultDict, Dict, List, Set, Tuple, Union
+from typing import DefaultDict, Union
 
 from absl import logging
 

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -53,7 +53,7 @@ def Add(statement: str) -> str:
         return statement
 
 
-def ChainFormat(kind: str, name: str, ruleset: List[str]) -> str:
+def ChainFormat(kind: str, name: str, ruleset: list[str]) -> str:
     """Builds a chain in NFtables configuration format.
 
     Args:
@@ -67,7 +67,7 @@ def ChainFormat(kind: str, name: str, ruleset: List[str]) -> str:
     header_sp = 4
     content_sp = 8
     chain_output = []
-    chain_output.append(TabSpacer(header_sp, '%s %s {' % (kind, name)))
+    chain_output.append(TabSpacer(header_sp, f'{kind} {name} {{'))
     for line in ruleset:
         chain_output.append(TabSpacer(content_sp, line))
     chain_output.append(TabSpacer(header_sp, '}'))
@@ -122,7 +122,7 @@ class Term(aclgenerator.Term):
         self.hook = nf_hook
         self.verbose = verbose
 
-    def MapICMPtypes(self, af: SyntaxWarning, term_icmp_types: List[str]) -> List[str]:
+    def MapICMPtypes(self, af: SyntaxWarning, term_icmp_types: list[str]) -> list[str]:
         """Normalize certain ICMP_TYPES for NFTables rendering.
 
         If we encounter certain keyword values in policy.Term.ICMP_TYPE keywords,
@@ -176,7 +176,7 @@ class Term(aclgenerator.Term):
                     term_icmp_types[term_icmp_types.index(item)] = ICMP_TYPE_REMAP[6].get(item)
         return term_icmp_types
 
-    def CreateAnonymousSet(self, data: List[str]) -> str:
+    def CreateAnonymousSet(self, data: list[str]) -> str:
         """Build a nftables anonymous set from some elements.
 
         Anonymous are formatted using curly braces then some data. These sets are
@@ -198,7 +198,7 @@ class Term(aclgenerator.Term):
             return nfset
         if len(data) > 1:
             nfset = ', '.join(data)
-            return '{{ {0} }}'.format(nfset)
+            return f'{{ {nfset} }}'
 
     def PortsAndProtocols(self, address_family, protocol, src_ports, dst_ports, icmp_type):
         """Handling protocol specific NFTable statements.
@@ -215,17 +215,17 @@ class Term(aclgenerator.Term):
 
         """
 
-        def PortStatement(protocol: List[str], source: str, destination: str) -> List[str]:
+        def PortStatement(protocol: list[str], source: str, destination: str) -> list[str]:
             """NFT port statement. Returns empty if no ports defined."""
             ports_list = []
 
             # SOURCE PORTS.
             if source:
-                ports_list.append('%s sport %s' % (protocol, self.CreateAnonymousSet(source)))
+                ports_list.append(f'{protocol} sport {self.CreateAnonymousSet(source)}')
 
             # DESTINATION PORTS.
             if destination:
-                ports_list.append('%s dport %s' % (protocol, self.CreateAnonymousSet(destination)))
+                ports_list.append(f'{protocol} dport {self.CreateAnonymousSet(destination)}')
 
             # Normalize ports into single nft statement.
             if ports_list:
@@ -353,8 +353,8 @@ class Term(aclgenerator.Term):
             return ''
 
     def GroupExpressions(
-        self, address_expr: List[str], pp_expr: List[str], options: str, verdict: str
-    ) -> List[str]:
+        self, address_expr: list[str], pp_expr: list[str], options: str, verdict: str
+    ) -> list[str]:
         """Combines all expressions with a verdict (decision).
 
         The inputs are already pre-sanitized by RulesetGenerator. NFTables processes
@@ -391,15 +391,15 @@ class Term(aclgenerator.Term):
                 statement.append(pstat + Add(options) + Add(verdict))
         else:
             # If no addresses or ports & protocol. Verdict only statement.
-            statement.append((Add(options) + verdict))
+            statement.append(Add(options) + verdict)
         return statement
 
     def _AddrStatement(
         self,
         address_family: str,
-        src_addr: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
-        dst_addr: List[Union[nacaddr.IPv4, nacaddr.IPv6]],
-    ) -> List[str]:
+        src_addr: list[Union[nacaddr.IPv4, nacaddr.IPv6]],
+        dst_addr: list[Union[nacaddr.IPv4, nacaddr.IPv6]],
+    ) -> list[str]:
         """Builds an NFTables address statement.
 
         Args:
@@ -459,7 +459,7 @@ class Term(aclgenerator.Term):
                     )
         return address_statement
 
-    def RulesetGenerator(self, term: policy.Term) -> List[str]:
+    def RulesetGenerator(self, term: policy.Term) -> list[str]:
         """Generate string rules of a given Term.
 
         Rules are constructed from Terms() and are contained within chains.
@@ -506,8 +506,8 @@ class Term(aclgenerator.Term):
         return term_ruleset
 
     def _AddressClassifier(
-        self, address_to_classify: List[Union[nacaddr.IPv4, nacaddr.IPv6]]
-    ) -> DefaultDict[str, List[Union[nacaddr.IPv4, nacaddr.IPv6]]]:
+        self, address_to_classify: list[Union[nacaddr.IPv4, nacaddr.IPv6]]
+    ) -> DefaultDict[str, list[Union[nacaddr.IPv4, nacaddr.IPv6]]]:
         """Organizes network addresses according to IP family in a dict.
 
         Args:
@@ -524,7 +524,7 @@ class Term(aclgenerator.Term):
                 addresses['ip6'].append(str(addr))
         return addresses
 
-    def _Group(self, group: List[Tuple[int, int]]) -> str:
+    def _Group(self, group: list[tuple[int, int]]) -> str:
         """If 1 item return it, else return [ item1 item2 ].
 
         Args:
@@ -584,7 +584,7 @@ class Nftables(aclgenerator.ACLGenerator):
     # In Nftables 'inet' contains both IPv4 and IPv6 addresses and rules.
     NF_TABLE_AF_MAP = {'inet': 'ip', 'inet6': 'ip6', 'mixed': 'inet'}
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """NFTables generator list of supported tokens and sub tokens.
 
         Returns:
@@ -713,7 +713,7 @@ class Nftables(aclgenerator.ACLGenerator):
                 )
             )
 
-    def _ProcessHeader(self, header_options: List[str]) -> Tuple[str, str, int, str, bool]:
+    def _ProcessHeader(self, header_options: list[str]) -> tuple[str, str, int, str, bool]:
         """Aerleon policy header processing.
 
         Args:
@@ -768,7 +768,7 @@ class Nftables(aclgenerator.ACLGenerator):
         return netfilter_family, netfilter_hook, netfilter_priority, policy_default_action, verbose
 
     def _ConfigurationDictionary(
-        self, nft_pol: List[Union[policy.Header, str, int, bool, DefaultDict]]
+        self, nft_pol: list[Union[policy.Header, str, int, bool, DefaultDict]]
     ) -> DefaultDict[str, Union[str, DefaultDict]]:
         """NFTables configuration object.
 

--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -26,14 +26,20 @@ from aerleon.lib.policy import Term
 
 R24_3_2 = "r24.3.2"  # Option flag to generate release >= 24.3.2 syntax
 
+
 class IPPrefix(TypedDict):
     prefix: str
+
+
 class PortRange(TypedDict):
     start: int
     end: int
+
+
 class Port(TypedDict):
     value: int
     range: PortRange
+
 
 Match = TypedDict(
     "Match",
@@ -48,9 +54,13 @@ Match = TypedDict(
         "destination-port": Port,
     },
 )
+
+
 class Action(TypedDict):
     accept: None
     drop: None
+
+
 ACLEntry = TypedDict(
     "ACLEntry",
     {

--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -19,13 +19,10 @@ More information about the SR Linux ACL model schema: https://yang.srlinux.dev/
 
 """
 
-import sys
-from typing import Dict, List, Set, Tuple
+from typing import TypedDict
 
 from aerleon.lib import aclgenerator, openconfig
 from aerleon.lib.policy import Term
-
-from typing import TypedDict
 
 R24_3_2 = "r24.3.2"  # Option flag to generate release >= 24.3.2 syntax
 

--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -25,16 +25,18 @@ from typing import Dict, List, Set, Tuple
 from aerleon.lib import aclgenerator, openconfig
 from aerleon.lib.policy import Term
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 R24_3_2 = "r24.3.2"  # Option flag to generate release >= 24.3.2 syntax
 
-IPPrefix = TypedDict("IPPrefix", {"prefix": str})
-PortRange = TypedDict("PortRange", {"start": int, "end": int})
-Port = TypedDict("Port", {"value": int, "range": PortRange})
+class IPPrefix(TypedDict):
+    prefix: str
+class PortRange(TypedDict):
+    start: int
+    end: int
+class Port(TypedDict):
+    value: int
+    range: PortRange
 
 Match = TypedDict(
     "Match",
@@ -49,7 +51,9 @@ Match = TypedDict(
         "destination-port": Port,
     },
 )
-Action = TypedDict("Action", {"accept": None, "drop": None})
+class Action(TypedDict):
+    accept: None
+    drop: None
 ACLEntry = TypedDict(
     "ACLEntry",
     {
@@ -63,7 +67,7 @@ ACLEntry = TypedDict(
 Entries = TypedDict(
     "Entries",
     {
-        "entry": List[ACLEntry],
+        "entry": list[ACLEntry],
         "description": str,
         "name": str,
         "type": str,
@@ -104,7 +108,7 @@ class SRLTerm(openconfig.Term):
         # Put name in description field
         self.term_dict['description'] = name
 
-    def SetAction(self, filter_options: List[str]) -> None:
+    def SetAction(self, filter_options: list[str]) -> None:
         action = self.ACTION_MAP[self.term.action[0]]
         if R24_3_2 in filter_options:
             self.term_dict['action'] = {action: {}}
@@ -121,18 +125,18 @@ class SRLTerm(openconfig.Term):
                     )
             self.term_dict['action'] = {action: log}
 
-    def SetComments(self, comments: List[str]) -> None:
+    def SetComments(self, comments: list[str]) -> None:
         self.term_dict['_annotate_description'] = "_".join(comments)[:255]
 
     # Handles syntax changes in release 24.3.2 and beyond
-    def _field(self, key, filter_options: List[str]):
+    def _field(self, key, filter_options: list[str]):
         if R24_3_2 in filter_options:
             if key not in self.term_dict['match']:
                 self.term_dict['match'][key] = {}
             return self.term_dict['match'][key]
         return self.term_dict['match']
 
-    def SetOptions(self, family: str, filter_options: List[str]) -> None:
+    def SetOptions(self, family: str, filter_options: list[str]) -> None:
         # Handle various options
         opts = [str(x) for x in self.term.option]
         self.term_dict['match'] = {}
@@ -183,27 +187,27 @@ class SRLTerm(openconfig.Term):
         ):
             self.SetProtocol(family=family, protocol="tcp", filter_options=filter_options)
 
-    def SetSourceAddress(self, family: str, saddr: str, filter_options: List[str]) -> None:
+    def SetSourceAddress(self, family: str, saddr: str, filter_options: list[str]) -> None:
         self._field(family, filter_options)['source-ip'] = {'prefix': saddr}
 
-    def SetDestAddress(self, family: str, daddr: str, filter_options: List[str]) -> None:
+    def SetDestAddress(self, family: str, daddr: str, filter_options: list[str]) -> None:
         self._field(family, filter_options)['destination-ip'] = {'prefix': daddr}
 
-    def SetSourcePorts(self, start: int, end: int, filter_options: List[str]) -> None:
+    def SetSourcePorts(self, start: int, end: int, filter_options: list[str]) -> None:
         if start == end:
             val = {'value': start}
         else:
             val = {'range': {'start': start, 'end': end}}
         self._field('transport', filter_options)['source-port'] = val
 
-    def SetDestPorts(self, start: int, end: int, filter_options: List[str]) -> None:
+    def SetDestPorts(self, start: int, end: int, filter_options: list[str]) -> None:
         if start == end:
             val = {'value': start}
         else:
             val = {'range': {'start': start, 'end': end}}
         self._field('transport', filter_options)['destination-port'] = val
 
-    def SetProtocol(self, family: str, protocol: int, filter_options: List[str]) -> None:
+    def SetProtocol(self, family: str, protocol: int, filter_options: list[str]) -> None:
         field_name = "protocol" if family == "ipv4" else "next-header"
         self._field(family, filter_options)[field_name] = protocol
 
@@ -214,7 +218,7 @@ class NokiaSRLinux(openconfig.OpenConfig):
     _PLATFORM = 'nokiasrl'
     SUFFIX = '.srl_acl'
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -240,17 +244,17 @@ class NokiaSRLinux(openconfig.OpenConfig):
 
     def _InitACLSet(self) -> None:
         """Initialize self.acl_sets with proper Typing"""
-        self.acl_sets: List[IPFilters] = []
+        self.acl_sets: list[IPFilters] = []
 
     def _TranslateTerms(
         self,
-        terms: List[Term],
+        terms: list[Term],
         address_family: str,
         filter_name: str,
-        hdr_comments: List[str],
-        filter_options: List[str],
+        hdr_comments: list[str],
+        filter_options: list[str],
     ) -> None:
-        srl_acl_entries: Dict[str, List[ACLEntry]] = {'inet': [], 'inet6': []}
+        srl_acl_entries: dict[str, list[ACLEntry]] = {'inet': [], 'inet6': []}
         afs = ['inet', 'inet6'] if address_family == 'mixed' else [address_family]
         for term in terms:
             for term_af in afs:

--- a/aerleon/lib/nsxt.py
+++ b/aerleon/lib/nsxt.py
@@ -273,7 +273,7 @@ class Nsxt(aclgenerator.ACLGenerator):
     _DEFAULT_PROTOCOL = 'ip'
     SUFFIX = '.nsxt'
 
-    _OPTIONAL_SUPPORTED_KEYWORDS = set(['expiration', 'logging'])
+    _OPTIONAL_SUPPORTED_KEYWORDS = {'expiration', 'logging'}
     _FILTER_OPTIONS_DICT = {}
 
     def _TranslatePolicy(self, pol, exp_info):

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -173,7 +173,9 @@ class Term(aclgenerator.Term):
                 self.term.name,
             )
 
-        name = '{}{}{}'.format(_XML_TABLE.get('nameStart'), self.term.name, _XML_TABLE.get('nameEnd'))
+        name = '{}{}{}'.format(
+            _XML_TABLE.get('nameStart'), self.term.name, _XML_TABLE.get('nameEnd')
+        )
 
         notes = ''
         if self.term.comment:
@@ -495,8 +497,8 @@ class Nsxv(aclgenerator.ACLGenerator):
     SUFFIX = '.nsx'
 
     _OPTIONAL_SUPPORTED_KEYWORDS = {
-            'expiration',
-            'logging',
+        'expiration',
+        'logging',
     }
     _FILTER_OPTIONS_DICT = {}
 

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -173,13 +173,13 @@ class Term(aclgenerator.Term):
                 self.term.name,
             )
 
-        name = '%s%s%s' % (_XML_TABLE.get('nameStart'), self.term.name, _XML_TABLE.get('nameEnd'))
+        name = '{}{}{}'.format(_XML_TABLE.get('nameStart'), self.term.name, _XML_TABLE.get('nameEnd'))
 
         notes = ''
         if self.term.comment:
             for comment in self.term.comment:
-                notes = '%s%s' % (notes, comment)
-            notes = '%s%s%s' % (_XML_TABLE.get('noteStart'), notes, _XML_TABLE.get('noteEnd'))
+                notes = f'{notes}{comment}'
+            notes = '{}{}{}'.format(_XML_TABLE.get('noteStart'), notes, _XML_TABLE.get('noteEnd'))
 
         # protocol
         protocol = None
@@ -287,34 +287,34 @@ class Term(aclgenerator.Term):
                 # inet4
                 if isinstance(saddr, nacaddr.IPv4):
                     if saddr.num_addresses > 1:
-                        saddr = '%s%s%s' % (
+                        saddr = '{}{}{}'.format(
                             _XML_TABLE.get('srcIpv4Start'),
                             saddr.with_prefixlen,
                             _XML_TABLE.get('srcIpv4End'),
                         )
                     else:
-                        saddr = '%s%s%s' % (
+                        saddr = '{}{}{}'.format(
                             _XML_TABLE.get('srcIpv4Start'),
                             saddr.network_address,
                             _XML_TABLE.get('srcIpv4End'),
                         )
-                    sources = '%s%s' % (sources, saddr)
+                    sources = f'{sources}{saddr}'
                 # inet6
                 if isinstance(saddr, nacaddr.IPv6):
                     if saddr.num_addresses > 1:
-                        saddr = '%s%s%s' % (
+                        saddr = '{}{}{}'.format(
                             _XML_TABLE.get('srcIpv6Start'),
                             saddr.with_prefixlen,
                             _XML_TABLE.get('srcIpv6End'),
                         )
                     else:
-                        saddr = '%s%s%s' % (
+                        saddr = '{}{}{}'.format(
                             _XML_TABLE.get('srcIpv6Start'),
                             saddr.network_address,
                             _XML_TABLE.get('srcIpv6End'),
                         )
-                    sources = '%s%s' % (sources, saddr)
-            sources = '%s%s' % (sources, '</sources>')
+                    sources = f'{sources}{saddr}'
+            sources = '{}{}'.format(sources, '</sources>')
 
         destinations = ''
         if destination_addr:
@@ -323,34 +323,34 @@ class Term(aclgenerator.Term):
                 # inet4
                 if isinstance(daddr, nacaddr.IPv4):
                     if daddr.num_addresses > 1:
-                        daddr = '%s%s%s' % (
+                        daddr = '{}{}{}'.format(
                             _XML_TABLE.get('destIpv4Start'),
                             daddr.with_prefixlen,
                             _XML_TABLE.get('destIpv4End'),
                         )
                     else:
-                        daddr = '%s%s%s' % (
+                        daddr = '{}{}{}'.format(
                             _XML_TABLE.get('destIpv4Start'),
                             daddr.network_address,
                             _XML_TABLE.get('destIpv4End'),
                         )
-                    destinations = '%s%s' % (destinations, daddr)
+                    destinations = f'{destinations}{daddr}'
                 # inet6
                 if isinstance(daddr, nacaddr.IPv6):
                     if daddr.num_addresses > 1:
-                        daddr = '%s%s%s' % (
+                        daddr = '{}{}{}'.format(
                             _XML_TABLE.get('destIpv6Start'),
                             daddr.with_prefixlen,
                             _XML_TABLE.get('destIpv6End'),
                         )
                     else:
-                        daddr = '%s%s%s' % (
+                        daddr = '{}{}{}'.format(
                             _XML_TABLE.get('destIpv6Start'),
                             daddr.network_address,
                             _XML_TABLE.get('destIpv6End'),
                         )
-                    destinations = '%s%s' % (destinations, daddr)
-            destinations = '%s%s' % (destinations, '</destinations>')
+                    destinations = f'{destinations}{daddr}'
+            destinations = '{}{}'.format(destinations, '</destinations>')
 
         services = []
         if protocol:
@@ -364,22 +364,22 @@ class Term(aclgenerator.Term):
 
         service = ''
         for s in services:
-            service = '%s%s' % (service, s)
+            service = f'{service}{s}'
 
         # applied_to
         applied_to_list = ''
         if self.applied_to:
             applied_to_list = '<appliedToList>'
-            applied_to_element = '%s%s%s' % (
+            applied_to_element = '{}{}{}'.format(
                 _XML_TABLE.get('appliedToStart'),
                 self.applied_to,
                 _XML_TABLE.get('appliedToEnd'),
             )
-            applied_to_list = '%s%s' % (applied_to_list, applied_to_element)
-            applied_to_list = '%s%s' % (applied_to_list, '</appliedToList>')
+            applied_to_list = f'{applied_to_list}{applied_to_element}'
+            applied_to_list = '{}{}'.format(applied_to_list, '</appliedToList>')
 
         # action
-        action = '%s%s%s' % (
+        action = '{}{}{}'.format(
             _XML_TABLE.get('actionStart'),
             _ACTION_TABLE.get(str(self.term.action[0])),
             _XML_TABLE.get('actionEnd'),
@@ -397,7 +397,7 @@ class Term(aclgenerator.Term):
         return ''.join(ret_str)
 
     def _ServiceToString(
-        self, proto: int, sports: Tuple[int, int], dports: Tuple[int, int], icmp_types: List[str]
+        self, proto: int, sports: tuple[int, int], dports: tuple[int, int], icmp_types: list[str]
     ):
         """Converts service to string.
 
@@ -416,7 +416,7 @@ class Term(aclgenerator.Term):
         if proto == 1 or proto == 58:
             # handle icmp protocol
             for icmp_type in icmp_types:
-                icmp_service = '%s%s%s%s' % (
+                icmp_service = '{}{}{}{}'.format(
                     _XML_TABLE.get('serviceStart'),
                     _XML_TABLE.get('protocolStart'),
                     proto,
@@ -424,17 +424,17 @@ class Term(aclgenerator.Term):
                 )
                 # handle icmp types
                 if icmp_type:
-                    icmp_type = '%s%s%s' % (
+                    icmp_type = '{}{}{}'.format(
                         _XML_TABLE.get('icmpTypeStart'),
                         str(icmp_type),
                         _XML_TABLE.get('icmpTypeEnd'),
                     )
-                    icmp_service = '%s%s' % (icmp_service, icmp_type)
-                icmp_service = '%s%s' % (icmp_service, _XML_TABLE.get('serviceEnd'))
-                service = '%s%s' % (service, icmp_service)
+                    icmp_service = f'{icmp_service}{icmp_type}'
+                icmp_service = '{}{}'.format(icmp_service, _XML_TABLE.get('serviceEnd'))
+                service = f'{service}{icmp_service}'
         else:
             # handle other protocols
-            service = '%s%s%s%s' % (
+            service = '{}{}{}{}'.format(
                 _XML_TABLE.get('serviceStart'),
                 _XML_TABLE.get('protocolStart'),
                 proto,
@@ -446,10 +446,10 @@ class Term(aclgenerator.Term):
                 str_sport = []
                 for sport in sports:
                     if sport[0] != sport[1]:
-                        str_sport.append('%s-%s' % (sport[0], sport[1]))
+                        str_sport.append(f'{sport[0]}-{sport[1]}')
                     else:
                         str_sport.append('%s' % (sport[0]))
-                service = '%s%s%s%s' % (
+                service = '{}{}{}{}'.format(
                     service,
                     _XML_TABLE.get('srcPortStart'),
                     ', '.join(str_sport),
@@ -461,16 +461,16 @@ class Term(aclgenerator.Term):
                 str_dport = []
                 for dport in dports:
                     if dport[0] != dport[1]:
-                        str_dport.append('%s-%s' % (dport[0], dport[1]))
+                        str_dport.append(f'{dport[0]}-{dport[1]}')
                     else:
                         str_dport.append('%s' % (dport[0]))
-                service = '%s%s%s%s' % (
+                service = '{}{}{}{}'.format(
                     service,
                     _XML_TABLE.get('destPortStart'),
                     ', '.join(str_dport),
                     _XML_TABLE.get('destPortEnd'),
                 )
-            service = '%s%s' % (service, _XML_TABLE.get('serviceEnd'))
+            service = '{}{}'.format(service, _XML_TABLE.get('serviceEnd'))
 
         return service
 
@@ -494,15 +494,13 @@ class Nsxv(aclgenerator.ACLGenerator):
     _DEFAULT_PROTOCOL = 'ip'
     SUFFIX = '.nsx'
 
-    _OPTIONAL_SUPPORTED_KEYWORDS = set(
-        [
+    _OPTIONAL_SUPPORTED_KEYWORDS = {
             'expiration',
             'logging',
-        ]
-    )
+    }
     _FILTER_OPTIONS_DICT = {}
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -579,7 +577,7 @@ class Nsxv(aclgenerator.ACLGenerator):
 
             self.nsxv_policies.append((header, filter_name, [filter_type], new_terms))
 
-    def _ParseFilterOptions(self, filter_options: List[str]):
+    def _ParseFilterOptions(self, filter_options: list[str]):
         """Parses the target in header for filter type, section_id and applied_to.
 
         Args:
@@ -665,7 +663,7 @@ class Nsxv(aclgenerator.ACLGenerator):
                 target.append('<section name="%s">' % (section_name.strip(' \t\n\r')))
             else:
                 target.append(
-                    '<section id="%s" name="%s">' % (section_id, section_name.strip(' \t\n\r'))
+                    '<section id="{}" name="{}">'.format(section_id, section_name.strip(' \t\n\r'))
                 )
 
             # now add the terms

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -18,7 +18,7 @@
 
 import re
 import xml
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 from absl import logging
 

--- a/aerleon/lib/nvueapi.py
+++ b/aerleon/lib/nvueapi.py
@@ -23,7 +23,7 @@ https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-514/System-Co
 
 import itertools
 import json
-from typing import Dict, List, Optional
+from typing import Optional
 
 try:
     from absl import logging

--- a/aerleon/lib/nvueapi.py
+++ b/aerleon/lib/nvueapi.py
@@ -92,7 +92,7 @@ class Term(aclgenerator.Term):
         # which handles the cartesian product of multiple addresses
         raise NotImplementedError("Use GenerateRules() method instead")
 
-    def GenerateRules(self) -> List[Dict]:
+    def GenerateRules(self) -> list[dict]:
         """Generate NVUE rules handling multiple addresses.
 
         Since NVUE only supports single CIDR prefixes per rule (like iptables),
@@ -131,7 +131,7 @@ class Term(aclgenerator.Term):
 
         return rules
 
-    def _GetFilteredAddresses(self, addresses) -> List[str]:
+    def _GetFilteredAddresses(self, addresses) -> list[str]:
         """Get addresses filtered by address family.
 
         Args:
@@ -151,7 +151,7 @@ class Term(aclgenerator.Term):
                 filtered.append(str(addr))
         return filtered
 
-    def _GetProtocols(self) -> List[Optional[str]]:
+    def _GetProtocols(self) -> list[Optional[str]]:
         """Get protocol list, translating Aerleon protocol names to NVUE format.
 
         Returns:
@@ -161,7 +161,7 @@ class Term(aclgenerator.Term):
             return [None]
         return [_PROTO_TABLE.get(p, p) for p in self.term.protocol]
 
-    def _GetPorts(self, port_list) -> List[Optional[str]]:
+    def _GetPorts(self, port_list) -> list[Optional[str]]:
         """Get port list in NVUE format (porta:portz).
 
         Args:
@@ -182,7 +182,7 @@ class Term(aclgenerator.Term):
                 ports.append(f"{port_range[0]}:{port_range[1]}")
         return ports
 
-    def _GetIcmpTypes(self) -> List[Optional[str]]:
+    def _GetIcmpTypes(self) -> list[Optional[str]]:
         """Get ICMP type list, converting from Aerleon format to iptables format.
 
         Returns:
@@ -201,7 +201,7 @@ class Term(aclgenerator.Term):
         dest_port: Optional[str],
         source_port: Optional[str],
         icmp_type: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """Create a single NVUE rule from the given parameters.
 
         Args:
@@ -299,7 +299,7 @@ class NvueApi(aclgenerator.ACLGenerator):
     _PLATFORM = 'nvueapi'
     _DEFAULT_PROTOCOL = 'ip'
     SUFFIX = '.nvueapi.json'
-    SUPPORTED_AF = set(['inet', 'inet6'])
+    SUPPORTED_AF = {'inet', 'inet6'}
     SUPPORTED_TARGETS = frozenset(['nvueapi'])
     WARN_IF_UNSUPPORTED = frozenset(['translated', 'stateless_reply', 'counter', 'policer'])
 

--- a/aerleon/lib/openconfig.py
+++ b/aerleon/lib/openconfig.py
@@ -60,24 +60,39 @@ TransportConfig = TypedDict(
         "builtin-detail": str,
     },
 )
+
+
 class Transport(TypedDict):
     transport: TransportConfig
+
+
 IPConfig = TypedDict(
     "IPConfig", {"source-address": str, "destination-address": str, "protocol": int}
 )
+
+
 class IP(TypedDict):
     config: IPConfig
+
+
 ActionConfig = TypedDict("ActionConfig", {"forwarding-action": str})
+
+
 class Action(TypedDict):
     config: ActionConfig
+
+
 ACLEntry = TypedDict(
     "ACLEntry",
     {"sequence-id": int, "actions": Action, "ipv4": IP, "ipv6": IP, "transport": Transport},
 )
 aclEntries = TypedDict("aclEntries", {"acl-entry": list[ACLEntry]})
+
+
 class ACLSetConfig(TypedDict):
     name: str
     type: str
+
 
 ACLSet = TypedDict(
     "ACLSet", {"acl-entries": aclEntries, "config": ACLSetConfig, "name": str, "type": str}

--- a/aerleon/lib/openconfig.py
+++ b/aerleon/lib/openconfig.py
@@ -22,15 +22,12 @@ http://ops.openconfig.net/branches/models/master/openconfig-acl.html
 
 import copy
 import json
-import sys
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Set, Tuple, Union
+from typing import Any, DefaultDict, TypedDict, Union
 
 from absl import logging
 
 from aerleon.lib import aclgenerator, policy
-
-from typing import TypedDict
 
 
 class Error(aclgenerator.Error):

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -18,7 +18,7 @@
 
 import collections
 import copy
-from typing import Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 from absl import logging
 

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -280,7 +280,7 @@ class Term(aclgenerator.Term):
 
         return '\n'.join(str(v) for v in ret_str if v)
 
-    def _CheckAddressAf(self, addrs: List[Union[IPv4, IPv6]]) -> List[Union[IPv4, IPv6, str]]:
+    def _CheckAddressAf(self, addrs: list[Union[IPv4, IPv6]]) -> list[Union[IPv4, IPv6, str]]:
         """Verify that the requested address-family matches the address's family."""
         if not addrs:
             return ['any']
@@ -297,20 +297,20 @@ class Term(aclgenerator.Term):
         self,
         action: str,
         direction: str,
-        log: List[VarType],
+        log: list[VarType],
         interface: Optional[str],
         af: str,
-        proto: List[str],
+        proto: list[str],
         src_addr: str,
-        src_port: Union[List[str], str],
+        src_port: Union[list[str], str],
         dst_addr: str,
-        dst_port: Union[List[str], str],
-        tcp_flags_set: List[str],
-        tcp_flags_check: List[str],
-        icmp_types: List[Union[str, int]],
-        options: List[str],
+        dst_port: Union[list[str], str],
+        tcp_flags_set: list[str],
+        tcp_flags_check: list[str],
+        icmp_types: list[Union[str, int]],
+        options: list[str],
         stateful: bool,
-    ) -> List[str]:
+    ) -> list[str]:
         """Format the string which will become a single PF entry."""
         line = ['%s' % self._ACTION_TABLE.get(action)]
 
@@ -347,7 +347,7 @@ class Term(aclgenerator.Term):
 
         if tcp_flags_set and tcp_flags_check:
             line.append('flags')
-            line.append('%s/%s' % (''.join(tcp_flags_set), ''.join(tcp_flags_check)))
+            line.append('{}/{}'.format(''.join(tcp_flags_set), ''.join(tcp_flags_check)))
 
         if 'icmp' in proto and icmp_types:
             type_strs = [str(icmp_type) for icmp_type in icmp_types]
@@ -371,7 +371,7 @@ class Term(aclgenerator.Term):
 
         return [' '.join(line)]
 
-    def _GenerateProtoStatement(self, protocols: List[str]) -> str:
+    def _GenerateProtoStatement(self, protocols: list[str]) -> str:
         proto = ''
         if protocols:
             protocols = copy.deepcopy(protocols)
@@ -386,7 +386,7 @@ class Term(aclgenerator.Term):
         return proto
 
     def _GenerateAddrStatement(
-        self, addrs: List[Union[IPv4, IPv6]], exclude_addrs: List[Union[IPv4, IPv6]]
+        self, addrs: list[Union[IPv4, IPv6]], exclude_addrs: list[Union[IPv4, IPv6]]
     ) -> str:
         addresses = set()
         if addrs != ['any']:
@@ -407,13 +407,13 @@ class Term(aclgenerator.Term):
                 addresses.add('!<%s>' % token[:31])
         return '{ %s }' % ', '.join(sorted(addresses))
 
-    def _GeneratePortStatement(self, ports: List[Tuple[int, int]]) -> str:
+    def _GeneratePortStatement(self, ports: list[tuple[int, int]]) -> str:
         port_list = []
         for port_tuple in ports:
             if port_tuple[0] == port_tuple[1]:
                 port_list.append(str(port_tuple[0]))
             else:
-                port_list.append('%s:%s' % (port_tuple[0], port_tuple[1]))
+                port_list.append(f'{port_tuple[0]}:{port_tuple[1]}')
         return '{ %s }' % (' '.join(list(collections.OrderedDict.fromkeys(port_list))))
 
     def _SetDefaultAction(self) -> None:
@@ -431,7 +431,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
     SUFFIX = '.pf'
     _TERM = Term
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -544,7 +544,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
                         self.def_short_to_long[src_token] = source_addr.parent_token
 
                     if src_token not in self.address_book:
-                        self.address_book[src_token] = set([source_addr])
+                        self.address_book[src_token] = {source_addr}
                     else:
                         self.address_book[src_token].add(source_addr)
 
@@ -568,7 +568,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
                         self.def_short_to_long[dst_token] = dest_addr.parent_token
 
                     if dst_token not in self.address_book:
-                        self.address_book[dst_token] = set([dest_addr])
+                        self.address_book[dst_token] = {dest_addr}
                     else:
                         self.address_book[dst_token].add(dest_addr)
 
@@ -601,17 +601,17 @@ class PacketFilter(aclgenerator.ACLGenerator):
     def __str__(self) -> str:
         """Render the output of the PF policy into config."""
         target = []
-        pretty_platform = '%s%s' % (self._PLATFORM[0].upper(), self._PLATFORM[1:])
+        pretty_platform = f'{self._PLATFORM[0].upper()}{self._PLATFORM[1:]}'
         # Create address table.
         for name in sorted(self.address_book):
             v4 = sorted([x for x in self.address_book[name] if x.version == 4])
             v6 = sorted([x for x in self.address_book[name] if x.version == 6])
             entries = ',\\\n'.join(str(x) for x in v4 + v6)
-            target.append('table <%s> {%s}' % (name, entries))
+            target.append(f'table <{name}> {{{entries}}}')
         # pylint: disable=unused-variable
         for header, filter_name, filter_type, terms in self.pf_policies:
             # Add comments for this filter
-            target.append('# %s %s Policy' % (pretty_platform, header.FilterName(self._PLATFORM)))
+            target.append(f'# {pretty_platform} {header.FilterName(self._PLATFORM)} Policy')
 
             # reformat long text comments, if needed
             comments = aclgenerator.WrapWords(header.comment, 70)

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -76,8 +76,8 @@ class ServiceMap:
     def get_service_name(
         self,
         term_name: str,
-        src_ports: Tuple[str],
-        ports: Union[Tuple[str, str], Tuple[str]],
+        src_ports: tuple[str],
+        ports: Union[tuple[str, str], tuple[str]],
         protocol: str,
         prefix: Optional[str] = None,
     ) -> str:
@@ -87,7 +87,7 @@ class ServiceMap:
 
         if prefix is None:
             prefix = "service-"
-        service_name = "%s%s-%s" % (prefix, term_name, protocol)
+        service_name = f"{prefix}{term_name}-{protocol}"
 
         if len(service_name) > 63:
             raise PaloAltoFWNameTooLongError(
@@ -130,7 +130,7 @@ class Rule:
     @staticmethod
     def TermToOptions(
         from_zone: str, to_zone: str, term: Term, service_map: ServiceMap
-    ) -> Tuple[Dict[str, Union[List[str], str]], Optional[Term]]:
+    ) -> tuple[dict[str, Union[list[str], str]], Optional[Term]]:
         """Convert term to Palo Alto security rule options."""
         options = {}
         options["from_zone"] = [from_zone]
@@ -267,7 +267,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
 
     _PLATFORM = "paloalto"
     SUFFIX = ".xml"
-    _SUPPORTED_AF = set(("inet", "inet6", "mixed"))
+    _SUPPORTED_AF = {"inet", "inet6", "mixed"}
     _AF_MAP = {"inet": (4,), "inet6": (6,), "mixed": (4, 6)}
     _TERM_MAX_LENGTH = 63
     _APPLICATION_NAME_MAX_LENGTH = 31
@@ -342,7 +342,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
         self.service_map = ServiceMap()
         super().__init__(pol, exp_info)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -815,7 +815,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
 
             self.pafw_policies.append((header, ruleset, filter_options))
 
-    def _SortAddressBookNumCheck(self, item: str) -> Tuple[str, int]:
+    def _SortAddressBookNumCheck(self, item: str) -> tuple[str, int]:
         """Used to give a natural order to the list of acl entries.
 
         Args:
@@ -848,7 +848,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
             if i[0] == i[1]:
                 port_list.append(str(i[0]))
             else:
-                port_list.append("%s-%s" % (str(i[0]), str(i[1])))
+                port_list.append(f"{str(i[0])}-{str(i[1])}")
         return port_list
 
     def __str__(self) -> str:

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -18,7 +18,7 @@ import collections
 import copy
 import re
 import xml.etree.ElementTree as etree
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Optional, Union
 from xml.dom import minidom
 
 from absl import logging

--- a/aerleon/lib/pcap.py
+++ b/aerleon/lib/pcap.py
@@ -202,7 +202,7 @@ class Term(aclgenerator.Term):
 
         return cond + '\n'
 
-    def _CheckAddressAf(self, addrs: List[Union[IPv4, IPv6]]) -> List[Union[str, IPv4, IPv6]]:
+    def _CheckAddressAf(self, addrs: list[Union[IPv4, IPv6]]) -> list[Union[str, IPv4, IPv6]]:
         """Verify that the requested address-family matches the address's family."""
         if not addrs:
             return ['any']
@@ -216,7 +216,7 @@ class Term(aclgenerator.Term):
         return af_addrs
 
     @staticmethod
-    def JoinConditionals(condition_list: List[str], operator: str) -> str:
+    def JoinConditionals(condition_list: list[str], operator: str) -> str:
         """Join conditionals using the specified operator.
 
         Filters out empty elements and blank strings.
@@ -239,7 +239,7 @@ class Term(aclgenerator.Term):
         return res
 
     def _GenerateAddrStatement(
-        self, addrs: List[Union[str, IPv6, IPv4]], exclude_addrs: List[Union[str, IPv6, IPv4]]
+        self, addrs: list[Union[str, IPv6, IPv4]], exclude_addrs: list[Union[str, IPv6, IPv4]]
     ) -> str:
         addrlist = []
         for d in addrs:
@@ -263,22 +263,22 @@ class Term(aclgenerator.Term):
         else:
             return Term.JoinConditionals(addrlist, 'or')
 
-    def _GenerateProtoStatement(self, protocols: List[str]) -> str:
+    def _GenerateProtoStatement(self, protocols: list[str]) -> str:
         return Term.JoinConditionals([self._PROTO_TABLE[p] for p in protocols], 'or')
 
-    def _GeneratePortStatement(self, ports: List[Tuple[int, int]], direction: str) -> str:
+    def _GeneratePortStatement(self, ports: list[tuple[int, int]], direction: str) -> str:
         conditions = []
         # term.destination_port is a list of tuples containing the start and end
         # ports of the port range.  In the event it is a single port, the start
         # and end ports are the same.
         for port_tuple in ports:
             if port_tuple[0] == port_tuple[1]:
-                conditions.append('%s port %s' % (direction, port_tuple[0]))
+                conditions.append(f'{direction} port {port_tuple[0]}')
             else:
-                conditions.append('%s portrange %s-%s' % (direction, port_tuple[0], port_tuple[1]))
+                conditions.append(f'{direction} portrange {port_tuple[0]}-{port_tuple[1]}')
         return Term.JoinConditionals(conditions, 'or')
 
-    def _GenerateTcpOptions(self, options: List[str]) -> str:
+    def _GenerateTcpOptions(self, options: list[str]) -> str:
         opts = [str(x) for x in options]
         tcp_flags_set = []
         tcp_flags_check = []
@@ -295,13 +295,13 @@ class Term(aclgenerator.Term):
                         tcp_flags_set.append(self._TCP_FLAGS_TABLE.get(next_flag))
 
         if tcp_flags_check:
-            return '(tcp[tcpflags] & (%s) == (%s))' % (
+            return '(tcp[tcpflags] & ({}) == ({}))'.format(
                 '|'.join(tcp_flags_check),
                 '|'.join(tcp_flags_set),
             )
         return ''
 
-    def _GenerateIcmpType(self, icmp_types: List[int], icmp_code: List[int]) -> str:
+    def _GenerateIcmpType(self, icmp_types: list[int], icmp_code: list[int]) -> str:
         rtr_str = ''
         if icmp_types:
             code_strings = ['']
@@ -344,7 +344,7 @@ class PcapFilter(aclgenerator.ACLGenerator):
             del kwargs['invert']
         super().__init__(*args, **kwargs)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/pcap.py
+++ b/aerleon/lib/pcap.py
@@ -29,7 +29,7 @@ Stolen liberally from packetfilter.py.
 """
 
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 from absl import logging
 

--- a/aerleon/lib/plugin.py
+++ b/aerleon/lib/plugin.py
@@ -111,5 +111,5 @@ class BasePlugin:
         raise NotImplementedError
 
     @property
-    def generators(self) -> "dict[str, aclgenerator.ACLGenerator]":
+    def generators(self) -> dict[str, aclgenerator.ACLGenerator]:
         raise NotImplementedError

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -47,7 +47,6 @@ import pathlib
 import sys
 from dataclasses import dataclass
 from importlib import import_module
-from typing import List, Optional, Tuple
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points, version

--- a/aerleon/lib/plugin_supervisor.py
+++ b/aerleon/lib/plugin_supervisor.py
@@ -64,13 +64,13 @@ __all__ = ["PluginSupervisor", "PluginSupervisorConfiguration", "SystemMetadata"
 
 class _PluginSupervisor:
     is_setup: bool
-    plugins: list[Tuple]
+    plugins: list[tuple]
     generators: dict
 
     def __init__(self) -> None:
         self.is_setup = False
 
-    def Start(self, config: Optional[PluginSupervisorConfiguration] = None) -> None:
+    def Start(self, config: PluginSupervisorConfiguration | None = None) -> None:
         setup = _PluginSetup(config)
         self.plugins, self.generators = setup.plugins, setup.generators
         self.is_setup = True
@@ -91,7 +91,7 @@ SYSTEM_METADATA: SystemMetadata = SystemMetadata(engine_version=version("aerleon
 __doc_BUILTIN_PLUGINS__ = (
     """Built-in plugins included with this project. These will always be loaded.""",
 )
-BUILTIN_GENERATORS: list[Tuple] = [
+BUILTIN_GENERATORS: list[tuple] = [
     # fmt: off
     #Target                  Module                              Constructor
     ('juniper',              'aerleon.lib.juniper',              'Juniper'),
@@ -160,9 +160,9 @@ class PluginSupervisorConfiguration:
     """
 
     disable_discovery: bool = False
-    disable_plugin: Optional[list[str]] = None
-    disable_builtin: Optional[list[str]] = None
-    include_path: Optional[list[list[str]]] = None
+    disable_plugin: list[str] | None = None
+    disable_builtin: list[str] | None = None
+    include_path: list[list[str]] | None = None
 
 
 class _PluginSetup:
@@ -179,11 +179,11 @@ class _PluginSetup:
     """
 
     disable_discovery: bool = False
-    disable_plugin: Optional[list[str]] = None
-    disable_builtin: Optional[list[str]] = None
-    include_path: Optional[list[list[str]]] = None
+    disable_plugin: list[str] | None = None
+    disable_builtin: list[str] | None = None
+    include_path: list[list[str]] | None = None
 
-    def __init__(self, config: Optional[PluginSupervisorConfiguration] = None) -> None:
+    def __init__(self, config: PluginSupervisorConfiguration | None = None) -> None:
         """Initialize self.generators, self.plugins."""
 
         self.generators = {}
@@ -288,8 +288,8 @@ class _PluginSetup:
         return loaded_plugins
 
     def _CollectBuiltinGenerators(
-        self, builtin_generators: List[Tuple[str, str, str]]
-    ) -> List[Tuple[str, ACLGenerator]]:
+        self, builtin_generators: list[tuple[str, str, str]]
+    ) -> list[tuple[str, ACLGenerator]]:
         """Import built-in modules by name."""
         loaded_generators = []
         for target, module_name, class_or_func in builtin_generators:

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 DEFINITIONS = None
 DEFAULT_DEFINITIONS = './def'
-ACTIONS = set(('accept', 'count', 'deny', 'reject', 'next', 'reject-with-tcp-rst'))
+ACTIONS = {'accept', 'count', 'deny', 'reject', 'next', 'reject-with-tcp-rst'}
 PROTOS_WITH_PORTS = frozenset(('tcp', 'udp', 'udplite', 'sctp'))
 FLEXIBLE_MATCH_RANGE_ATTRIBUTES = {
     'byte-offset',
@@ -49,7 +49,7 @@ FLEXIBLE_MATCH_RANGE_ATTRIBUTES = {
     'flexible-range-name',
 }
 FLEXIBLE_MATCH_START_OPTIONS = {'layer-3', 'layer-4', 'payload'}
-_LOGGING = set(('true', 'True', 'syslog', 'local', 'disable', 'log-both'))
+_LOGGING = {'true', 'True', 'syslog', 'local', 'disable', 'log-both'}
 _OPTIMIZE = True
 _SHADE_CHECK = False
 _MAX_TTL = 255
@@ -146,8 +146,8 @@ class InvalidNumericProtoValue(Error):
 
 
 def TranslatePorts(
-    ports: List[str], protocols: List[str], term_name: str
-) -> List[Tuple[int, int]]:
+    ports: list[str], protocols: list[str], term_name: str
+) -> list[tuple[int, int]]:
     """Return all ports of all protocols requested.
 
     Args:
@@ -188,7 +188,7 @@ def TranslatePorts(
 class Policy:
     """The policy object contains everything found in a given policy file."""
 
-    def __init__(self, header: Header, terms: Optional[List[Term]]) -> None:
+    def __init__(self, header: Header, terms: list[Term] | None) -> None:
         """Initiator for the Policy object.
 
         Args:
@@ -206,14 +206,14 @@ class Policy:
         self.filename = ''
         self.AddFilter(header, terms)
 
-    def AddFilter(self, header: Header, terms: Optional[List[Term]]) -> None:
+    def AddFilter(self, header: Header, terms: list[Term] | None) -> None:
         """Add another header & filter."""
         self.filters.append((header, terms))
         self._TranslateTerms(terms)
         if _SHADE_CHECK:
             self._DetectShading(terms)
 
-    def _TranslateTerms(self, terms: Optional[List[Term]]) -> None:
+    def _TranslateTerms(self, terms: list[Term] | None) -> None:
         """."""
         if not terms:
             raise NoTermsError('no terms found')
@@ -262,7 +262,7 @@ class Policy:
         return False
 
     @property
-    def headers(self) -> List[Header]:
+    def headers(self) -> list[Header]:
         """Returns the headers from each of the configured filters.
 
         Returns:
@@ -270,7 +270,7 @@ class Policy:
         """
         return [x[0] for x in self.filters]
 
-    def _DetectShading(self, terms: List[Term]) -> None:
+    def _DetectShading(self, terms: list[Term]) -> None:
         """Finds terms which are shaded (impossible to reach).
 
         Iterate through each term, looking at each prior term. If a prior term
@@ -305,7 +305,7 @@ class Policy:
 
     def __str__(self) -> str:
         def tuple_str(tup):
-            return '%s:%s' % (tup[0], tup[1])
+            return f'{tup[0]}:{tup[1]}'
 
         return 'Policy: {%s}' % ', '.join(map(tuple_str, self.filters))
 
@@ -423,7 +423,7 @@ class Term:
     _IPV4_BYTE_SIZE = 1
     _IPV6_BYTE_SIZE = 4
 
-    def __init__(self, obj: Union[VarType, List[VarType]]) -> None:
+    def __init__(self, obj: VarType | list[VarType]) -> None:
         self.name = None
 
         self.action = []
@@ -789,7 +789,7 @@ class Term:
         if self.logging:
             ret_str.append('  logging: %s' % self.logging)
         if self.log_limit:
-            ret_str.append('  log_limit: %s/%s' % (self.log_limit[0], self.log_limit[1]))
+            ret_str.append(f'  log_limit: {self.log_limit[0]}/{self.log_limit[1]}')
         if self.log_name:
             ret_str.append('  log_name: %s' % self.log_name)
         if self.priority:
@@ -815,7 +815,7 @@ class Term:
         if self.vpn:
             vpn_name, pair_policy = self.vpn
             if pair_policy:
-                ret_str.append('  vpn: name = %s, pair_policy = %s' % (vpn_name, pair_policy))
+                ret_str.append(f'  vpn: name = {vpn_name}, pair_policy = {pair_policy}')
             else:
                 ret_str.append('  vpn: name = %s' % vpn_name)
         if self.source_zone:
@@ -988,7 +988,7 @@ class Term:
     def __ne__(self, other: Term) -> bool:
         return not self.__eq__(other)
 
-    def _SortAddressesByFamily(self, addr_type: str) -> List[Union[IPv4, IPv6]]:
+    def _SortAddressesByFamily(self, addr_type: str) -> list[IPv4 | IPv6]:
         """Provide the term address field to sort.
 
         Method will sort v4 and then concatenate sorted v6 addresses. This will
@@ -1009,7 +1009,7 @@ class Term:
         # Concatenate
         return sort_v4 + sort_v6
 
-    def AddressesByteLength(self, address_family: Tuple[int, int] = (4, 6)) -> int:
+    def AddressesByteLength(self, address_family: tuple[int, int] = (4, 6)) -> int:
         """Returns the byte length of all IP addresses in the term.
 
         This is used in the srx generator due to a address size limitation.
@@ -1073,8 +1073,8 @@ class Term:
                 self.address = self.flattened_addr
 
     def GetAddressOfVersion(
-        self, addr_type: str, af: Optional[int] = None
-    ) -> List[Union[IPv4, IPv6]]:
+        self, addr_type: str, af: int | None = None
+    ) -> list[IPv4 | IPv6]:
         """Returns addresses of the appropriate Address Family.
 
         Args:
@@ -1091,7 +1091,7 @@ class Term:
 
         return [x for x in getattr(self, addr_type) if x.version == af]
 
-    def AddObject(self, obj: Union[VarType, List[VarType]]) -> None:
+    def AddObject(self, obj: VarType | list[VarType]) -> None:
         """Add an object of unknown type to this term.
 
         Args:
@@ -1398,7 +1398,7 @@ class Term:
         if self.ttl:
             if not _MIN_TTL <= self.ttl <= _MAX_TTL:
                 raise InvalidTermTTLValue(
-                    'Term %s contains invalid TTL: %s' % (self.name, self.ttl)
+                    f'Term {self.name} contains invalid TTL: {self.ttl}'
                 )
         for proto in self.protocol:
             if proto.isnumeric():
@@ -1453,7 +1453,7 @@ class Term:
         if self.destination_port:
             self.destination_port = self.CollapsePortList(self.destination_port)
 
-    def CollapsePortList(self, ports: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    def CollapsePortList(self, ports: list[tuple[int, int]]) -> list[tuple[int, int]]:
         """Given a list of ports, Collapse to the smallest required.
 
         Args:
@@ -1482,7 +1482,7 @@ class Term:
                 ret_ports.append(port)
         return ret_ports
 
-    def CheckProtocolIsContained(self, superset: List[str], subset: List[str]) -> bool:
+    def CheckProtocolIsContained(self, superset: list[str], subset: list[str]) -> bool:
         """Check if the given list of protocols is wholly contained.
 
         Args:
@@ -1504,8 +1504,8 @@ class Term:
 
     def CheckPortIsContained(
         self,
-        superset: List[Tuple[int, int]],
-        subset: List[Tuple[int, int]],
+        superset: list[tuple[int, int]],
+        subset: list[tuple[int, int]],
     ) -> bool:
         """Check if the given list of ports is wholly contained.
 
@@ -1532,7 +1532,7 @@ class Term:
         return True
 
     def CheckAddressIsContained(
-        self, superset: Optional[List[IPv4.IPv6]], subset: Optional[List[IPv4, IPv6]]
+        self, superset: list[IPv4.IPv6] | None, subset: list[IPv4, IPv6] | None
     ) -> bool:
         """Check if subset is wholey contained by superset.
 
@@ -1664,7 +1664,7 @@ class Header:
         self.apply_groups = []
         self.apply_groups_except = []
 
-    def AddObject(self, obj: Union[Target, VarType]) -> None:
+    def AddObject(self, obj: Target | VarType) -> None:
         """Add and object to the Header.
 
         Args:
@@ -1688,11 +1688,11 @@ class Header:
             raise RuntimeError('Unable to add object from header.')
 
     @property
-    def platforms(self) -> List[str]:
+    def platforms(self) -> list[str]:
         """The platform targets of this particular header."""
         return [x.platform for x in self.target]
 
-    def FilterOptions(self, platform: str) -> List[str]:
+    def FilterOptions(self, platform: str) -> list[str]:
         """Given a platform return the options.
 
         Args:
@@ -1723,7 +1723,7 @@ class Header:
                 if target.options:
                     if platform in ['srx', 'paloalto']:
                         if len(target.options) >= 3:
-                            return '%s>%s' % (target.options[1], target.options[3])
+                            return f'{target.options[1]}>{target.options[3]}'
                         else:
                             return None
                     else:
@@ -1731,7 +1731,7 @@ class Header:
         return None
 
     def __str__(self) -> str:
-        return 'Target[%s], Comments [%s], Apply groups: [%s], except: [%s]' % (
+        return 'Target[{}], Comments [{}], Apply groups: [{}], except: [{}]'.format(
             ', '.join(map(str, self.target)),
             ', '.join(self.comment),
             ', '.join(self.apply_groups),
@@ -1773,7 +1773,7 @@ class Header:
 class Target:
     """The type of acl to be rendered from this policy file."""
 
-    def __init__(self, target: List[str]) -> None:
+    def __init__(self, target: list[str]) -> None:
         self.platform = target[0]
         self.options = target[1:]
 
@@ -1985,7 +1985,7 @@ def t_newline(t: LexToken) -> None:
 
 
 def t_error(t):
-    print("Illegal character '%s' on line %s" % (t.value[0], t.lineno))
+    print(f"Illegal character '{t.value[0]}' on line {t.lineno}")
     t.lexer.skip(1)
 
 
@@ -2660,16 +2660,16 @@ def _ReadFile(filename):
     logging.debug('ReadFile(%s)', filename)
     if os.path.exists(filename):
         try:
-            with open(filename, 'r') as f:
+            with open(filename) as f:
                 data = f.read()
             return data
-        except IOError:
+        except OSError:
             raise FileReadError('Unable to open or read file %s' % filename)
     else:
         raise FileNotFoundError('Unable to open policy file %s' % filename)
 
 
-def _Preprocess(data: str, max_depth: int = 5, base_dir: str = '') -> List[str]:
+def _Preprocess(data: str, max_depth: int = 5, base_dir: str = '') -> list[str]:
     """Search input for include statements and import specified include file.
 
     Search input for include statements and if found, import specified file
@@ -2717,7 +2717,7 @@ def _Preprocess(data: str, max_depth: int = 5, base_dir: str = '') -> List[str]:
     return rval
 
 
-def _SubpathOf(parent: str, subpath: Union[str, pathlib.Path]) -> bool:
+def _SubpathOf(parent: str, subpath: str | pathlib.Path) -> bool:
     return str(pathlib.Path(subpath).resolve()).startswith(str(pathlib.Path(parent).resolve()))
 
 
@@ -2745,7 +2745,7 @@ def ParseFile(filename, definitions=None, optimize=True, base_dir='', shade_chec
 
 def ParsePolicy(
     data: str,
-    definitions: Optional[naming.Naming] = None,
+    definitions: naming.Naming | None = None,
     optimize: bool = True,
     base_dir: str = '',
     shade_check: bool = False,
@@ -2804,8 +2804,8 @@ if __name__ == '__main__':
     ret = 0
     if len(sys.argv) > 1:
         try:
-            ret = ParsePolicy(open(sys.argv[1], 'r').read(), filename=sys.argv[1])
-        except IOError:
+            ret = ParsePolicy(open(sys.argv[1]).read(), filename=sys.argv[1])
+        except OSError:
             print('ERROR: \'%s\' either does not exist or is not readable' % (sys.argv[1]))
             ret = 1
     else:

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -1072,9 +1072,7 @@ class Term:
             if mutate:
                 self.address = self.flattened_addr
 
-    def GetAddressOfVersion(
-        self, addr_type: str, af: int | None = None
-    ) -> list[IPv4 | IPv6]:
+    def GetAddressOfVersion(self, addr_type: str, af: int | None = None) -> list[IPv4 | IPv6]:
         """Returns addresses of the appropriate Address Family.
 
         Args:
@@ -1397,9 +1395,7 @@ class Term:
 
         if self.ttl:
             if not _MIN_TTL <= self.ttl <= _MAX_TTL:
-                raise InvalidTermTTLValue(
-                    f'Term {self.name} contains invalid TTL: {self.ttl}'
-                )
+                raise InvalidTermTTLValue(f'Term {self.name} contains invalid TTL: {self.ttl}')
         for proto in self.protocol:
             if proto.isnumeric():
                 if int(proto) < 0 or 255 < int(proto):

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -22,7 +22,7 @@ import datetime
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 from absl import logging
 from ply import lex, yacc

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -51,9 +51,11 @@ if typing.TYPE_CHECKING:
 
 WordList: TypeAlias = "str | list[str]"
 
+
 class VPNValue(TypedDict):
     name: str
     policy: 'NotRequired[str]'
+
 
 PolicyTerm = TypedDict(
     'PolicyTerm',
@@ -129,8 +131,10 @@ PolicyTerm = TypedDict(
     total=False,
 )
 
+
 class PolicyInclude(TypedDict):
     include: str
+
 
 PolicyFilterHeader = TypedDict(
     'PolicyFilterHeader',
@@ -143,9 +147,11 @@ PolicyFilterHeader = TypedDict(
     total=False,
 )
 
+
 class PolicyFilter(TypedDict):
     header: PolicyFilterHeader
     terms: 'list[PolicyTerm | PolicyInclude]'
+
 
 class PolicyDict(TypedDict):
     filters: 'list[PolicyFilter]'

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -29,15 +29,9 @@ from aerleon.lib.recognizers import (
     TValue,
 )
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Annotated
-else:
-    from typing import Annotated
+from typing import Annotated
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -60,7 +54,9 @@ if typing.TYPE_CHECKING:
 
 WordList: TypeAlias = "str | list[str]"
 
-VPNValue = TypedDict('VPNValue', {"name": str, "policy": "NotRequired[str]"})
+class VPNValue(TypedDict):
+    name: str
+    policy: 'NotRequired[str]'
 
 PolicyTerm = TypedDict(
     'PolicyTerm',
@@ -136,7 +132,8 @@ PolicyTerm = TypedDict(
     total=False,
 )
 
-PolicyInclude = TypedDict('PolicyInclude', {"include": str})
+class PolicyInclude(TypedDict):
+    include: str
 
 PolicyFilterHeader = TypedDict(
     'PolicyFilterHeader',
@@ -149,11 +146,12 @@ PolicyFilterHeader = TypedDict(
     total=False,
 )
 
-PolicyFilter = TypedDict(
-    'PolicyFilter', {"header": PolicyFilterHeader, "terms": "list[PolicyTerm | PolicyInclude]"}
-)
+class PolicyFilter(TypedDict):
+    header: PolicyFilterHeader
+    terms: 'list[PolicyTerm | PolicyInclude]'
 
-PolicyDict = TypedDict('PolicyDict', {"filters": "list[PolicyFilter]"})
+class PolicyDict(TypedDict):
+    filters: 'list[PolicyFilter]'
 
 
 RawTarget = Annotated[
@@ -174,8 +172,8 @@ class RawFilterHeader:
         kvs: A mapping containing any other key/value pairs in the header.
     """
 
-    targets: typing.Dict[str, RawTarget]
-    kvs: typing.Dict[str, typing.Any] = field(default_factory=dict)
+    targets: dict[str, RawTarget]
+    kvs: dict[str, typing.Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -188,7 +186,7 @@ class RawTerm:
     """
 
     name: str
-    kvs: typing.Dict[str, typing.Any] = field(default_factory=dict)
+    kvs: dict[str, typing.Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -4,6 +4,7 @@ import enum
 import sys
 import typing
 from dataclasses import dataclass, field
+from typing import Annotated, TypedDict
 
 from absl import logging
 
@@ -28,10 +29,6 @@ from aerleon.lib.recognizers import (
     TUnion,
     TValue,
 )
-
-from typing import TypedDict
-
-from typing import Annotated
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias

--- a/aerleon/lib/policy_simple.py
+++ b/aerleon/lib/policy_simple.py
@@ -43,7 +43,7 @@ class Field:
                 f = k
                 break
         indent = len(f) + 5
-        return '%s::%s' % (f, self.ValueStr().replace('\n', '\n' + ' ' * indent))
+        return '{}::{}'.format(f, self.ValueStr().replace('\n', '\n' + ' ' * indent))
 
     def __eq__(self, o: Target) -> bool:
         if not isinstance(o, self.__class__):
@@ -76,7 +76,7 @@ class NamingField(Field):
         super().__init__(value)
         self.value = self.ParseString(value)
 
-    def ParseString(self, value: str) -> Set[str]:
+    def ParseString(self, value: str) -> set[str]:
         """Split and validate a string value into individual names."""
         parts = set(value.split())
         for p in parts:
@@ -426,7 +426,7 @@ class Block:
             raise TypeError('%s not subclass of Field.' % field)
         self.fields.append(field)
 
-    def FieldsWithType(self, f_type: Type[Comment]) -> List[Comment]:
+    def FieldsWithType(self, f_type: type[Comment]) -> list[Comment]:
         if not issubclass(f_type, Field):
             raise TypeError('%s not subclass of Field.' % f_type)
         return [x for x in self.fields if isinstance(x, f_type)]
@@ -440,7 +440,7 @@ class Block:
     def Name(self) -> str:
         return ''
 
-    def __eq__(self, o: Union[Header, Term]) -> bool:
+    def __eq__(self, o: Header | Term) -> bool:
         if not isinstance(o, self.__class__):
             return False
         if len(self.fields) != len(o.fields):
@@ -614,7 +614,7 @@ class Include:
     def __str__(self):
         return '#include %s' % self.identifier
 
-    def __eq__(self, o: "Include") -> bool:
+    def __eq__(self, o: Include) -> bool:
         if not isinstance(o, self.__class__):
             return False
         return self.identifier == o.identifier
@@ -626,7 +626,7 @@ class Include:
 class Policy:
     """An ordered list of headers, terms, comments, blank lines and includes."""
 
-    def __init__(self, identifier: Optional[str]) -> None:
+    def __init__(self, identifier: str | None) -> None:
         self.identifier = identifier
         self.members = []
 

--- a/aerleon/lib/policy_simple.py
+++ b/aerleon/lib/policy_simple.py
@@ -24,8 +24,6 @@ inline comments but preservers line-level comments. Fields expected to have
 
 from __future__ import annotations
 
-from typing import List, Optional, Set, Type, Union
-
 from absl import logging
 
 

--- a/aerleon/lib/policyreader.py
+++ b/aerleon/lib/policyreader.py
@@ -96,10 +96,10 @@ class Policy:
         self.defs = naming.Naming(defs_data)
         self.filter = []
         try:
-            self.data = open(filename, 'r').readlines()
-        except IOError as error_info:
+            self.data = open(filename).readlines()
+        except OSError as error_info:
             info = str(filename) + ' cannot be opened'
-            raise FileOpenError('%s\n%s' % (info, error_info))
+            raise FileOpenError(f'{info}\n{error_info}')
 
         indent = 0
         in_header = False

--- a/aerleon/lib/proxmox.py
+++ b/aerleon/lib/proxmox.py
@@ -1,6 +1,6 @@
 import math
-from typing import Dict, List, Optional, Set, Tuple, Type, Union
 from collections.abc import MutableMapping
+from typing import Optional, Union
 
 from aerleon.lib import aclgenerator, policy
 from aerleon.lib.nacaddr import ExcludeAddrs, IPv4, IPv6

--- a/aerleon/lib/proxmox.py
+++ b/aerleon/lib/proxmox.py
@@ -1,5 +1,6 @@
 import math
-from typing import Dict, List, MutableMapping, Optional, Set, Tuple, Type, Union
+from typing import Dict, List, Optional, Set, Tuple, Type, Union
+from collections.abc import MutableMapping
 
 from aerleon.lib import aclgenerator, policy
 from aerleon.lib.nacaddr import ExcludeAddrs, IPv4, IPv6
@@ -48,7 +49,7 @@ class ZoneMismatchError(Error):
 ### helper classes ###
 class ProxmoxConfigDataClass(MutableMapping):
     def __init__(self, *args, **kwargs):
-        self._store: Dict[str, Union[str, List[str]]] = dict()
+        self._store: dict[str, Union[str, list[str]]] = dict()
         self._store.update(*args)
         self._store.update(**kwargs)
         self._store['enable'] = '1'
@@ -125,7 +126,7 @@ class ProxmoxPort:
         else:
             return f"{port[0]}-{port[1]}"
 
-    def __init__(self, port: Union[Tuple[int, int], int]):
+    def __init__(self, port: Union[tuple[int, int], int]):
         self.str_representation = ''
         if isinstance(port, int):
             self.str_representation = self._singlePortFmt(port)
@@ -270,13 +271,13 @@ class Term(aclgenerator.Term):
         self.direction = direction
 
     @staticmethod
-    def has_mixed_af(addresses: List[Union[IPv4, IPv6]]):
+    def has_mixed_af(addresses: list[Union[IPv4, IPv6]]):
         has_v4 = any(map(lambda a: isinstance(a, IPv4), addresses))
         has_v6 = any(map(lambda a: isinstance(a, IPv6), addresses))
         return has_v4 and has_v6
 
     @staticmethod
-    def filter_for_af(af: Union[Type[IPv4], Type[IPv6]], addresses: List[Union[IPv4, IPv6]]):
+    def filter_for_af(af: Union[type[IPv4], type[IPv6]], addresses: list[Union[IPv4, IPv6]]):
         return list(filter(lambda a: isinstance(a, af), addresses))
 
     @staticmethod
@@ -339,16 +340,16 @@ class Term(aclgenerator.Term):
         protocol: Optional[str],
         direction: str,
         action: str,
-        source_addresses: List[Union[IPv4, IPv6]],
-        destination_addresses: List[Union[IPv4, IPv6]],
+        source_addresses: list[Union[IPv4, IPv6]],
+        destination_addresses: list[Union[IPv4, IPv6]],
         icmp_code: Optional[str],
         icmp_type: Optional[str],
         source_interface: str,
-        source_ports: List[Union[Tuple[int, int], int]],
-        destination_ports: List[Union[Tuple[int, int], int]],
-        comment: List[str],
-        logging: List[str],
-        term_options: List[str],
+        source_ports: list[Union[tuple[int, int], int]],
+        destination_ports: list[Union[tuple[int, int], int]],
+        comment: list[str],
+        logging: list[str],
+        term_options: list[str],
     ):
         def to_network_addr(i: Union[IPv6, IPv4]):
             return str(i.with_prefixlen)
@@ -486,7 +487,7 @@ class Proxmox(aclgenerator.ACLGenerator):
         self.proxmox_policies = []
         super().__init__(pol, exp_info)
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """returns the list of DSL + YAML supplementary tokens supported (proxmox-firewall specific)"""
         supported_tokens, supported_sub_tokens = super()._BuildTokens()
         supported_tokens |= {
@@ -546,8 +547,8 @@ class Proxmox(aclgenerator.ACLGenerator):
             )
 
     def __str__(self):
-        target: List[str] = []
-        terms_str: List[str] = []
+        target: list[str] = []
+        terms_str: list[str] = []
         global_policy_config = ''
         for header, zone, direction, filter_config, terms in self.proxmox_policies:
             global_policy_config = filter_config  # only one (merged) config for the whole zone

--- a/aerleon/lib/recognizers.py
+++ b/aerleon/lib/recognizers.py
@@ -23,7 +23,6 @@ import enum
 import re
 import typing
 from dataclasses import dataclass
-from typing import Optional
 
 if typing.TYPE_CHECKING:
     from aerleon.lib.policy_builder import (

--- a/aerleon/lib/recognizers.py
+++ b/aerleon/lib/recognizers.py
@@ -38,12 +38,12 @@ if typing.TYPE_CHECKING:
 @dataclass
 class RecognizerContext:
     policy: RawPolicy
-    filter: Optional[RawFilter] = None
-    header: Optional[RawFilterHeader] = None
-    target: Optional[RawTarget] = None
-    term: Optional[RawTerm] = None
-    keyword: Optional[str] = None
-    value: Optional[str] = None
+    filter: RawFilter | None = None
+    header: RawFilterHeader | None = None
+    target: RawTarget | None = None
+    term: RawTerm | None = None
+    keyword: str | None = None
+    value: str | None = None
 
 
 @dataclass
@@ -56,13 +56,13 @@ class RecognizerKeywordResult:
 class RecognizerValueResult:
     recognized: bool
     securityCritical: bool = False
-    valueKV: Optional[dict] = None
+    valueKV: dict | None = None
 
 
 @dataclass
 class RecognizerOptionResult:
     securityCritical: bool
-    valueKV: Optional[dict] = None
+    valueKV: dict | None = None
 
 
 class TValue(enum.Enum):
@@ -225,7 +225,7 @@ class TUnion(TComposition):
         of: A list of allowed types. The input must match one of these types.
     """
 
-    of: "list[TValue | TComposition]"
+    of: list[TValue | TComposition]
 
     def Recognize(self, value):
         """Match and parse the input value using the list of sub-recognizers given in the 'of'
@@ -257,10 +257,10 @@ class TList(TComposition):
         collapsible: Whether a list with a single item can be given directly.
     """
 
-    of: "TValue | TComposition"
+    of: TValue | TComposition
     collapsible: bool = False
 
-    def Recognize(self, value: str) -> typing.List[str]:
+    def Recognize(self, value: str) -> list[str]:
         """Match and parse the input value using the recognizer given in the 'of' class attribute.
 
         Arguments:
@@ -303,7 +303,7 @@ class TList(TComposition):
         if (
             isinstance(value, str)
             and isinstance(self.of, TUnion)
-            and all((_isSpaceFreeValue(value_type) for value_type in self.of.of))
+            and all(_isSpaceFreeValue(value_type) for value_type in self.of.of)
         ):
             return list(map(self.of.Recognize, value.split()))
 
@@ -344,9 +344,9 @@ class TSection(TComposition):
             any value recognized by the given recognizer.
     """
 
-    of: "list[typing.Tuple[str | TValue | TUnion, TValue | TComposition]]"
+    of: list[tuple[str | TValue | TUnion, TValue | TComposition]]
 
-    def Recognize(self, value: dict) -> typing.Dict[str, typing.List[str]]:
+    def Recognize(self, value: dict) -> dict[str, list[str]]:
         """Match and parse the input value using the list of rules given in the 'of' class attribute.
         See class docstring for more details on how to specify the rules list.
 

--- a/aerleon/lib/sonic.py
+++ b/aerleon/lib/sonic.py
@@ -1,7 +1,5 @@
 """SONiC generator."""
 
-from typing import Dict
-
 from aerleon.lib import openconfig
 
 

--- a/aerleon/lib/sonic.py
+++ b/aerleon/lib/sonic.py
@@ -11,7 +11,7 @@ class Term(openconfig.Term):
     For when SONiC spec differs from OpenConfig
     """
 
-    def _tcp_established(self) -> Dict[str, bool]:
+    def _tcp_established(self) -> dict[str, bool]:
         """Return's openconfig TCP_ESTABLISHED configuration.
 
         Other vendors (eg. SONiC) have slighly different implementations,

--- a/aerleon/lib/srxlo.py
+++ b/aerleon/lib/srxlo.py
@@ -39,8 +39,8 @@ class Term(juniper.Term):
         ]
 
     def NormalizeIcmpTypes(
-        self, icmp_types: List[str], protocols: List[str], af: str
-    ) -> List[int]:
+        self, icmp_types: list[str], protocols: list[str], af: str
+    ) -> list[int]:
         protocols = ['icmpv6' if x == 'icmp6' else x for x in protocols]
         return super().NormalizeIcmpTypes(icmp_types, protocols, af)
 
@@ -52,7 +52,7 @@ class SRXlo(juniper.Juniper):
     SUFFIX = '.jsl'
     _TERM = Term
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:

--- a/aerleon/lib/srxlo.py
+++ b/aerleon/lib/srxlo.py
@@ -21,8 +21,6 @@ uses the same syntax as regular Juniper stateless ACLs, with minor
 differences. This subclass effects those differences.
 """
 
-from typing import Dict, List, Set, Tuple
-
 from aerleon.lib import juniper
 
 

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -108,7 +108,7 @@ class DSMNet:
             return text
 
 
-def ToDottedQuad(net: DSMNet, negate: bool = False, nondsm: bool = False) -> Tuple[str, str]:
+def ToDottedQuad(net: DSMNet, negate: bool = False, nondsm: bool = False) -> tuple[str, str]:
     """Turns a DSMNet object into decimal dotted quad tuple.
 
     Args:
@@ -153,7 +153,7 @@ def _PrefixlenForNonDSM(intmask: int) -> str:
     if dotmask == '255.255.255.255':
         return '32'
 
-    bitmask = '{:032b}'.format(intmask)
+    bitmask = f'{intmask:032b}'
 
     prefixlen = 0
     while bitmask[prefixlen] == '1':
@@ -180,7 +180,7 @@ def _Int32ToDottedQuad(num: int) -> str:
     return '.'.join(octets)
 
 
-def _NacaddrNetToDSMNet(net: Union[IPv4, IPv6]) -> DSMNet:
+def _NacaddrNetToDSMNet(net: IPv4 | IPv6) -> DSMNet:
     """Converts nacaddr.IPv4 or nacaddr.IPv6 object into DSMNet object.
 
     Args:
@@ -211,12 +211,12 @@ def _ToPrettyBinaryFormat(num: int) -> str:
     # like ipaddr make assumption that this is ipv4
     byte_strings = []
     while num > 0 or len(byte_strings) < 4:
-        byte_strings.append('{0:08b}'.format(num & 0xFF))
+        byte_strings.append(f'{num & 0xFF:08b}')
         num >>= 8
     return ' '.join(reversed(byte_strings))
 
 
-def Summarize(nets: List[Union[IPv4, IPv6]]) -> List[DSMNet]:
+def Summarize(nets: list[IPv4 | IPv6]) -> list[DSMNet]:
     """Summarizes networks while allowing for discontinuous subnet mask.
 
     Args:
@@ -239,7 +239,7 @@ def Summarize(nets: List[Union[IPv4, IPv6]]) -> List[DSMNet]:
     return sorted(result)
 
 
-def _SummarizeSameMask(nets: List[DSMNet]) -> List[DSMNet]:
+def _SummarizeSameMask(nets: list[DSMNet]) -> list[DSMNet]:
     """Summarizes networks while allowing for discontinuous subnet mask.
 
     Args:

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import collections
-from typing import List, Tuple, Union
 
 from aerleon.lib import nacaddr
 from aerleon.lib.nacaddr import IPv4, IPv6

--- a/aerleon/lib/windows.py
+++ b/aerleon/lib/windows.py
@@ -17,7 +17,7 @@
 """Generic Windows security policy generator; requires subclassing."""
 
 import string
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 from absl import logging
 

--- a/aerleon/lib/windows.py
+++ b/aerleon/lib/windows.py
@@ -64,7 +64,7 @@ class Term(aclgenerator.Term):
         else:
             self._all_ips = nacaddr.IPv4('0.0.0.0/0')
 
-        self.term_name = '%s_%s' % (self.filter[:1], self.term.name)
+        self.term_name = f'{self.filter[:1]}_{self.term.name}'
 
     def __str__(self) -> str:
         ret_str = []
@@ -140,7 +140,7 @@ class Term(aclgenerator.Term):
         # if a srcport or dstport is specified.  Fail if src or dst ports are
         # specified and of the protocols are not exactly one or both of 'tcp'
         # or 'udp'.
-        if (not set(protocols).issubset(set(['tcp', 'udp']))) and (
+        if (not set(protocols).issubset({'tcp', 'udp'})) and (
             len(src_ports) > 1 or len(dst_ports) > 1
         ):
             raise aclgenerator.UnsupportedFilterError(
@@ -164,7 +164,7 @@ class Term(aclgenerator.Term):
 
         return '\n'.join(str(v) for v in ret_str if v)
 
-    def _HandleIcmpTypes(self, icmp_types: List[str], protocols: List[str]) -> Tuple[None, None]:
+    def _HandleIcmpTypes(self, icmp_types: list[str], protocols: list[str]) -> tuple[None, None]:
         """Perform implementation-specific icmp_type and protocol transforms.
 
         Note that icmp_types or protocols are passed as parameters in case they
@@ -181,8 +181,8 @@ class Term(aclgenerator.Term):
         return None, None
 
     def _HandlePorts(
-        self, src_ports: List[Tuple[int, int]], dst_ports: List[Tuple[int, int]]
-    ) -> Tuple[None, None]:
+        self, src_ports: list[tuple[int, int]], dst_ports: list[tuple[int, int]]
+    ) -> tuple[None, None]:
         """Perform implementation-specific port transforms.
 
         Note that icmp_types or protocols are passed as parameters in case they
@@ -198,7 +198,7 @@ class Term(aclgenerator.Term):
         """
         return None, None
 
-    def _HandlePreRule(self, ret_str: List[str]) -> None:
+    def _HandlePreRule(self, ret_str: list[str]) -> None:
         """Perform any pre-cartesian product transforms on the ret_str array.
 
         Args:
@@ -209,13 +209,13 @@ class Term(aclgenerator.Term):
 
     def _CartesianProduct(
         self,
-        src_addr: List[Union[IPv4, IPv6]],
-        dst_addr: List[Union[IPv4, IPv6]],
-        protocol: List[str],
-        unused_icmp_types: List[str],
-        src_port: List[str],
-        dst_port: List[str],
-        ret_str: List[str],
+        src_addr: list[Union[IPv4, IPv6]],
+        dst_addr: list[Union[IPv4, IPv6]],
+        protocol: list[str],
+        unused_icmp_types: list[str],
+        src_port: list[str],
+        dst_port: list[str],
+        ret_str: list[str],
     ) -> None:
         """Perform any the appropriate cartesian product of the input parameters.
 
@@ -253,7 +253,7 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
 
     _GOOD_AFS = ['inet', 'inet6']
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -350,14 +350,14 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
 
     def __str__(self) -> str:
         target = []
-        pretty_platform = '%s%s' % (self._PLATFORM[0].upper(), self._PLATFORM[1:])
+        pretty_platform = f'{self._PLATFORM[0].upper()}{self._PLATFORM[1:]}'
 
         if self._RENDER_PREFIX:
             target.append(self._RENDER_PREFIX)
 
         for header, _, filter_type, default_action, terms in self.windows_policies:
             # Add comments for this filter
-            target.append(': %s %s Policy' % (pretty_platform, header.FilterName(self._PLATFORM)))
+            target.append(f': {pretty_platform} {header.FilterName(self._PLATFORM)} Policy')
 
             self._HandlePolicyHeader(header, target)
 
@@ -386,8 +386,8 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
         target.append('')
         return '\n'.join(target)
 
-    def _HandlePolicyHeader(self, header: Header, target: List[str]) -> None:
+    def _HandlePolicyHeader(self, header: Header, target: list[str]) -> None:
         pass
 
-    def _HandleTermFooter(self, header: Header, term: Term, target: List[str]) -> None:
+    def _HandleTermFooter(self, header: Header, term: Term, target: list[str]) -> None:
         pass

--- a/aerleon/lib/windows_advfirewall.py
+++ b/aerleon/lib/windows_advfirewall.py
@@ -16,7 +16,7 @@
 """Windows advfirewall policy generator."""
 
 import string
-from typing import List, Tuple, Union
+from typing import Union
 
 from aerleon.lib import windows
 from aerleon.lib.nacaddr import IPv4, IPv6

--- a/aerleon/lib/windows_advfirewall.py
+++ b/aerleon/lib/windows_advfirewall.py
@@ -54,8 +54,8 @@ class Term(windows.Term):
     }
 
     def _HandleIcmpTypes(
-        self, icmp_types: List[str], protocols: List[str]
-    ) -> Tuple[List[str], List[str]]:
+        self, icmp_types: list[str], protocols: list[str]
+    ) -> tuple[list[str], list[str]]:
         # advfirewall actually puts this in the protocol spec, eg.:
         # icmpv4 | icmpv6 | icmpv4:type,code | icmpv6:type,code
         types = ['']
@@ -69,7 +69,7 @@ class Term(windows.Term):
             if types:
                 protocols = []
                 for typ in types:
-                    protocols.append('%s:%s,any' % (icmp_prefix, typ))
+                    protocols.append(f'{icmp_prefix}:{typ},any')
                 types = ['']
 
         # fixup for icmp v4
@@ -80,19 +80,19 @@ class Term(windows.Term):
         return (types, protocols)
 
     def _HandlePorts(
-        self, src_ports: List[Tuple[int, int]], dst_ports: List[Tuple[int, int]]
-    ) -> Tuple[List[str], List[str]]:
+        self, src_ports: list[tuple[int, int]], dst_ports: list[tuple[int, int]]
+    ) -> tuple[list[str], list[str]]:
         return ([self._ComposePortString(src_ports)], [self._ComposePortString(dst_ports)])
 
     def _CartesianProduct(
         self,
-        src_addr: List[Union[IPv4, IPv6]],
-        dst_addr: List[Union[IPv4, IPv6]],
-        protocol: List[str],
-        unused_icmp_types: List[str],
-        src_port: List[str],
-        dst_port: List[str],
-        ret_str: List[str],
+        src_addr: list[Union[IPv4, IPv6]],
+        dst_addr: list[Union[IPv4, IPv6]],
+        protocol: list[str],
+        unused_icmp_types: list[str],
+        src_port: list[str],
+        dst_port: list[str],
+        ret_str: list[str],
     ) -> None:
         # At least advfirewall supports port ranges, unlike windows ipsec,
         # so the src and dst port lists will always be one element long.
@@ -151,7 +151,7 @@ class Term(windows.Term):
             name=self.term_name, atoms=' '.join(atoms)
         )
 
-    def _ComposePortString(self, ports: List[Tuple[int, int]]) -> str:
+    def _ComposePortString(self, ports: list[tuple[int, int]]) -> str:
         """Convert the list of ports tuples into a multiport range string."""
         if not ports:
             return ''

--- a/aerleon/lib/windows_ipsec.py
+++ b/aerleon/lib/windows_ipsec.py
@@ -78,8 +78,8 @@ class Term(windows.Term):
     }
 
     def _HandleIcmpTypes(
-        self, icmp_types: List[str], protocols: List[str]
-    ) -> Tuple[List[str], List[str]]:
+        self, icmp_types: list[str], protocols: list[str]
+    ) -> tuple[list[str], list[str]]:
         if icmp_types:
             raise aclgenerator.UnsupportedFilterError(
                 '\n%s %s %s %s'
@@ -88,24 +88,24 @@ class Term(windows.Term):
         return ([''], protocols)
 
     def _HandlePorts(
-        self, src_ports: List[Tuple[int, int]], dst_ports: List[Tuple[int, int]]
-    ) -> Tuple[List[str], List[str]]:
+        self, src_ports: list[tuple[int, int]], dst_ports: list[tuple[int, int]]
+    ) -> tuple[list[str], list[str]]:
         # ports = Map the ports in a straight list since multiports aren't supported
         return (self._CollapsePortTuples(src_ports), self._CollapsePortTuples(dst_ports))
 
-    def _HandlePreRule(self, ret_str: List[str]) -> None:
+    def _HandlePreRule(self, ret_str: list[str]) -> None:
         ret_str.append(self._ComposeFilterList())
         ret_str.append(self._ComposeFilterAction(self._ACTION_TABLE[self.term.action[0]]))
 
     def _CartesianProduct(
         self,
-        src_addr: List[Union[IPv4, IPv6]],
-        dst_addr: List[Union[IPv4, IPv6]],
-        protocol: List[str],
-        unused_icmp_types: List[str],
-        src_port: List[str],
-        dst_port: List[str],
-        ret_str: List[str],
+        src_addr: list[Union[IPv4, IPv6]],
+        dst_addr: list[Union[IPv4, IPv6]],
+        protocol: list[str],
+        unused_icmp_types: list[str],
+        src_port: list[str],
+        dst_port: list[str],
+        ret_str: list[str],
     ) -> None:
         for saddr in src_addr:
             if saddr.version != 4:
@@ -142,7 +142,7 @@ class Term(windows.Term):
                                 )
                             )
 
-    def _CollapsePortTuples(self, port_tuples: Tuple[int, int]) -> List[Union[str, int]]:
+    def _CollapsePortTuples(self, port_tuples: tuple[int, int]) -> list[Union[str, int]]:
         ports = ['']
         for tpl in port_tuples:
             if tpl:
@@ -217,7 +217,7 @@ class WindowsIPSec(windows.WindowsGenerator):
 
     _GOOD_AFS = ['inet']
 
-    def _BuildTokens(self) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Build supported tokens for platform.
 
         Returns:
@@ -229,9 +229,9 @@ class WindowsIPSec(windows.WindowsGenerator):
         del supported_sub_tokens['icmp_type']
         return supported_tokens, supported_sub_tokens
 
-    def _HandlePolicyHeader(self, header: Header, target: List[str]) -> None:
+    def _HandlePolicyHeader(self, header: Header, target: list[str]) -> None:
         policy_name = header.FilterName(self._PLATFORM) + self._POLICY_SUFFIX
         target.append(Term.CMD_PREFIX + self._POLICY_FORMAT.substitute(name=policy_name) + '\n')
 
-    def _HandleTermFooter(self, header: Header, term: Term, target: List[str]):
+    def _HandleTermFooter(self, header: Header, term: Term, target: list[str]):
         target.append(term.ComposeRule(header.FilterName(self._PLATFORM)) + '\n')

--- a/aerleon/lib/windows_ipsec.py
+++ b/aerleon/lib/windows_ipsec.py
@@ -18,7 +18,7 @@
 
 # pylint: disable=g-importing-member
 from string import Template
-from typing import Dict, List, Set, Tuple, Union
+from typing import Union
 
 from absl import logging
 

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -101,7 +101,7 @@ def ParseFile(filename, base_dir='', definitions=None, optimize=False, shade_che
     Raises:
         PolicyTypeError: The policy file provided is not valid.
     """
-    with open(pathlib.Path(base_dir).joinpath(filename), 'r') as file:
+    with open(pathlib.Path(base_dir).joinpath(filename)) as file:
         try:
             policy_dict = yaml.load(file, Loader=SpanSafeYamlLoader(filename=filename))
         except YAMLError as yaml_error:
@@ -169,7 +169,7 @@ class YAMLPolicyPreprocessor:
     def __call__(
         self, filename: str, policy_dict: Optional[PolicyDict]
     ) -> Optional[
-        Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]
+        dict[str, list[dict[str, Union[dict[str, dict[str, str]], list[dict[str, str]]]]]]
     ]:
         """Process includes and validate the file data as a PolicyDict.
 
@@ -191,7 +191,7 @@ class YAMLPolicyPreprocessor:
     def _preprocess_inner(
         self, depth: int, debug_stack: list, filename: str, policy_dict: Optional[PolicyDict]
     ) -> Optional[
-        Dict[str, List[Dict[str, Union[Dict[str, Dict[str, str]], List[Dict[str, str]]]]]]
+        dict[str, list[dict[str, Union[dict[str, dict[str, str]], list[dict[str, str]]]]]]
     ]:
         # Empty files are ignored with a warning
         if policy_dict is None or not policy_dict:
@@ -430,7 +430,7 @@ class YAMLPolicyPreprocessor:
 
     def _load_include_file(
         self, relative_path: str, stack: list
-    ) -> Tuple[Optional[PolicyDict], Union[str, pathlib.Path]]:
+    ) -> tuple[Optional[PolicyDict], Union[str, pathlib.Path]]:
         """Load, parse, and validate an include file path."""
         if not suffix_is_yaml(relative_path):
             raise ValueError(
@@ -442,7 +442,7 @@ class YAMLPolicyPreprocessor:
                 f"Include file cannot be loaded from outside the base directory. File={include_path} base_directory={self.base_dir}"
             )
 
-        with open(include_path, 'r') as include_file:
+        with open(include_path) as include_file:
             include_data = yaml.load(
                 include_file.read(), Loader=SpanSafeYamlLoader(filename=str(include_path))
             )
@@ -452,7 +452,7 @@ class YAMLPolicyPreprocessor:
 class GenerateAPIPolicyPreprocessor(YAMLPolicyPreprocessor):
     """A YAMLPolicyPreprocessor that sources includes from a dictionary."""
 
-    def __init__(self, includes: Dict[str, PolicyDict]):
+    def __init__(self, includes: dict[str, PolicyDict]):
         """
         Args:
             includes: A read-only mapping from include name to file_dict.
@@ -462,6 +462,6 @@ class GenerateAPIPolicyPreprocessor(YAMLPolicyPreprocessor):
 
     def _load_include_file(
         self, relative_path: str, stack: list
-    ) -> Tuple[Optional[PolicyDict], Union[str, pathlib.Path]]:
+    ) -> tuple[Optional[PolicyDict], Union[str, pathlib.Path]]:
         """Override to load includes from the self.includes dictionary."""
         return self.includes.get(relative_path), relative_path

--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -1,7 +1,7 @@
 """YAML front-end. Loads a Policy model from a .yaml file."""
 
 import pathlib
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 from unittest.mock import MagicMock
 
 import yaml

--- a/aerleon/lib/yaml_loader.py
+++ b/aerleon/lib/yaml_loader.py
@@ -15,7 +15,7 @@ def SpanSafeYamlLoader(*, filename):
 
     class PluginYamlLoader(SafeLoader):
         def construct_mapping(self, node, deep=False):
-            mapping = super(PluginYamlLoader, self).construct_mapping(node, deep=deep)
+            mapping = super().construct_mapping(node, deep=deep)
             # Add 1 so line numbering starts at 1
             # TODO(jb) look at cases where line number does not match up, e.g. filter['__line__']
             mapping['__line__'] = node.start_mark.line + 1

--- a/aerleon/utils/config.py
+++ b/aerleon/utils/config.py
@@ -65,7 +65,7 @@ def load_config(
             config = pathlib.Path(config)
 
         try:
-            with open(config, 'r') as f:
+            with open(config) as f:
                 data = yaml.safe_load(f)
 
                 if not data or not isinstance(data, dict):

--- a/aerleon/utils/iputils.py
+++ b/aerleon/utils/iputils.py
@@ -3,7 +3,8 @@
 """A module of utilities to work with IP addresses in a faster way."""
 
 import ipaddress
-from typing import Iterator, Union
+from typing import Union
+from collections.abc import Iterator
 
 
 def exclude_address(
@@ -41,7 +42,7 @@ def exclude_address(
     if (
         not base_net._version == exclude_net._version
     ):  # pylint disable=protected-access # pytype: disable=attribute-error
-        raise TypeError('%s and %s are not of the same version' % (base_net, exclude_net))
+        raise TypeError(f'{base_net} and {exclude_net} are not of the same version')
 
     if not exclude_net.subnet_of(base_net):  # pytype: disable=attribute-error
         raise ValueError()
@@ -60,19 +61,15 @@ def exclude_address(
     if include_range[0] == exclude_range[0]:
         result_start = address_class(exclude_range[1] + 1)
         result_end = address_class(include_range[1])
-        for address in ipaddress.summarize_address_range(result_start, result_end):
-            yield address
+        yield from ipaddress.summarize_address_range(result_start, result_end)
     elif include_range[1] == exclude_range[1]:
         result_start = address_class(include_range[0])
         result_end = address_class(exclude_range[0] - 1)
-        for address in ipaddress.summarize_address_range(result_start, result_end):
-            yield address
+        yield from ipaddress.summarize_address_range(result_start, result_end)
     else:
         first_section_start = address_class(include_range[0])
         first_section_end = address_class(exclude_range[0] - 1)
         second_section_start = address_class(exclude_range[1] + 1)
         second_section_end = address_class(include_range[1])
-        for address in ipaddress.summarize_address_range(first_section_start, first_section_end):
-            yield address
-        for address in ipaddress.summarize_address_range(second_section_start, second_section_end):
-            yield address
+        yield from ipaddress.summarize_address_range(first_section_start, first_section_end)
+        yield from ipaddress.summarize_address_range(second_section_start, second_section_end)

--- a/aerleon/utils/iputils.py
+++ b/aerleon/utils/iputils.py
@@ -3,8 +3,8 @@
 """A module of utilities to work with IP addresses in a faster way."""
 
 import ipaddress
-from typing import Union
 from collections.abc import Iterator
+from typing import Union
 
 
 def exclude_address(

--- a/aerleon/utils/options.py
+++ b/aerleon/utils/options.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, List, Optional
 from collections.abc import MutableMapping
+from typing import Any, Callable, Optional
 
 
 class AbstractOption(metaclass=ABCMeta):

--- a/aerleon/utils/options.py
+++ b/aerleon/utils/options.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, List, MutableMapping, Optional
+from typing import Any, Callable, List, Optional
+from collections.abc import MutableMapping
 
 
 class AbstractOption(metaclass=ABCMeta):
@@ -85,7 +86,7 @@ class AbstractValueOption(AbstractOption, metaclass=ABCMeta):
 
 
 class ValueOption(AbstractValueOption):
-    def __init__(self, *args, **kwargs: List[str]):
+    def __init__(self, *args, **kwargs: list[str]):
         super().__init__(*args, **kwargs)
         self.key = list(kwargs.keys())[0]
         self.values = kwargs[self.key]
@@ -139,8 +140,8 @@ class OptionError(Exception):
 
 
 def ProcessOptions(
-    options_lambda: Callable[[MutableMapping], List[AbstractOption]],
-    tokens: List[str],
+    options_lambda: Callable[[MutableMapping], list[AbstractOption]],
+    tokens: list[str],
     with_config: Optional[MutableMapping] = None,
 ):
     if with_config is None:

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -213,7 +213,11 @@ class ACLGeneratorTest(absltest.TestCase):
 
         # Include all tags.
         self.assertListEqual(
-            ['{}Id:{}'.format('$', '$'), '{}Date:{}'.format('$', '$'), '{}Revision:{}'.format('$', '$')],
+            [
+                '{}Id:{}'.format('$', '$'),
+                '{}Date:{}'.format('$', '$'),
+                '{}Revision:{}'.format('$', '$'),
+            ],
             aclgenerator.AddRepositoryTags(),
         )
         # Remove the revision tag.
@@ -223,7 +227,8 @@ class ACLGeneratorTest(absltest.TestCase):
         )
         # Only include the Id: tag.
         self.assertListEqual(
-            ['{}Id:{}'.format('$', '$')], aclgenerator.AddRepositoryTags(date=False, revision=False)
+            ['{}Id:{}'.format('$', '$')],
+            aclgenerator.AddRepositoryTags(date=False, revision=False),
         )
         # Wrap the Date: tag.
         self.assertListEqual(

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -213,21 +213,21 @@ class ACLGeneratorTest(absltest.TestCase):
 
         # Include all tags.
         self.assertListEqual(
-            ['%sId:%s' % ('$', '$'), '%sDate:%s' % ('$', '$'), '%sRevision:%s' % ('$', '$')],
+            ['{}Id:{}'.format('$', '$'), '{}Date:{}'.format('$', '$'), '{}Revision:{}'.format('$', '$')],
             aclgenerator.AddRepositoryTags(),
         )
         # Remove the revision tag.
         self.assertListEqual(
-            ['%sId:%s' % ('$', '$'), '%sDate:%s' % ('$', '$')],
+            ['{}Id:{}'.format('$', '$'), '{}Date:{}'.format('$', '$')],
             aclgenerator.AddRepositoryTags(revision=False),
         )
         # Only include the Id: tag.
         self.assertListEqual(
-            ['%sId:%s' % ('$', '$')], aclgenerator.AddRepositoryTags(date=False, revision=False)
+            ['{}Id:{}'.format('$', '$')], aclgenerator.AddRepositoryTags(date=False, revision=False)
         )
         # Wrap the Date: tag.
         self.assertListEqual(
-            ['"%sDate:%s"' % ('$', '$')],
+            ['"{}Date:{}"'.format('$', '$')],
             aclgenerator.AddRepositoryTags(revision=False, rid=False, wrap=True),
         )
 

--- a/tests/lib/nacaddr_test.py
+++ b/tests/lib/nacaddr_test.py
@@ -29,21 +29,21 @@ class NacaddrUnitTest(absltest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.addr1 = nacaddr.IPv4(u'10.0.0.0/8', 'The 10 block')
+        self.addr1 = nacaddr.IPv4('10.0.0.0/8', 'The 10 block')
         self.addr2 = nacaddr.IPv6(
             'DEAD:BEEF:BABE:FACE:DEAF:FEED:C0DE:F001/64', 'An IPv6 Address', strict=False
         )
 
     def testCollapsing(self):
-        ip1 = nacaddr.IPv4(u'1.1.0.0/24', 'foo')
-        ip2 = nacaddr.IPv4(u'1.1.1.0/24', 'foo')
-        ip3 = nacaddr.IPv4(u'1.1.2.0/24', 'baz')
-        ip4 = nacaddr.IPv4(u'1.1.3.0/24')
-        ip5 = nacaddr.IPv4(u'1.1.4.0/24')
+        ip1 = nacaddr.IPv4('1.1.0.0/24', 'foo')
+        ip2 = nacaddr.IPv4('1.1.1.0/24', 'foo')
+        ip3 = nacaddr.IPv4('1.1.2.0/24', 'baz')
+        ip4 = nacaddr.IPv4('1.1.3.0/24')
+        ip5 = nacaddr.IPv4('1.1.4.0/24')
 
         # stored in no particular order b/c we want CollapseAddr to call [].sort
         # and we want that sort to call nacaddr.IP.__cmp__() on our array members
-        ip6 = nacaddr.IPv4(u'1.1.0.0/22')
+        ip6 = nacaddr.IPv4('1.1.0.0/22')
 
         # check that addreses are subsumed properlly.
         collapsed = nacaddr.CollapseAddrList([ip1, ip2, ip3, ip4, ip5, ip6])
@@ -51,19 +51,19 @@ class NacaddrUnitTest(absltest.TestCase):
         # test that the comments are collapsed properlly, and that comments aren't
         # added to addresses that have no comments.
         self.assertListEqual([collapsed[0].text, collapsed[1].text], ['foo, baz', ''])
-        self.assertListEqual(collapsed, [nacaddr.IPv4(u'1.1.0.0/22'), nacaddr.IPv4(u'1.1.4.0/24')])
+        self.assertListEqual(collapsed, [nacaddr.IPv4('1.1.0.0/22'), nacaddr.IPv4('1.1.4.0/24')])
 
         # test that two addresses are supernet'ed properlly
         collapsed = nacaddr.CollapseAddrList([ip1, ip2])
         self.assertEqual(len(collapsed), 1)
         self.assertEqual(collapsed[0].text, 'foo')
-        self.assertListEqual(collapsed, [nacaddr.IPv4(u'1.1.0.0/23')])
+        self.assertListEqual(collapsed, [nacaddr.IPv4('1.1.0.0/23')])
 
-        ip_same1 = ip_same2 = nacaddr.IPv4(u'1.1.1.1/32')
+        ip_same1 = ip_same2 = nacaddr.IPv4('1.1.1.1/32')
         self.assertListEqual(nacaddr.CollapseAddrList([ip_same1, ip_same2]), [ip_same1])
-        ip1 = nacaddr.IPv6(u'::2001:1/100', strict=False)
-        ip2 = nacaddr.IPv6(u'::2002:1/120', strict=False)
-        ip3 = nacaddr.IPv6(u'::2001:1/96', strict=False)
+        ip1 = nacaddr.IPv6('::2001:1/100', strict=False)
+        ip2 = nacaddr.IPv6('::2002:1/120', strict=False)
+        ip3 = nacaddr.IPv6('::2001:1/96', strict=False)
         # test that ipv6 addresses are subsumed properlly.
         collapsed = nacaddr.CollapseAddrList([ip1, ip2, ip3])
         self.assertListEqual(collapsed, [ip3])

--- a/tests/lib/policy_simple_test.py
+++ b/tests/lib/policy_simple_test.py
@@ -95,7 +95,7 @@ class FieldTest(absltest.TestCase):
         f = policy_simple.NamingField('RFC1918 CORP_INTERNAL RFC1918')
         f.Append('RFC1918')
         f.Append('CORP_INTERNAL RFC1918')
-        self.assertEqual(set(['RFC1918', 'CORP_INTERNAL']), f.value)
+        self.assertEqual({'RFC1918', 'CORP_INTERNAL'}, f.value)
 
     def testNamingFieldStr(self):
         f = policy_simple.NamingField(' '.join(str(x) for x in range(25)))

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -877,18 +877,18 @@ class PolicyTest(parameterized.TestCase):
     def testGoodAddrExcludesFlatten(self):
         expected = sorted(
             [
-                nacaddr.IPv4(u'10.0.0.0/11'),
-                nacaddr.IPv4(u'10.32.0.0/12'),
-                nacaddr.IPv4(u'10.48.0.0/13'),
-                nacaddr.IPv4(u'10.56.0.0/14'),
-                nacaddr.IPv4(u'10.60.0.0/15'),
-                nacaddr.IPv4(u'10.64.0.0/10'),
-                nacaddr.IPv4(u'10.130.0.0/15'),
-                nacaddr.IPv4(u'10.132.0.0/14'),
-                nacaddr.IPv4(u'10.136.0.0/13'),
-                nacaddr.IPv4(u'10.144.0.0/12'),
-                nacaddr.IPv4(u'10.160.0.0/11'),
-                nacaddr.IPv4(u'10.192.0.0/10'),
+                nacaddr.IPv4('10.0.0.0/11'),
+                nacaddr.IPv4('10.32.0.0/12'),
+                nacaddr.IPv4('10.48.0.0/13'),
+                nacaddr.IPv4('10.56.0.0/14'),
+                nacaddr.IPv4('10.60.0.0/15'),
+                nacaddr.IPv4('10.64.0.0/10'),
+                nacaddr.IPv4('10.130.0.0/15'),
+                nacaddr.IPv4('10.132.0.0/14'),
+                nacaddr.IPv4('10.136.0.0/13'),
+                nacaddr.IPv4('10.144.0.0/12'),
+                nacaddr.IPv4('10.160.0.0/11'),
+                nacaddr.IPv4('10.192.0.0/10'),
             ]
         )
         pol = HEADER + GOOD_TERM_27
@@ -1349,7 +1349,7 @@ class PolicyTest(parameterized.TestCase):
     def testLogLimit(self):
         pol = policy.ParsePolicy(HEADER_4 + GOOD_TERM_44, self.naming)
         term = pol.filters[0][1][0]
-        self.assertEqual((u'999', u'day'), term.log_limit)
+        self.assertEqual(('999', 'day'), term.log_limit)
 
     def testGREandTCPUDPError(self):
         pol = HEADER + BAD_TERM_16

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -499,8 +499,8 @@ class CiscoTest(absltest.TestCase):
         )
         self.assertIn('access-list 50 remark numbered standard', str(acl), str(acl))
         self.assertIn('access-list 50 remark standard-term-1', str(acl), str(acl))
-        self.assertIn('access-list 50 remark %sId:%s' % ('$', '$'), str(acl), str(acl))
-        self.assertNotIn('access-list 50 remark %sRevision:%s' % ('$', '$'), str(acl), str(acl))
+        self.assertIn('access-list 50 remark {}Id:{}'.format('$', '$'), str(acl), str(acl))
+        self.assertNotIn('access-list 50 remark {}Revision:{}'.format('$', '$'), str(acl), str(acl))
         print(acl)
 
     @capture.stdout
@@ -608,9 +608,9 @@ class CiscoTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_OBJGRP_HEADER + GOOD_TERM_2 + GOOD_TERM_18, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
 
-        self.assertIn('\n'.join(ip_grp), str(acl), '%s %s' % ('\n'.join(ip_grp), str(acl)))
-        self.assertIn('\n'.join(port_grp1), str(acl), '%s %s' % ('\n'.join(port_grp1), str(acl)))
-        self.assertIn('\n'.join(port_grp2), str(acl), '%s %s' % ('\n'.join(port_grp2), str(acl)))
+        self.assertIn('\n'.join(ip_grp), str(acl), '{} {}'.format('\n'.join(ip_grp), str(acl)))
+        self.assertIn('\n'.join(port_grp1), str(acl), '{} {}'.format('\n'.join(port_grp1), str(acl)))
+        self.assertIn('\n'.join(port_grp2), str(acl), '{} {}'.format('\n'.join(port_grp2), str(acl)))
 
         # Object-group terms should use the object groups created.
         self.assertIn(

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -500,7 +500,9 @@ class CiscoTest(absltest.TestCase):
         self.assertIn('access-list 50 remark numbered standard', str(acl), str(acl))
         self.assertIn('access-list 50 remark standard-term-1', str(acl), str(acl))
         self.assertIn('access-list 50 remark {}Id:{}'.format('$', '$'), str(acl), str(acl))
-        self.assertNotIn('access-list 50 remark {}Revision:{}'.format('$', '$'), str(acl), str(acl))
+        self.assertNotIn(
+            'access-list 50 remark {}Revision:{}'.format('$', '$'), str(acl), str(acl)
+        )
         print(acl)
 
     @capture.stdout
@@ -609,8 +611,12 @@ class CiscoTest(absltest.TestCase):
         acl = cisco.Cisco(pol, EXP_INFO)
 
         self.assertIn('\n'.join(ip_grp), str(acl), '{} {}'.format('\n'.join(ip_grp), str(acl)))
-        self.assertIn('\n'.join(port_grp1), str(acl), '{} {}'.format('\n'.join(port_grp1), str(acl)))
-        self.assertIn('\n'.join(port_grp2), str(acl), '{} {}'.format('\n'.join(port_grp2), str(acl)))
+        self.assertIn(
+            '\n'.join(port_grp1), str(acl), '{} {}'.format('\n'.join(port_grp1), str(acl))
+        )
+        self.assertIn(
+            '\n'.join(port_grp2), str(acl), '{} {}'.format('\n'.join(port_grp2), str(acl))
+        )
 
         # Object-group terms should use the object groups created.
         self.assertIn(

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -221,8 +221,8 @@ class CiscoNXTest(absltest.TestCase):
         self.assertIn(expected, str(acl), str(acl))
         expected = 'test-filter remark'
         self.assertNotIn(expected, str(acl), str(acl))
-        self.assertNotIn(' remark %sId:%s' % ('$', '$'), str(acl), str(acl))
-        self.assertIn(' remark "%sRevision:%s"' % ('$', '$'), str(acl), str(acl))
+        self.assertNotIn(' remark {}Id:{}'.format('$', '$'), str(acl), str(acl))
+        self.assertIn(' remark "{}Revision:{}"'.format('$', '$'), str(acl), str(acl))
         self.assertNotIn(' remark $', str(acl), str(acl))
 
         print(acl)

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -168,11 +168,11 @@ term good-term-5 {
 """
 
 GOOD_TERM_6 = """
-term good-term-6 {
+term good-term-6 {{
   comment:: "Some text describing what this block does,
              possibly including newines, blank lines,
              and extra-long comments (over 255 characters)
-             %(long_line)s
+             {long_line}
 
              All these cause problems if passed verbatim to iptables.
              "
@@ -180,10 +180,10 @@ term good-term-6 {
   protocol:: tcp
   action:: accept
 
-}
-""" % {
-    'long_line': '-' * 260
-}
+}}
+""".format(
+    long_line='-' * 260
+)
 
 
 GOOD_TERM_7 = """
@@ -1044,7 +1044,7 @@ class AclCheckTest(absltest.TestCase):
         acl = iptables.Iptables(pol, EXP_INFO)
         result = str(acl)
         self.assertIn(
-            '%s %s' % ('--tcp-flags ACK,FIN,RST,SYN RST', '--dport 1024:65535 -j ACCEPT'),
+            '{} {}'.format('--tcp-flags ACK,FIN,RST,SYN RST', '--dport 1024:65535 -j ACCEPT'),
             result,
             'No rule matching packets with RST bit only.\n' + result,
         )
@@ -1599,16 +1599,16 @@ YAML_GOOD_TERM_6 = """
         Some text describing what this block does,
         possibly including newines, blank lines,
         and extra-long comments (over 255 characters)
-        %(long_line)s
+        {long_line}
 
         All these cause problems if passed verbatim to iptables.
                
     protocol: tcp
     action: accept
 
-""" % {
-    'long_line': '-' * 260
-}
+""".format(
+    long_line='-' * 260
+)
 
 
 YAML_GOOD_TERM_7 = """

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -1502,9 +1502,9 @@ class JuniperTest(parameterized.TestCase):
         )
         output = str(jcl)
         for result in expected:
-            self.assertIn(result, output, 'expected "%s" in %s' % (result, output))
+            self.assertIn(result, output, f'expected "{result}" in {output}')
         for result in unexpected:
-            self.assertNotIn(result, output, 'unexpected "%s" in %s' % (result, output))
+            self.assertNotIn(result, output, f'unexpected "{result}" in {output}')
 
         print(output)
 

--- a/tests/regression/junipermsmpc/junipermsmpc_test.py
+++ b/tests/regression/junipermsmpc/junipermsmpc_test.py
@@ -960,9 +960,9 @@ class JuniperMSMPCTest(parameterized.TestCase):
         )
         output = str(msmpc)
         for result in expected:
-            self.assertIn(result, output, 'expected "%s" in %s' % (result, output))
+            self.assertIn(result, output, f'expected "{result}" in {output}')
         for result in unexpected:
-            self.assertNotIn(result, output, 'unexpected "%s" in %s' % (result, output))
+            self.assertNotIn(result, output, f'unexpected "{result}" in {output}')
 
         print(output)
 

--- a/tests/regression/windows_advfirewall/windows_advfirewall_test.py
+++ b/tests/regression/windows_advfirewall/windows_advfirewall_test.py
@@ -268,7 +268,7 @@ class WindowsAdvFirewallTest(absltest.TestCase):
             super().assertIn(
                 fullstring,
                 result,
-                'did not find "%s" for %s\nGot:\n%s' % (fullstring, term, result),
+                f'did not find "{fullstring}" for {term}\nGot:\n{result}',
             )
 
     @capture.stdout

--- a/tests/regression/windows_ipsec/windows_ipsec_test.py
+++ b/tests/regression/windows_ipsec/windows_ipsec_test.py
@@ -124,7 +124,7 @@ class WindowsIPSecTest(absltest.TestCase):
     def assertTrue(self, strings, result, term):
         for string in strings:
             fullstring = 'netsh ipsec static add %s' % (string)
-            super().assertIn(fullstring, result, 'did not find "%s" for %s' % (fullstring, term))
+            super().assertIn(fullstring, result, f'did not find "{fullstring}" for {term}')
 
     @capture.stdout
     def testPolicy(self):

--- a/tests/regression/yaml/yaml_regression_test.py
+++ b/tests/regression/yaml/yaml_regression_test.py
@@ -617,18 +617,18 @@ class YAMLPolicyTermTest(absltest.TestCase):
 
         expected = sorted(
             [
-                nacaddr.IPv4(u'10.0.0.0/11'),
-                nacaddr.IPv4(u'10.32.0.0/12'),
-                nacaddr.IPv4(u'10.48.0.0/13'),
-                nacaddr.IPv4(u'10.56.0.0/14'),
-                nacaddr.IPv4(u'10.60.0.0/15'),
-                nacaddr.IPv4(u'10.64.0.0/10'),
-                nacaddr.IPv4(u'10.130.0.0/15'),
-                nacaddr.IPv4(u'10.132.0.0/14'),
-                nacaddr.IPv4(u'10.136.0.0/13'),
-                nacaddr.IPv4(u'10.144.0.0/12'),
-                nacaddr.IPv4(u'10.160.0.0/11'),
-                nacaddr.IPv4(u'10.192.0.0/10'),
+                nacaddr.IPv4('10.0.0.0/11'),
+                nacaddr.IPv4('10.32.0.0/12'),
+                nacaddr.IPv4('10.48.0.0/13'),
+                nacaddr.IPv4('10.56.0.0/14'),
+                nacaddr.IPv4('10.60.0.0/15'),
+                nacaddr.IPv4('10.64.0.0/10'),
+                nacaddr.IPv4('10.130.0.0/15'),
+                nacaddr.IPv4('10.132.0.0/14'),
+                nacaddr.IPv4('10.136.0.0/13'),
+                nacaddr.IPv4('10.144.0.0/12'),
+                nacaddr.IPv4('10.160.0.0/11'),
+                nacaddr.IPv4('10.192.0.0/10'),
             ]
         )
         self.assertEqual(sorted(terms[0].address), expected)
@@ -1338,7 +1338,7 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
         print(pol)
         term = pol.filters[0][1][0]
-        self.assertEqual((u'999', u'day'), term.log_limit)
+        self.assertEqual(('999', 'day'), term.log_limit)
 
     @capture.stdout
     def testTargetServiceAccount(self, mock_open, _mock_warn):

--- a/tests/regression_utils/capture.py
+++ b/tests/regression_utils/capture.py
@@ -127,19 +127,19 @@ def files(filenames):
                 file_base = ".".join([func.__qualname__, filename])
                 file_ref = ".".join([file_base, "ref"])
                 try:
-                    with open(os.path.join(_testdir(func), file_ref), "r") as ref_file:
+                    with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                         self.assertEqual(
                             ref_file.read(),
                             _collapse_mock_writes(inner_mocks, filename),
                         )
-                except IOError:
+                except OSError:
                     try:
                         with open(
                             os.path.join(_testdir(func), ".".join([file_base, "actual"])),
                             "w",
                         ) as actual:
                             actual.write(_collapse_mock_writes(inner_mocks, filename))
-                    except IOError:
+                    except OSError:
                         # In this case the actual content was not written, but this is not critical.
                         # The user does not need to be warned here.
                         pass
@@ -156,7 +156,7 @@ def files(filenames):
                             "w",
                         ) as actual:
                             actual.write(_collapse_mock_writes(inner_mocks, filename))
-                    except IOError:
+                    except OSError:
                         # In this case the actual content was not written, but this is not critical.
                         # The user does not need to be warned here.
                         pass
@@ -180,16 +180,16 @@ def stdout(func):
             file_base = ".".join([base_name, "stdout"])
             file_ref = ".".join([file_base, "ref"])
             try:
-                with open(os.path.join(_testdir(func), file_ref), "r") as ref_file:
+                with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                     self.assertEqual(ref_file.read(), mock_stdout.getvalue())
-            except IOError:
+            except OSError:
                 try:
                     with open(
                         os.path.join(_testdir(func), ".".join([file_base, "actual"])),
                         "w",
                     ) as actual:
                         actual.write(mock_stdout.getvalue())
-                except IOError:
+                except OSError:
                     # In this case the actual content was not written, but this is not critical.
                     # The user does not need to be warned here.
                     pass
@@ -206,7 +206,7 @@ def stdout(func):
                         "w",
                     ) as actual:
                         actual.write(mock_stdout.getvalue())
-                except IOError:
+                except OSError:
                     # In this case the actual content was not written, but this is not critical.
                     # The user does not need to be warned here.
                     pass
@@ -225,16 +225,16 @@ def stderr(func):
             file_base = ".".join([func.__qualname__, "stderr"])
             file_ref = ".".join([file_base, "ref"])
             try:
-                with open(os.path.join(_testdir(func), file_ref), "r") as ref_file:
+                with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                     self.assertEqual(ref_file.read(), mock_stderr.getvalue())
-            except IOError:
+            except OSError:
                 try:
                     with open(
                         os.path.join(_testdir(func), ".".join([file_base, "actual"])),
                         "w",
                     ) as actual:
                         actual.write(mock_stderr.getvalue())
-                except IOError:
+                except OSError:
                     # In this case the actual content was not written, but this is not critical.
                     # The user does not need to be warned here.
                     pass
@@ -251,7 +251,7 @@ def stderr(func):
                         "w",
                     ) as actual:
                         actual.write(mock_stderr.getvalue())
-                except IOError:
+                except OSError:
                     # In this case the actual content was not written, but this is not critical.
                     # The user does not need to be warned here.
                     pass

--- a/tests/utils/iputils_test.py
+++ b/tests/utils/iputils_test.py
@@ -9,7 +9,7 @@ from aerleon.utils import iputils
 
 file_directory = pathlib.Path(__file__).parent.absolute()
 exclude_address_testcases = []
-with open(str(file_directory) + "/address_exclude_test_cases.txt", 'r') as f:
+with open(str(file_directory) + "/address_exclude_test_cases.txt") as f:
     for line in f:
         ipstr, exstrs, restrs = line.strip().split(' ')
         ip = nacaddr.IP(ipstr)

--- a/tools/cgrep.py
+++ b/tools/cgrep.py
@@ -39,7 +39,6 @@ Examples:
   $ cgrep.py -p 22 tcp
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import logging
@@ -326,13 +325,13 @@ def print_diff(ip, common, diff1, diff2):
     """
     logging.info('IP: %s', ip)
     if common:
-        common = ['  {0}'.format(elem) for elem in common]
+        common = [f'  {elem}' for elem in common]
         logging.info('\n'.join(common))
     if diff1:
-        diff = ['+ {0}'.format(elem) for elem in diff1]
+        diff = [f'+ {elem}' for elem in diff1]
         logging.info('\n'.join(diff))
     if diff2:
-        diff = ['- {0}'.format(elem) for elem in diff2]
+        diff = [f'- {elem}' for elem in diff2]
         logging.info('\n'.join(diff))
 
 
@@ -377,7 +376,7 @@ def get_ip_parents(ip, db):
         prefix_and_nets = get_nets_and_highest_prefix(ip, v, db)
         if nested:
             for n in nested:
-                results.append(('%s -> %s' % (n, v), prefix_and_nets))
+                results.append((f'{n} -> {v}', prefix_and_nets))
         else:
             results.append((v, prefix_and_nets))
     # sort the results by prefix length descending
@@ -475,9 +474,9 @@ def compare_ip_token(options, db):
     for ip in options.ip:
         rval = db.GetIpParents(ip)
         if token in rval:
-            results = '%s is in %s' % (ip, token)
+            results = f'{ip} is in {token}'
         else:
-            results = '%s is _not_ in %s' % (ip, token)
+            results = f'{ip} is _not_ in {token}'
     return results
 
 

--- a/tools/iputilstools.py
+++ b/tools/iputilstools.py
@@ -36,4 +36,4 @@ def write_excludes_testcase(ipstr, excludelist='', max_prefix_range=8, max_rando
     exst = ",".join(map(str, excludelist))
     rest = ";".join(",".join(map(str, sorted(result))) for result in result_list)
     with open('tests/utils/address_exclude_test_cases.txt', 'a') as f:
-        f.write("%s %s %s\n" % (ipst, exst, rest))
+        f.write(f"{ipst} {exst} {rest}\n")


### PR DESCRIPTION
[`pyupgrade`](https://github.com/asottile/pyupgrade) is a tool that can automatically upgrade Python syntax for newer versions of Python.  This PR runs `pyupgrade --py39-plus` to upgrade files to Python 3.9 syntax.  It mostly made changes for pep 585 typing rewrites and rewriting strings to use f-strings printf-style strings.