### PR TITLE
f-string reformats using flynt

### DIFF
--- a/aerleon/__main__.py
+++ b/aerleon/__main__.py
@@ -7,5 +7,5 @@ try:
     aclgen.EntryPoint()
     rc = 0
 except Exception as e:
-    print('Error: %s' % e, file=sys.stderr)
+    print(f'Error: {e}', file=sys.stderr)
 sys.exit(rc)

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -56,7 +56,7 @@ def SetupFlags():
     flags.DEFINE_boolean(
         'optimize',
         None,
-        'Turn on optimization.\nDefault: \'%s\'' % config.defaults['optimize'],
+        f"Turn on optimization.\nDefault: '{config.defaults['optimize']}'",
         short_name='o',
     )
     flags.DEFINE_boolean(
@@ -68,7 +68,7 @@ def SetupFlags():
     flags.DEFINE_boolean(
         'debug',
         None,
-        'Display detailed messages.\nDefault: \'%s\'' % str(config.defaults['debug']).lower(),
+        f"Display detailed messages.\nDefault: '{str(config.defaults['debug']).lower()}'",
     )
     flags.DEFINE_boolean('verbose', None, 'UNUSED. Use --debug instead.')
     flags.DEFINE_list(
@@ -344,7 +344,7 @@ def DescendDirectory(input_dirname: str, ignore_directories: list[str]) -> list[
     for ignored_directory in ignore_directories:
 
         def Filtering(path, ignored=ignored_directory):
-            return not path.match('%s/**/pol' % ignored) and not path.match('%s/pol' % ignored)
+            return not path.match(f'{ignored}/**/pol') and not path.match(f'{ignored}/pol')
 
         policy_directories = filter(Filtering, policy_directories)
 
@@ -358,7 +358,7 @@ def DescendDirectory(input_dirname: str, ignore_directories: list[str]) -> list[
         )
         depth = len(directory.parents) - 1
         logging.warning(
-            '-' * (2 * depth) + '> %s (%d pol files found)' % (directory, len(directory_policies))
+            '-' * (2 * depth) + f'> {directory} ({len(directory_policies)} pol files found)'
         )
         policy_files.extend(filter(lambda path: path.is_file(), directory_policies))
 
@@ -430,7 +430,7 @@ def Run(
     try:
         definitions = naming.Naming(definitions_directory)
     except naming.NoDefinitionsError:
-        err_msg = 'bad definitions directory: %s' % definitions_directory
+        err_msg = f'bad definitions directory: {definitions_directory}'
         logging.fatal(err_msg)
         return  # static type analyzer can't detect that logging.fatal exits program
 

--- a/aerleon/aclgen.py
+++ b/aerleon/aclgen.py
@@ -242,7 +242,7 @@ def RenderFile(
                 acl_obj = generator(copy.deepcopy(pol), exp_info)
                 RenderACL(
                     str(acl_obj),
-                    '-accept' + acl_obj.SUFFIX,
+                    f"-accept{acl_obj.SUFFIX}",
                     output_directory,
                     input_file,
                     write_files,
@@ -250,7 +250,7 @@ def RenderFile(
                 acl_obj = generator(copy.deepcopy(pol), exp_info, invert=True)
                 RenderACL(
                     str(acl_obj),
-                    '-deny' + acl_obj.SUFFIX,
+                    f"-deny{acl_obj.SUFFIX}",
                     output_directory,
                     input_file,
                     write_files,
@@ -358,7 +358,7 @@ def DescendDirectory(input_dirname: str, ignore_directories: list[str]) -> list[
         )
         depth = len(directory.parents) - 1
         logging.warning(
-            '-' * (2 * depth) + f'> {directory} ({len(directory_policies)} pol files found)'
+            f"{'-' * (2 * depth)}> {directory} ({len(directory_policies)} pol files found)"
         )
         policy_files.extend(filter(lambda path: path.is_file(), directory_policies))
 

--- a/aerleon/api.py
+++ b/aerleon/api.py
@@ -451,13 +451,13 @@ def _GenerateACL(
                 acl_obj = generator(copy.deepcopy(policy_obj), exp_info)
                 EmitACL(
                     str(acl_obj),
-                    '-accept' + acl_obj.SUFFIX,
+                    f"-accept{acl_obj.SUFFIX}",
                     write_files,
                 )
                 acl_obj = generator(copy.deepcopy(policy_obj), exp_info, invert=True)
                 EmitACL(
                     str(acl_obj),
-                    '-deny' + acl_obj.SUFFIX,
+                    f"-deny{acl_obj.SUFFIX}",
                     write_files,
                 )
             else:

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -108,7 +108,7 @@ class AclCheck:
             try:
                 self.src = nacaddr.IP(src)
             except ValueError:
-                raise AddressError('bad source address: %s\n' % src)
+                raise AddressError(f'bad source address: {src}\n')
 
         # validate destination address
         if not dst or dst == 'any':
@@ -117,7 +117,7 @@ class AclCheck:
             try:
                 self.dst = nacaddr.IP(dst)
             except ValueError:
-                raise AddressError('bad destination address: %s\n' % dst)
+                raise AddressError(f'bad destination address: {dst}\n')
 
         if not isinstance(self.pol_obj, (policy.Policy)):
             raise BadPolicyError('Policy object is not valid.')

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -306,12 +306,12 @@ class Match:
     def __str__(self):
         text = ''
         if self.possibles:
-            text += 'possible ' + self.action
+            text += f"possible {self.action}"
         else:
             text += self.action
-        text += ' in term ' + self.term + ' of filter ' + self.filter
+        text += f" in term {self.term} of filter {self.filter}"
         if self.possibles:
-            text += ' with factors: ' + str(', '.join(self.possibles))
+            text += f" with factors: {', '.join(self.possibles)!s}"
         return text
 
 

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -138,7 +138,7 @@ class Term:
                     str(p) for p in self.PROTO_MAP_BY_NUMBER
                 ]:
                     raise UnsupportedFilterError(
-                        'Protocol(s) %s are not supported.' % str(term.protocol)
+                        f'Protocol(s) {term.protocol!s} are not supported.'
                     )
 
             term.protocol = ProtocolNameToNumber(
@@ -166,7 +166,7 @@ class Term:
             af = self.AF_MAP[af]
         else:
             raise UnsupportedAFError(
-                'Address family %s is not supported, ' 'term %s.' % (af, self.term.name)
+                f'Address family {af} is not supported, term {self.term.name}.'
             )
         return af
 
@@ -360,7 +360,7 @@ class ACLGenerator:
     def _TranslatePolicy(self, pol: policy.Policy, exp_info: int) -> None:
         # pylint: disable=unused-argument
         """Translate policy contents to platform specific data structures."""
-        raise Error('%s does not implement _TranslatePolicies()' % self._PLATFORM)
+        raise Error(f'{self._PLATFORM} does not implement _TranslatePolicies()')
 
     def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """Provide a default for supported tokens and sub tokens.
@@ -491,7 +491,7 @@ class ACLGenerator:
                 elif not all_protocols_stateful:
                     errmsg = 'Established option supplied with inappropriate protocol(s)'
                     raise EstablishedError(
-                        '{} {} {} {}'.format(errmsg, unstateful_protocols, 'in term', term.name)
+                        f'{errmsg} {unstateful_protocols} in term {term.name}'
                     )
                 break
 
@@ -635,9 +635,9 @@ def AddRepositoryTags(
     tags = []
     wrapper = '"' if wrap else ''
 
-    p4_id = '{}$Id:${}'.format(wrapper, wrapper)
-    p4_date = '{}$Date:${}'.format(wrapper, wrapper)
-    p4_revision = '{}$Revision:${}'.format(wrapper, wrapper)
+    p4_id = f'{wrapper}$Id:${wrapper}'
+    p4_date = f'{wrapper}$Date:${wrapper}'
+    p4_revision = f'{wrapper}$Revision:${wrapper}'
     if rid:
         tags.append(f'{prefix}{p4_id}')
     if date:

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -490,9 +490,7 @@ class ACLGenerator:
                     mod.destination_port = mod.CollapsePortList(mod.destination_port)
                 elif not all_protocols_stateful:
                     errmsg = 'Established option supplied with inappropriate protocol(s)'
-                    raise EstablishedError(
-                        f'{errmsg} {unstateful_protocols} in term {term.name}'
-                    )
+                    raise EstablishedError(f'{errmsg} {unstateful_protocols} in term {term.name}')
                 break
 
         return mod

--- a/aerleon/lib/aclgenerator.py
+++ b/aerleon/lib/aclgenerator.py
@@ -635,11 +635,9 @@ def AddRepositoryTags(
     tags = []
     wrapper = '"' if wrap else ''
 
-    # Format print the '$' into the RCS tags in order prevent the tags from
-    # being interpolated here.
-    p4_id = '{}{}Id:{}{}'.format(wrapper, '$', '$', wrapper)
-    p4_date = '{}{}Date:{}{}'.format(wrapper, '$', '$', wrapper)
-    p4_revision = '{}{}Revision:{}{}'.format(wrapper, '$', '$', wrapper)
+    p4_id = '{}$Id:${}'.format(wrapper, wrapper)
+    p4_date = '{}$Date:${}'.format(wrapper, wrapper)
+    p4_revision = '{}$Revision:${}'.format(wrapper, wrapper)
     if rid:
         tags.append(f'{prefix}{p4_id}')
     if date:

--- a/aerleon/lib/arista.py
+++ b/aerleon/lib/arista.py
@@ -57,19 +57,19 @@ class Arista(cisco.Cisco):
         target = []
         if filter_type == 'standard':
             if filter_name.isdigit():
-                target.append('no access-list %s' % filter_name)
+                target.append(f'no access-list {filter_name}')
             else:
-                target.append('no ip access-list standard %s' % filter_name)
-                target.append('ip access-list standard %s' % filter_name)
+                target.append(f'no ip access-list standard {filter_name}')
+                target.append(f'ip access-list standard {filter_name}')
         elif filter_type == 'extended':
-            target.append('no ip access-list %s' % filter_name)
-            target.append('ip access-list %s' % filter_name)
+            target.append(f'no ip access-list {filter_name}')
+            target.append(f'ip access-list {filter_name}')
         elif filter_type == 'object-group':
-            target.append('no ip access-list %s' % filter_name)
-            target.append('ip access-list %s' % filter_name)
+            target.append(f'no ip access-list {filter_name}')
+            target.append(f'ip access-list {filter_name}')
         elif filter_type == 'inet6':
-            target.append('no ipv6 access-list %s' % filter_name)
-            target.append('ipv6 access-list %s' % filter_name)
+            target.append(f'no ipv6 access-list {filter_name}')
+            target.append(f'ipv6 access-list {filter_name}')
         else:
             raise UnsupportedEosAccessListError(
                 f'access list type {filter_type} not supported by {self._PLATFORM}'

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -778,9 +778,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                         term.name = f"{af_map_txt[ft]}-default-all"
 
                     if term.name in term_names:
-                        raise aclgenerator.DuplicateTermError(
-                            f"multiple terms named: {term.name}"
-                        )
+                        raise aclgenerator.DuplicateTermError(f"multiple terms named: {term.name}")
                     term_names.add(term.name)
 
                     term = self.FixHighPorts(term, af=ft)

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -160,7 +160,7 @@ class Term(aclgenerator.Term):
         self.filter_type = filter_type
 
         if term_type not in self._TERM_TYPE:
-            raise ValueError("unknown filter type: %s" % term_type)
+            raise ValueError(f"unknown filter type: {term_type}")
 
     def __str__(self) -> str:
         config = Config()
@@ -208,12 +208,12 @@ class Term(aclgenerator.Term):
         family_keywords = self._TERM_TYPE.get(self.term_type)
 
         term_block.append(
-            [TERM_INDENT, "match {} {}".format(self.term.name, family_keywords["addr_fam"]), False]
+            [TERM_INDENT, f"match {self.term.name} {family_keywords['addr_fam']}", False]
         )
 
         term_af = self.AF_MAP.get(self.term_type)
         if self.term.owner and not self.noverbose:
-            self.term.comment.append("owner: %s" % self.term.owner)
+            self.term.comment.append(f"owner: {self.term.owner}")
         if self.term.comment and not self.noverbose:
             reflowed_comments = aclgenerator.WrapWords(self.term.comment, MAX_COMMENT_LENGTH)
             for line in reflowed_comments:
@@ -257,10 +257,10 @@ class Term(aclgenerator.Term):
                 src_str = "source prefix"
                 if src_addr_ex:
                     # this should correspond to the generated field set
-                    src_str += " field-set src-%s" % self.term.name
+                    src_str += f" field-set src-{self.term.name}"
                 else:
                     for addr in src_addr:
-                        src_str += " %s" % addr
+                        src_str += f" {addr}"
 
                 term_block.append([MATCH_INDENT, src_str, False])
             elif self.term.source_address:
@@ -280,10 +280,10 @@ class Term(aclgenerator.Term):
                 dst_str = "destination prefix"
                 if dst_addr_ex:
                     # this should correspond to the generated field set
-                    dst_str += " field-set dst-%s" % self.term.name
+                    dst_str += f" field-set dst-{self.term.name}"
                 else:
                     for addr in dst_addr:
-                        dst_str += " %s" % addr
+                        dst_str += f" {addr}"
 
                 term_block.append([MATCH_INDENT, dst_str, False])
 
@@ -299,16 +299,16 @@ class Term(aclgenerator.Term):
             if self.term.source_prefix:
                 src_pfx_str = "source prefix field-set"
                 for pfx in self.term.source_prefix:
-                    src_pfx_str += " %s" % pfx
+                    src_pfx_str += f" {pfx}"
 
-                term_block.append([MATCH_INDENT, " %s" % src_pfx_str, False])
+                term_block.append([MATCH_INDENT, f" {src_pfx_str}", False])
 
             if self.term.destination_prefix:
                 dst_pfx_str = "destination prefix field-set"
                 for pfx in self.term.destination_prefix:
-                    dst_pfx_str += " %s" % pfx
+                    dst_pfx_str += f" {pfx}"
 
-                term_block.append([MATCH_INDENT, " %s" % dst_pfx_str, False])
+                term_block.append([MATCH_INDENT, f" {dst_pfx_str}", False])
 
             # PROTOCOL MATCHES
             protocol_str = ""
@@ -342,19 +342,19 @@ class Term(aclgenerator.Term):
             # ADDITIONAL SUPPORTED MATCH OPTIONS ------------------------------
             # packet length
             if self.term.packet_length:
-                term_block.append([MATCH_INDENT, "ip length %s" % self.term.packet_length, False])
+                term_block.append([MATCH_INDENT, f"ip length {self.term.packet_length}", False])
 
             # fragment offset
             if self.term.fragment_offset:
                 term_block.append(
-                    [MATCH_INDENT, "fragment offset %s" % self.term.fragment_offset, False]
+                    [MATCH_INDENT, f"fragment offset {self.term.fragment_offset}", False]
                 )
 
             if self.term.hop_limit:
-                term_block.append([MATCH_INDENT, "ttl %s" % self.term.hop_limit, False])
+                term_block.append([MATCH_INDENT, f"ttl {self.term.hop_limit}", False])
 
             if self.term.ttl:
-                term_block.append([MATCH_INDENT, "ttl %s" % self.term.ttl, False])
+                term_block.append([MATCH_INDENT, f"ttl {self.term.ttl}", False])
 
             if misc_options:
                 for mopt in misc_options:
@@ -371,7 +371,7 @@ class Term(aclgenerator.Term):
         # if accept and no extra actions don't generate an actions statement
         if self.term.action != ["accept"]:
             term_block.append([MATCH_INDENT, "actions", False])
-            term_block.append([ACTION_INDENT, "%s" % current_action, False])
+            term_block.append([ACTION_INDENT, f"{current_action}", False])
         elif self.term.action == ["accept"] and has_extra_actions:
             term_block.append([MATCH_INDENT, "actions", False])
 
@@ -388,7 +388,7 @@ class Term(aclgenerator.Term):
 
                 # counters
             if self.term.counter:
-                term_block.append([ACTION_INDENT, "count %s" % self.term.counter, False])
+                term_block.append([ACTION_INDENT, f"count {self.term.counter}", False])
 
             term_block.append([MATCH_INDENT, "!", False])  # end of actions
         term_block.append([TERM_INDENT, "!", False])  # end of match entry
@@ -403,11 +403,11 @@ class Term(aclgenerator.Term):
 
         # source port generation
         if term.source_port:
-            port_str += " source port %s" % self._Group(term.source_port)
+            port_str += f" source port {self._Group(term.source_port)}"
 
         # destination port
         if term.destination_port:
-            port_str += " destination port %s" % self._Group(term.destination_port)
+            port_str += f" destination port {self._Group(term.destination_port)}"
 
         return port_str
 
@@ -420,7 +420,7 @@ class Term(aclgenerator.Term):
             icmp_types = self.NormalizeIcmpTypes(term.icmp_type, term.protocol, self.term_type)
         if icmp_types != [""]:
             for t in icmp_types:
-                icmp_type_str += "%s," % t
+                icmp_type_str += f"{t},"
 
             if icmp_type_str.endswith(","):
                 icmp_type_str = icmp_type_str[:-1]  # chomp trailing ','
@@ -430,7 +430,7 @@ class Term(aclgenerator.Term):
         if self.term.icmp_code and len(icmp_types) <= 1:
             icmp_codes = self._Group(self.term.icmp_code)
             icmp_codes = re.sub(r" ", ",", icmp_codes)
-            icmp_code_str += " code %s" % icmp_codes
+            icmp_code_str += f" code {icmp_codes}"
 
         return icmp_type_str, icmp_code_str
 
@@ -481,9 +481,9 @@ class Term(aclgenerator.Term):
                     num_prots.append(str(self.PROTO_MAP[p]))
                 except KeyError:
                     num_prots.append(str(p))
-            protocol_str += "protocol %s" % ",".join(num_prots)
+            protocol_str += f"protocol {','.join(num_prots)}"
         else:
-            protocol_str += "protocol %s" % self._Group(prots)
+            protocol_str += f"protocol {self._Group(prots)}"
 
         if prots == ["tcp"] and flags:
             protocol_str += " flags " + " ".join(flags)
@@ -718,11 +718,11 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
         field_list = ""
 
         for p in pfxs:
-            field_list += (" " * 6) + "%s\n" % p
+            field_list += (" " * 6) + f"{p}\n"
         for p in ex_pfxs:
-            field_list += (" " * 6) + "except %s\n" % p
+            field_list += (" " * 6) + f"except {p}\n"
 
-        fieldset_hdr = "field-set " + af + " prefix " + direction + "-" + ("%s" % name) + "\n"
+        fieldset_hdr = "field-set " + af + " prefix " + direction + "-" + f"{name}" + "\n"
         field_set = fieldset_hdr + field_list
         return field_set
 
@@ -779,7 +779,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
 
                     if term.name in term_names:
                         raise aclgenerator.DuplicateTermError(
-                            "multiple terms named: %s" % term.name
+                            f"multiple terms named: {term.name}"
                         )
                     term_names.add(term.name)
 
@@ -831,7 +831,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                         "is-fragment" in term.option or "fragment" in term.option
                     ) and filter_type == "inet6":
                         raise AristaTpFragmentInV6Error(
-                            "the term %s uses is-fragment but " "is a v6 policy." % term.name
+                            f"the term {term.name} uses is-fragment but is a v6 policy."
                         )
 
                     # this should error out more gracefully in mixed configs
@@ -882,7 +882,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
 
                         if src_addr_ex:
                             fs = self._GenPrefixFieldset(
-                                "src", "%s" % term.name, src_addr, src_addr_ex, af_map_txt[ft]
+                                "src", f"{term.name}", src_addr, src_addr_ex, af_map_txt[ft]
                             )
                             policy_field_sets.append(fs)
 
@@ -898,7 +898,7 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                         if dst_addr_ex:
                             fs = self._GenPrefixFieldset(
                                 "dst",
-                                "%s" % term.name,
+                                f"{term.name}",
                                 term.destination_address,
                                 term.destination_address_exclude,
                                 af_map_txt[ft],
@@ -943,13 +943,13 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                     config.Append("   ", fs)
                     config.Append("   ", "!")
 
-            config.Append("   ", "no traffic-policy %s" % filter_name)
-            config.Append("   ", "traffic-policy %s" % filter_name)
+            config.Append("   ", f"no traffic-policy {filter_name}")
+            config.Append("   ", f"traffic-policy {filter_name}")
 
             # if there are counters, export the list of counters
             if counters:
                 str_counters = " ".join(counters)
-                config.Append("   ", "counter %s" % str_counters)
+                config.Append("   ", f"counter {str_counters}")
 
             for term in terms:
                 term_str = str(term)

--- a/aerleon/lib/arista_tp.py
+++ b/aerleon/lib/arista_tp.py
@@ -217,7 +217,7 @@ class Term(aclgenerator.Term):
         if self.term.comment and not self.noverbose:
             reflowed_comments = aclgenerator.WrapWords(self.term.comment, MAX_COMMENT_LENGTH)
             for line in reflowed_comments:
-                term_block.append([MATCH_INDENT, "!! " + line, False])
+                term_block.append([MATCH_INDENT, f"!! {line}", False])
 
         has_match_criteria = (
             self.term.destination_address
@@ -486,7 +486,7 @@ class Term(aclgenerator.Term):
             protocol_str += f"protocol {self._Group(prots)}"
 
         if prots == ["tcp"] and flags:
-            protocol_str += " flags " + " ".join(flags)
+            protocol_str += f" flags {' '.join(flags)}"
 
         return protocol_str
 
@@ -513,16 +513,16 @@ class Term(aclgenerator.Term):
         for p in except_list:
             if 255 > p > ptr:
                 if (p - 1) == ptr:
-                    ex_str += str(ptr) + ","
+                    ex_str += f"{ptr!s},"
                 else:
-                    ex_str += str(ptr) + "-" + str(p - 1) + ","
+                    ex_str += f"{ptr!s}-{p - 1!s},"
 
                 ptr = p + 1
             elif p == ptr:
                 ptr = p + 1
 
-        ex_str += str(ptr) + "-" + "255"
-        protocol_str = "protocol " + ex_str
+        ex_str += f"{ptr!s}-255"
+        protocol_str = f"protocol {ex_str}"
 
         return protocol_str
 
@@ -718,11 +718,11 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
         field_list = ""
 
         for p in pfxs:
-            field_list += (" " * 6) + f"{p}\n"
+            field_list += f"{' ' * 6}{p}\n"
         for p in ex_pfxs:
-            field_list += (" " * 6) + f"except {p}\n"
+            field_list += f"{' ' * 6}except {p}\n"
 
-        fieldset_hdr = "field-set " + af + " prefix " + direction + "-" + f"{name}" + "\n"
+        fieldset_hdr = f"field-set {af} prefix {direction}-{name}\n"
         field_set = fieldset_hdr + field_list
         return field_set
 
@@ -772,10 +772,10 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                     # TODO(sulrich): if term names become unique to address
                     # families, this can be removed.
                     if filter_type == "mixed" and ft == "inet6":
-                        term.name = af_map_txt[ft] + "-" + term.name
+                        term.name = f"{af_map_txt[ft]}-{term.name}"
 
                     if default_term:
-                        term.name = af_map_txt[ft] + "-default-all"
+                        term.name = f"{af_map_txt[ft]}-default-all"
 
                     if term.name in term_names:
                         raise aclgenerator.DuplicateTermError(
@@ -956,4 +956,4 @@ class AristaTrafficPolicy(aclgenerator.ACLGenerator):
                 if term_str:
                     config.Append("", term_str, verbatim=True)
 
-        return str(config) + "\n"
+        return f"{config!s}\n"

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -212,7 +212,7 @@ class Term(aclgenerator.Term):
                 return [str(self._PROTOCOL_MAP[protocol])]
             for start_port, end_port in sorted(ports):
                 ret_ports.append(
-                    f'{protocol.lower()} {start_port}{" " + str(end_port) if start_port != end_port else ""}'
+                    f'{protocol.lower()} {start_port}{f" {end_port!s}" if start_port != end_port else ""}'
                 )
         return ret_ports
 

--- a/aerleon/lib/aruba.py
+++ b/aerleon/lib/aruba.py
@@ -89,7 +89,7 @@ class Term(aclgenerator.Term):
             comments = self.term.comment[:]
 
             if self.term.owner:
-                comments.append('Owner: %s' % self.term.owner)
+                comments.append(f'Owner: {self.term.owner}')
 
             if comments:
                 for line in aclgenerator.WrapWords(comments, self._COMMENT_LINE_LENGTH):
@@ -175,7 +175,7 @@ class Term(aclgenerator.Term):
         for address in addresses:
             ret_str.append(f'{self._IDENT}{self._GenerateNetworkOrHostTokens(address)}')
 
-        ret_str.append('%s\n' % _TERMINATOR_MARKER)
+        ret_str.append(f'{_TERMINATOR_MARKER}\n')
 
         return '\n'.join(t for t in ret_str if t)
 
@@ -289,7 +289,7 @@ class Aruba(aclgenerator.ACLGenerator):
     def __str__(self) -> str:
         target = []
 
-        target.extend(aclgenerator.AddRepositoryTags('%s ' % _COMMENT_MARKER))
+        target.extend(aclgenerator.AddRepositoryTags(f'{_COMMENT_MARKER} '))
 
         for filter_name, terms, _ in self.aruba_policies:
             netdestinations = []

--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -108,7 +108,7 @@ class TermStandard:
                 self.filter_name,
                 self.term.name,
             )
-            self.dscpstring = ' dscp' + self.term.dscp_match
+            self.dscpstring = f" dscp{self.term.dscp_match}"
 
     def __str__(self) -> str:
         ret_str = []
@@ -786,7 +786,7 @@ class Term(aclgenerator.Term):
             ' '.join(option),
         ]
         non_empty_elements = [x for x in all_elements if x]
-        return [' ' + ' '.join(non_empty_elements)]
+        return [f" {' '.join(non_empty_elements)}"]
 
     def _FixConsecutivePorts(self, port_list: list[tuple[int, int]]) -> list[tuple[int, int]]:
         """Takes a list of tuples and expands the tuple if the range is two.

--- a/aerleon/lib/ciscoasa.py
+++ b/aerleon/lib/ciscoasa.py
@@ -72,13 +72,13 @@ class Term(cisco.ExtendedTerm):
         if (self.af == 6 and 'icmp' in self.term.protocol) or (
             self.af == 4 and 'icmpv6' in self.term.protocol
         ):
-            ret_str.append('remark Term %s' % self.term.name)
+            ret_str.append(f'remark Term {self.term.name}')
             ret_str.append('remark not rendered due to protocol/AF mismatch.')
             return '\n'.join(ret_str)
 
         ret_str.append(f'access-list {self.filter_name} remark {self.term.name}')
         if self.term.owner:
-            self.term.comment.append('Owner: %s' % self.term.owner)
+            self.term.comment.append(f'Owner: {self.term.owner}')
         for comment in self.term.comment:
             for line in comment.split('\n'):
                 ret_str.append(f'access-list {self.filter_name} remark {str(line)[:100]}')
@@ -230,13 +230,13 @@ class Term(cisco.ExtendedTerm):
             if saddr.num_addresses > 1:
                 saddr = f'{saddr.network_address} {saddr.netmask}'
             else:
-                saddr = 'host %s' % (saddr.network_address)
+                saddr = f'host {saddr.network_address}'
         if isinstance(daddr, nacaddr.IPv4) or isinstance(daddr, ipaddress.IPv4Network):
             daddr = cast(self.IPV4_ADDRESS, daddr)
             if daddr.num_addresses > 1:
                 daddr = f'{daddr.network_address} {daddr.netmask}'
             else:
-                daddr = 'host %s' % (daddr.network_address)
+                daddr = f'host {daddr.network_address}'
         if isinstance(saddr, summarizer.DSMNet):
             saddr = '%s %s' % summarizer.ToDottedQuad(saddr, negate=False)
 
@@ -248,13 +248,13 @@ class Term(cisco.ExtendedTerm):
             if saddr.num_addresses > 1:
                 saddr = f'{saddr.network_address}/{saddr.prefixlen}'
             else:
-                saddr = 'host %s' % (saddr.network_address)
+                saddr = f'host {saddr.network_address}'
         if isinstance(daddr, nacaddr.IPv6) or isinstance(daddr, ipaddress.IPv6Network):
             daddr = cast(self.IPV6_ADDRESS, daddr)
             if daddr.num_addresses > 1:
                 daddr = f'{daddr.network_address}/{daddr.prefixlen}'
             else:
-                daddr = 'host %s' % (daddr.network_address)
+                daddr = f'host {daddr.network_address}'
 
         # fix ports
         if not sport:
@@ -265,7 +265,7 @@ class Term(cisco.ExtendedTerm):
                 cisco.PortMap.GetProtocol(sport[1], proto),
             )
         else:
-            sport = ' eq %s' % (cisco.PortMap.GetProtocol(sport[0], proto))
+            sport = f' eq {cisco.PortMap.GetProtocol(sport[0], proto)}'
 
         if not dport:
             dport = ''
@@ -275,7 +275,7 @@ class Term(cisco.ExtendedTerm):
                 cisco.PortMap.GetProtocol(dport[1], proto),
             )
         else:
-            dport = ' eq %s' % (cisco.PortMap.GetProtocol(dport[0], proto))
+            dport = f' eq {cisco.PortMap.GetProtocol(dport[0], proto)}'
 
         if not option:
             option = ['']
@@ -355,10 +355,10 @@ class CiscoASA(aclgenerator.ACLGenerator):
         target = []
 
         for header, filter_name, terms in self.ciscoasa_policies:
-            target.append('clear configure access-list %s' % filter_name)
+            target.append(f'clear configure access-list {filter_name}')
 
             # add the p4 tags
-            target.extend(aclgenerator.AddRepositoryTags('access-list %s remark ' % filter_name))
+            target.extend(aclgenerator.AddRepositoryTags(f'access-list {filter_name} remark '))
 
             # add a header comment if one exists
             for comment in header.comment:

--- a/aerleon/lib/cisconx.py
+++ b/aerleon/lib/cisconx.py
@@ -64,14 +64,14 @@ class CiscoNX(cisco.Cisco):
         """
         target = []
         if filter_type == 'extended':
-            target.append('no ip access-list %s' % filter_name)
-            target.append('ip access-list %s' % filter_name)
+            target.append(f'no ip access-list {filter_name}')
+            target.append(f'ip access-list {filter_name}')
         elif filter_type == 'object-group':
-            target.append('no ip access-list %s' % filter_name)
-            target.append('ip access-list %s' % filter_name)
+            target.append(f'no ip access-list {filter_name}')
+            target.append(f'ip access-list {filter_name}')
         elif filter_type == 'inet6':
-            target.append('no ipv6 access-list %s' % filter_name)
-            target.append('ipv6 access-list %s' % filter_name)
+            target.append(f'no ipv6 access-list {filter_name}')
+            target.append(f'ipv6 access-list {filter_name}')
         else:
             raise UnsupportedNXosAccessListError(
                 f'access list type {filter_type} not supported by {self._PLATFORM}'

--- a/aerleon/lib/ciscoxr.py
+++ b/aerleon/lib/ciscoxr.py
@@ -41,11 +41,11 @@ class CiscoXR(cisco.Cisco):
         """
         target = []
         if filter_type == 'inet6':
-            target.append('no ipv6 access-list %s' % filter_name)
-            target.append('ipv6 access-list %s' % filter_name)
+            target.append(f'no ipv6 access-list {filter_name}')
+            target.append(f'ipv6 access-list {filter_name}')
         else:
-            target.append('no ipv4 access-list %s' % filter_name)
-            target.append('ipv4 access-list %s' % filter_name)
+            target.append(f'no ipv4 access-list {filter_name}')
+            target.append(f'ipv4 access-list {filter_name}')
         return target
 
     def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -115,7 +115,7 @@ class Term(aclgenerator.Term):
             ) + self.term.GetAddressOfVersion('source_address', 6)
         else:
             raise UnsupportedFilterTypeError(
-                "'%s' is not a valid filter type" % self.address_family
+                f"'{self.address_family}' is not a valid filter type"
             )
 
         term_dict['match'] = {
@@ -241,7 +241,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
                 filter_type = filter_options[self._FILTER_OPTIONS_MAP['filter_type']]
                 if filter_type not in self._SUPPORTED_AF:
                     raise UnsupportedFilterTypeError(
-                        "'%s' is not a valid filter type" % filter_type
+                        f"'{filter_type}' is not a valid filter type"
                     )
 
             counter = 1

--- a/aerleon/lib/cloudarmor.py
+++ b/aerleon/lib/cloudarmor.py
@@ -114,9 +114,7 @@ class Term(aclgenerator.Term):
                 'source_address', 4
             ) + self.term.GetAddressOfVersion('source_address', 6)
         else:
-            raise UnsupportedFilterTypeError(
-                f"'{self.address_family}' is not a valid filter type"
-            )
+            raise UnsupportedFilterTypeError(f"'{self.address_family}' is not a valid filter type")
 
         term_dict['match'] = {
             'versionedExpr': 'SRC_IPS_V1',
@@ -240,9 +238,7 @@ class CloudArmor(aclgenerator.ACLGenerator):
             else:
                 filter_type = filter_options[self._FILTER_OPTIONS_MAP['filter_type']]
                 if filter_type not in self._SUPPORTED_AF:
-                    raise UnsupportedFilterTypeError(
-                        f"'{filter_type}' is not a valid filter type"
-                    )
+                    raise UnsupportedFilterTypeError(f"'{filter_type}' is not a valid filter type")
 
             counter = 1
 

--- a/aerleon/lib/demo.py
+++ b/aerleon/lib/demo.py
@@ -205,11 +205,11 @@ class Demo(aclgenerator.ACLGenerator):
         for header, filter_name, filter_type, interface_specific, terms in self.demo_policies:
             target.append('Header {')
             target.append(' ' * 4 + 'Name: %s {' % filter_name)
-            target.append(' ' * 8 + 'Type: %s ' % filter_type)
+            target.append(' ' * 8 + f'Type: {filter_type} ')
             for comment in header.comment:
                 for line in comment.split('\n'):
-                    target.append(' ' * 8 + 'Comment: %s' % line)
-            target.append(' ' * 8 + 'Family type: %s' % interface_specific)
+                    target.append(' ' * 8 + f'Comment: {line}')
+            target.append(' ' * 8 + f'Family type: {interface_specific}')
             target.append(' ' * 4 + '}')
             for term in terms:
                 target.append(str(term))

--- a/aerleon/lib/demo.py
+++ b/aerleon/lib/demo.py
@@ -46,15 +46,15 @@ class Term(aclgenerator.Term):
         ret_str = []
 
         # NAME
-        ret_str.append(' ' * 4 + 'Term: ' + self.term.name + '{')
+        ret_str.append(f"{' ' * 4}Term: {self.term.name}{{")
 
         # COMMENTS
         if self.term.comment:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + '#COMMENTS')
+            ret_str.append(f"{' ' * 8}#COMMENTS")
             for comment in self.term.comment:
                 for line in comment.split('\n'):
-                    ret_str.append(' ' * 8 + '#' + line)
+                    ret_str.append(f"{' ' * 8}#{line}")
 
         # SOURCE ADDRESS
         source_address = self.term.GetAddressOfVersion(
@@ -65,21 +65,21 @@ class Term(aclgenerator.Term):
         )
         if source_address:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Source IP\'s')
+            ret_str.append(f"{' ' * 8}Source IP's")
             for saddr in source_address:
                 ret_str.append(' ' * 8 + str(saddr))
 
         # SOURCE ADDRESS EXCLUDE
         if source_address_exclude:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Excluded Source IP\'s')
+            ret_str.append(f"{' ' * 8}Excluded Source IP's")
             for ex in source_address:
                 ret_str.append(' ' * 8 + str(ex))
 
         # SOURCE PORT
         if self.term.source_port:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Source ports')
+            ret_str.append(f"{' ' * 8}Source ports")
             ret_str.append(' ' * 8 + self._Group(self.term.source_port))
 
         # DESTINATION
@@ -91,40 +91,40 @@ class Term(aclgenerator.Term):
         )
         if destination_address:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Destination IP\'s')
+            ret_str.append(f"{' ' * 8}Destination IP's")
             for daddr in destination_address:
                 ret_str.append(' ' * 8 + str(daddr))
 
         # DESINATION ADDRESS EXCLUDE
         if destination_address_exclude:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Excluded Destination IP\'s')
+            ret_str.append(f"{' ' * 8}Excluded Destination IP's")
             for ex in destination_address_exclude:
                 ret_str.append(' ' * 8 + str(ex))
 
         # DESTINATION PORT
         if self.term.destination_port:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Destination Ports')
+            ret_str.append(f"{' ' * 8}Destination Ports")
             ret_str.append(' ' * 8 + self._Group(self.term.destination_port))
 
         # PROTOCOL
         if self.term.protocol:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Protocol')
+            ret_str.append(f"{' ' * 8}Protocol")
             ret_str.append(' ' * 8 + self._Group(self.term.protocol))
 
         # OPTION
         if self.term.option:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Options')
+            ret_str.append(f"{' ' * 8}Options")
             for option in self.term.option:
                 ret_str.append(' ' * 8 + option)
 
         # ACTION
         for action in self.term.action:
             ret_str.append(' ')
-            ret_str.append(' ' * 8 + 'Action: ' + self._ACTIONS.get(str(action)) + ' all traffic')
+            ret_str.append(f"{' ' * 8}Action: {self._ACTIONS.get(str(action))} all traffic")
         return '\n '.join(ret_str)
 
     def _Group(self, group):
@@ -141,7 +141,7 @@ class Term(aclgenerator.Term):
         if len(group) > 1:
             rval = ''
             for item in group:
-                rval = rval + str(item[0]) + ' '
+                rval = f"{rval}{item[0]!s} "
         else:
             rval = _FormattedGroup(group[0])
         return rval
@@ -205,15 +205,15 @@ class Demo(aclgenerator.ACLGenerator):
         for header, filter_name, filter_type, interface_specific, terms in self.demo_policies:
             target.append('Header {')
             target.append(' ' * 4 + 'Name: %s {' % filter_name)
-            target.append(' ' * 8 + f'Type: {filter_type} ')
+            target.append(f"{' ' * 8}Type: {filter_type} ")
             for comment in header.comment:
                 for line in comment.split('\n'):
-                    target.append(' ' * 8 + f'Comment: {line}')
-            target.append(' ' * 8 + f'Family type: {interface_specific}')
-            target.append(' ' * 4 + '}')
+                    target.append(f"{' ' * 8}Comment: {line}")
+            target.append(f"{' ' * 8}Family type: {interface_specific}")
+            target.append(f"{' ' * 4}}}")
             for term in terms:
                 target.append(str(term))
-                target.append(' ' * 4 + '}')
+                target.append(f"{' ' * 4}}}")
                 target.append(' ')
             target.append('}')
         return '\n'.join(target)

--- a/aerleon/lib/fortigate.py
+++ b/aerleon/lib/fortigate.py
@@ -263,11 +263,11 @@ class Term(aclgenerator.Term):
         self._TranslateAddresses(term.destination_address_exclude)
         if term.source_address_exclude:
             self._TranslateExcludes(
-                self.term.name + '-source', term.source_address, term.source_address_exclude
+                f"{self.term.name}-source", term.source_address, term.source_address_exclude
             )
         if term.destination_address_exclude:
             self._TranslateExcludes(
-                self.term.name + '-destination',
+                f"{self.term.name}-destination",
                 term.destination_address,
                 term.destination_address_exclude,
             )

--- a/aerleon/lib/gce.py
+++ b/aerleon/lib/gce.py
@@ -231,7 +231,7 @@ class Term(gcp.Term):
           GceFirewallError: The term name is too long.
         """
         if self.term.owner:
-            self.term.comment.append('Owner: %s' % self.term.owner)
+            self.term.comment.append(f'Owner: {self.term.owner}')
         term_dict = {
             'description': ' '.join(self.term.comment),
             'name': self.term.name,
@@ -239,7 +239,7 @@ class Term(gcp.Term):
         }
         if self.term.network:
             term_dict['network'] = self.term.network
-            term_dict['name'] = '{}-{}'.format(self.term.network.split('/')[-1], term_dict['name'])
+            term_dict['name'] = f"{self.term.network.split('/')[-1]}-{term_dict['name']}"
         # Identify if this is inet6 processing for a term under a mixed policy.
         mixed_policy_inet6_term = False
         if self.policy_inet_version == 'mixed' and self.inet_version == 'inet6':
@@ -251,11 +251,11 @@ class Term(gcp.Term):
         # Checking counts of tags, and ports to see if they exceeded limits.
         if len(self.term.source_tag) > self._TERM_SOURCE_TAGS_LIMIT:
             raise GceFirewallError(
-                'GCE firewall rule exceeded number of source tags per rule: %s' % self.term.name
+                f'GCE firewall rule exceeded number of source tags per rule: {self.term.name}'
             )
         if len(self.term.destination_tag) > self._TERM_TARGET_TAGS_LIMIT:
             raise GceFirewallError(
-                'GCE firewall rule exceeded number of target tags per rule: %s' % self.term.name
+                f'GCE firewall rule exceeded number of target tags per rule: {self.term.name}'
             )
 
         if self.term.source_tag:
@@ -277,7 +277,7 @@ class Term(gcp.Term):
         term_af = self.AF_MAP.get(self.inet_version)
         if self.inet_version == 'mixed':
             raise GceFirewallError(
-                'GCE firewall rule has incorrect inet_version for rule: %s' % self.term.name
+                f'GCE firewall rule has incorrect inet_version for rule: {self.term.name}'
             )
 
         # Exit early for inet6 processing of mixed rules that have only tags,
@@ -383,7 +383,7 @@ class Term(gcp.Term):
                         ports.append('%d-%d' % (start, end))
                 if len(ports) > self._TERM_PORTS_LIMIT:
                     raise GceFirewallError(
-                        'GCE firewall rule exceeded number of ports per rule: %s' % self.term.name
+                        f'GCE firewall rule exceeded number of ports per rule: {self.term.name}'
                     )
                 dest['ports'] = ports
 
@@ -426,7 +426,7 @@ class Term(gcp.Term):
         # Sanity checking term name lengths.
         long_rules = [rule['name'] for rule in rules if len(rule['name']) > 63]
         if long_rules:
-            raise GceFirewallError('GCE firewall name ended up being too long: %s' % long_rules)
+            raise GceFirewallError(f'GCE firewall name ended up being too long: {long_rules}')
         return rules
 
 
@@ -541,7 +541,7 @@ class GCE(gcp.GCP):
                     term.name += '-e'
                 term.name = self.FixTermLength(term.name)
                 if term.name in term_names:
-                    raise GceFirewallError('Duplicate term name %s' % term.name)
+                    raise GceFirewallError(f'Duplicate term name {term.name}')
                 term_names.add(term.name)
 
                 term.direction = direction

--- a/aerleon/lib/gcp.py
+++ b/aerleon/lib/gcp.py
@@ -166,4 +166,4 @@ def GetIpv6TermName(term_name: str) -> str:
       string: The IPv6 requivalent term name.
     """
 
-    return '{}-{}'.format(term_name, 'v6')
+    return f'{term_name}-v6'

--- a/aerleon/lib/gcp_hf.py
+++ b/aerleon/lib/gcp_hf.py
@@ -213,7 +213,7 @@ class Term(gcp.Term):
         term_name = self.term.name
         if mixed_policy_inet6_term:
             term_name = gcp.GetIpv6TermName(term_name)
-        raw_description = term_name + ': ' + ' '.join(self.term.comment)
+        raw_description = f"{term_name}: {' '.join(self.term.comment)}"
         term_dict['description'] = gcp.TruncateString(
             raw_description, self._MAX_TERM_COMMENT_LENGTH
         )

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -221,8 +221,8 @@ class Ipset(iptables.Iptables):
         c_str = 'create'
         a_str = 'add'
         if 'exists' in self.filter_options:
-            c_str = c_str + ' -exist'
-            a_str = a_str + ' -exist'
+            c_str = f"{c_str} -exist"
+            a_str = f"{a_str} -exist"
         for direction in sorted(term.addr_sets, reverse=True):
             set_name, addr_list = term.addr_sets[direction]
             set_hashsize = 1 << len(addr_list).bit_length()

--- a/aerleon/lib/ipset.py
+++ b/aerleon/lib/ipset.py
@@ -164,12 +164,12 @@ class Term(iptables.Term):
         if src_addr and dst_addr:
             if src_addr == self._all_ips:
                 if 'src' in self.addr_sets:
-                    src_addr_stmt = '-m set --match-set %s src' % self.addr_sets['src'][0]
+                    src_addr_stmt = f"-m set --match-set {self.addr_sets['src'][0]} src"
             else:
                 src_addr_stmt = '-s %s/%d' % (src_addr.network_address, src_addr.prefixlen)
             if dst_addr == self._all_ips:
                 if 'dst' in self.addr_sets:
-                    dst_addr_stmt = '-m set --match-set %s dst' % self.addr_sets['dst'][0]
+                    dst_addr_stmt = f"-m set --match-set {self.addr_sets['dst'][0]} dst"
             else:
                 dst_addr_stmt = '-d %s/%d' % (dst_addr.network_address, dst_addr.prefixlen)
         return (src_addr_stmt, dst_addr_stmt)

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -961,7 +961,7 @@ class Iptables(aclgenerator.ACLGenerator):
                 target.append('#')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags('# '))
-            target.append('# ' + filter_type)
+            target.append(f"# {filter_type}")
 
             if filter_name in self._GOOD_FILTERS:
                 if default_action:

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -293,9 +293,7 @@ class Term(aclgenerator.Term):
                 self.options.append(self._KNOWN_OPTIONS_MATCHERS[next_opt])
         if self.term.packet_length:
             # Policy format is "#-#", but iptables format is "#:#"
-            self.options.append(
-                f"-m length --length {self.term.packet_length.replace('-', ':')}"
-            )
+            self.options.append(f"-m length --length {self.term.packet_length.replace('-', ':')}")
         if self.term.fragment_offset:
             self.options.append(
                 f"-m u32 --u32 4&0x1FFF={self.term.fragment_offset.replace('-', ':')}"
@@ -713,17 +711,13 @@ class Term(aclgenerator.Term):
                 count += 2
             if count >= max_ports:
                 count = 0
-                portstrings.append(
-                    f"-m multiport --{direction}ports {','.join(norm_ports)}"
-                )
+                portstrings.append(f"-m multiport --{direction}ports {','.join(norm_ports)}")
                 norm_ports = []
         if norm_ports:
             if len(norm_ports) == 1:
                 portstrings.append(f'--{direction}port {norm_ports[0]}')
             else:
-                portstrings.append(
-                    f"-m multiport --{direction}ports {','.join(norm_ports)}"
-                )
+                portstrings.append(f"-m multiport --{direction}ports {','.join(norm_ports)}")
         return portstrings
 
     def _SetDefaultAction(self) -> None:

--- a/aerleon/lib/iptables.py
+++ b/aerleon/lib/iptables.py
@@ -152,7 +152,7 @@ class Term(aclgenerator.Term):
 
         if self.verbose:
             if self.term.owner:
-                self.term.comment.append('Owner: %s' % self.term.owner)
+                self.term.comment.append(f'Owner: {self.term.owner}')
             # reformat long comments, if needed
             #
             # iptables allows individual comments up to 256 chars.
@@ -195,7 +195,7 @@ class Term(aclgenerator.Term):
                         'iptables output.',
                     )
                 )
-            return '# skipped %s due to source or destination prefix rule' % self.term.name
+            return f'# skipped {self.term.name} due to source or destination prefix rule'
 
         # protocol
         if self.term.protocol:
@@ -294,11 +294,11 @@ class Term(aclgenerator.Term):
         if self.term.packet_length:
             # Policy format is "#-#", but iptables format is "#:#"
             self.options.append(
-                '-m length --length %s' % self.term.packet_length.replace('-', ':')
+                f"-m length --length {self.term.packet_length.replace('-', ':')}"
             )
         if self.term.fragment_offset:
             self.options.append(
-                '-m u32 --u32 4&0x1FFF=%s' % self.term.fragment_offset.replace('-', ':')
+                f"-m u32 --u32 4&0x1FFF={self.term.fragment_offset.replace('-', ':')}"
             )
         icmp_code = ['']
         if self.term.icmp_code:
@@ -524,11 +524,11 @@ class Term(aclgenerator.Term):
 
         source_int = ''
         if sint:
-            source_int = '-i %s' % sint
+            source_int = f'-i {sint}'
 
         destination_int = ''
         if dint:
-            destination_int = '-o %s' % dint
+            destination_int = f'-o {dint}'
 
         log_jump = ''
         if log_hits:
@@ -544,7 +544,7 @@ class Term(aclgenerator.Term):
         proto = self._PROTO_TABLE.get(str(protocol))
         # Don't drop protocol if we don't recognize it
         if protocol and not proto:
-            proto = '-p %s' % str(protocol)
+            proto = f'-p {protocol!s}'
 
         if protocol == 'hopopt':
             proto = ''
@@ -585,9 +585,9 @@ class Term(aclgenerator.Term):
         if not icmp_type:
             icmp = ''
         elif str(protocol) == 'icmpv6':
-            icmp = '-m icmp6 --icmpv6-type %s' % icmp_type
+            icmp = f'-m icmp6 --icmpv6-type {icmp_type}'
         else:
-            icmp = '--icmp-type %s' % icmp_type
+            icmp = f'--icmp-type {icmp_type}'
         if code:
             icmp += r'/%d' % code
 
@@ -714,7 +714,7 @@ class Term(aclgenerator.Term):
             if count >= max_ports:
                 count = 0
                 portstrings.append(
-                    '-m multiport --{}ports {}'.format(direction, ','.join(norm_ports))
+                    f"-m multiport --{direction}ports {','.join(norm_ports)}"
                 )
                 norm_ports = []
         if norm_ports:
@@ -722,7 +722,7 @@ class Term(aclgenerator.Term):
                 portstrings.append(f'--{direction}port {norm_ports[0]}')
             else:
                 portstrings.append(
-                    '-m multiport --{}ports {}'.format(direction, ','.join(norm_ports))
+                    f"-m multiport --{direction}ports {','.join(norm_ports)}"
                 )
         return portstrings
 
@@ -895,12 +895,12 @@ class Iptables(aclgenerator.ACLGenerator):
                 )
                 if term.name in term_names:
                     raise aclgenerator.DuplicateTermError(
-                        'You have a duplicate term: %s' % term.name
+                        f'You have a duplicate term: {term.name}'
                     )
                 term_names.add(term.name)
                 if not term.logging and term.log_limit:
                     raise LimitButNoLogError(
-                        'Term %s: Cannoy use log-limit without logging' % term.name
+                        f'Term {term.name}: Cannoy use log-limit without logging'
                     )
                 if not chained_terms:
                     term.name = filter_name
@@ -957,7 +957,7 @@ class Iptables(aclgenerator.ACLGenerator):
             comments = aclgenerator.WrapWords(header.comment, 70)
             if comments and comments[0]:
                 for line in comments:
-                    target.append('# %s' % line)
+                    target.append(f'# {line}')
                 target.append('#')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags('# '))

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -251,7 +251,7 @@ class Term(aclgenerator.Term):
             config.Append('/*')
             for comment in self.term.comment:
                 for line in comment.split('\n'):
-                    config.Append('** ' + line)
+                    config.Append(f"** {line}")
             config.Append('*/')
 
         # Term verbatim output - this will skip over normal term creation
@@ -279,12 +279,12 @@ class Term(aclgenerator.Term):
                 elif opt.startswith('established'):
                     if self.term.protocol == ['tcp']:
                         if 'tcp-established;' not in from_str:
-                            from_str.append(family_keywords['tcp-est'] + ';')
+                            from_str.append(f"{family_keywords['tcp-est']};")
 
                 # if tcp-established specified, but more than just tcp is included
                 # in the protocols, raise an error
                 elif opt.startswith('tcp-established'):
-                    flag = family_keywords['tcp-est'] + ';'
+                    flag = f"{family_keywords['tcp-est']};"
                     if self.term.protocol == ['tcp']:
                         if flag not in from_str:
                             from_str.append(flag)
@@ -466,18 +466,18 @@ class Term(aclgenerator.Term):
             if self.term.source_prefix or self.term.source_prefix_except:
                 config.Append('source-prefix-list {')
                 for pfx in self.term.source_prefix:
-                    config.Append(pfx + ';')
+                    config.Append(f"{pfx};")
                 for epfx in self.term.source_prefix_except:
-                    config.Append(epfx + ' except;')
+                    config.Append(f"{epfx} except;")
                 config.Append('}')
 
             # destination prefix <except> list
             if self.term.destination_prefix or self.term.destination_prefix_except:
                 config.Append('destination-prefix-list {')
                 for pfx in self.term.destination_prefix:
-                    config.Append(pfx + ';')
+                    config.Append(f"{pfx};")
                 for epfx in self.term.destination_prefix_except:
-                    config.Append(epfx + ' except;')
+                    config.Append(f"{epfx} except;")
                 config.Append('}')
 
             # Only generate ttl if inet, inet6 uses hop-limit instead.
@@ -494,7 +494,7 @@ class Term(aclgenerator.Term):
                     protocol[loc] = 'icmp6'
                 # both are supported on JunOS, but only icmp6 is supported
                 # on SRX loopback stateless filter
-                config.Append(family_keywords['protocol'] + ' ' + self._Group(protocol))
+                config.Append(f"{family_keywords['protocol']} {self._Group(protocol)}")
 
             # protocol
             if self.term.protocol_except:
@@ -504,7 +504,7 @@ class Term(aclgenerator.Term):
                     loc = protocol_except.index('icmpv6')
                     protocol_except[loc] = 'icmp6'
                 config.Append(
-                    family_keywords['protocol-except'] + ' ' + self._Group(protocol_except)
+                    f"{family_keywords['protocol-except']} {self._Group(protocol_except)}"
                 )
 
             # port
@@ -709,12 +709,12 @@ class Term(aclgenerator.Term):
             if self.term.encapsulate:
                 config.Append(f'encapsulate {self.term.encapsulate!s};')
             for action in self.extra_actions:
-                config.Append(action + ';')
+                config.Append(f"{action};")
 
             # If there is a routing-instance defined, skip reject/accept/etc actions.
             if not self.term.routing_instance:
                 for action in self.term.action:
-                    config.Append(self.ACTIONS.get(action) + ';')
+                    config.Append(f"{self.ACTIONS.get(action)};")
 
             # DSCP SET
             if self.term.dscp_set:
@@ -870,11 +870,11 @@ class Term(aclgenerator.Term):
                             new_length_eol = length_eol
 
                         # what line am I gunna output?
-                        line = comment + ' ' + text[:new_length_eol].strip()
+                        line = f"{comment} {text[:new_length_eol].strip()}"
                         # truncate what's left
                         text = text[new_length_eol:]
                         # setup the comment and indentation for the next go-round
-                        comment = ' ' * indentation + '**'
+                        comment = f"{' ' * indentation}**"
 
                         rval.append(line)
 
@@ -922,9 +922,9 @@ class Term(aclgenerator.Term):
                 return '%d-%d' % (el[0], el[1])
 
         if len(group) > 1:
-            rval = '[ ' + ' '.join([_FormattedGroup(x) for x in group]) + ' ];'
+            rval = f"[ {' '.join([_FormattedGroup(x) for x in group])} ];"
         else:
-            rval = _FormattedGroup(group[0]) + ';'
+            rval = f"{_FormattedGroup(group[0])};"
         return rval
 
 
@@ -1137,7 +1137,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
             for comment in header.comment:
                 for line in comment.split('\n'):
-                    config.Append('** ' + line)
+                    config.Append(f"** {line}")
             config.Append('*/')
 
             config.Append('replace: filter %s {' % filter_name)
@@ -1155,4 +1155,4 @@ class Juniper(aclgenerator.ACLGenerator):
             config.Append('}')  # family inet { ... }
             config.Append('}')  # firewall { ... }
 
-        return str(config) + '\n'
+        return f"{config!s}\n"

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -571,9 +571,7 @@ class Term(aclgenerator.Term):
             # DSCP Except
             if self.term.dscp_except:
                 if self.term_type == 'inet6':
-                    config.Append(
-                        f"traffic-class-except [ {' '.join(self.term.dscp_except)} ];"
-                    )
+                    config.Append(f"traffic-class-except [ {' '.join(self.term.dscp_except)} ];")
                 else:
                     config.Append(f"dscp-except [ {' '.join(self.term.dscp_except)} ];")
 

--- a/aerleon/lib/juniper.py
+++ b/aerleon/lib/juniper.py
@@ -213,7 +213,7 @@ class Term(aclgenerator.Term):
 
         if self._PLATFORM != 'msmpc':
             if term_type not in self._TERM_TYPE:
-                raise ValueError('Unknown Filter Type: %s' % term_type)
+                raise ValueError(f'Unknown Filter Type: {term_type}')
             if 'hopopt' in self.term.protocol:
                 loc = self.term.protocol.index('hopopt')
                 self.term.protocol[loc] = 'hop-by-hop'
@@ -246,7 +246,7 @@ class Term(aclgenerator.Term):
         # len(output) < 80, etc. Note, if 'noverbose' is set for the filter, skip
         # all comment processing.
         if self.term.owner and not self.noverbose:
-            self.term.comment.append('Owner: %s' % self.term.owner)
+            self.term.comment.append(f'Owner: {self.term.owner}')
         if self.term.comment and not self.noverbose:
             config.Append('/*')
             for comment in self.term.comment:
@@ -305,7 +305,7 @@ class Term(aclgenerator.Term):
                 # we don't have a special way of dealing with this, so we output it and
                 # hope the user knows what they're doing.
                 else:
-                    from_str.append('%s;' % opt)
+                    from_str.append(f'{opt};')
 
         # if the term is inactive we have to set the prefix
         if self.term.inactive:
@@ -318,7 +318,7 @@ class Term(aclgenerator.Term):
 
         # The "filter" keyword is not compatible with from or then
         if self.term.filter_term:
-            config.Append('filter %s;' % self.term.filter_term)
+            config.Append(f'filter {self.term.filter_term};')
             config.Append('}')  # end term accept-foo-to-bar { ... }
             return str(config)
 
@@ -365,11 +365,11 @@ class Term(aclgenerator.Term):
                 config.Append('%s {' % family_keywords['addr'])
                 for addr in address:
                     for comment in self._Comment(addr):
-                        config.Append('%s' % comment)
+                        config.Append(f'{comment}')
                     if self.enable_dsmo:
                         config.Append('%s/%s;' % summarizer.ToDottedQuad(addr, nondsm=True))
                     else:
-                        config.Append('%s;' % addr)
+                        config.Append(f'{addr};')
                 config.Append('}')
             elif self.term.address:
                 if self.filter_type != 'mixed':
@@ -392,18 +392,18 @@ class Term(aclgenerator.Term):
                 config.Append('%s {' % family_keywords['saddr'])
                 for addr in src_addr:
                     for comment in self._Comment(addr):
-                        config.Append('%s' % comment)
+                        config.Append(f'{comment}')
                     if self.enable_dsmo:
                         config.Append('%s/%s;' % summarizer.ToDottedQuad(addr, nondsm=True))
                     else:
-                        config.Append('%s;' % addr)
+                        config.Append(f'{addr};')
                 for addr in src_addr_ex:
                     for comment in self._Comment(addr, exclude=True):
-                        config.Append('%s' % comment)
+                        config.Append(f'{comment}')
                     if self.enable_dsmo:
                         config.Append('%s/%s except;' % summarizer.ToDottedQuad(addr, nondsm=True))
                     else:
-                        config.Append('%s except;' % addr)
+                        config.Append(f'{addr} except;')
                 config.Append('}')
             elif self.term.source_address:
                 if self.filter_type != 'mixed':
@@ -427,18 +427,18 @@ class Term(aclgenerator.Term):
                 config.Append('%s {' % family_keywords['daddr'])
                 for addr in dst_addr:
                     for comment in self._Comment(addr):
-                        config.Append('%s' % comment)
+                        config.Append(f'{comment}')
                     if self.enable_dsmo:
                         config.Append('%s/%s;' % summarizer.ToDottedQuad(addr, nondsm=True))
                     else:
-                        config.Append('%s;' % addr)
+                        config.Append(f'{addr};')
                 for addr in dst_addr_ex:
                     for comment in self._Comment(addr, exclude=True):
-                        config.Append('%s' % comment)
+                        config.Append(f'{comment}')
                     if self.enable_dsmo:
                         config.Append('%s/%s except;' % summarizer.ToDottedQuad(addr, nondsm=True))
                     else:
-                        config.Append('%s except;' % addr)
+                        config.Append(f'{addr} except;')
                 config.Append('}')
             elif self.term.destination_address:
                 if self.filter_type != 'mixed':
@@ -452,7 +452,7 @@ class Term(aclgenerator.Term):
             # forwarding-class
             if self.term.forwarding_class:
                 config.Append(
-                    'forwarding-class %s' % self._Group(self.term.forwarding_class, lc=False)
+                    f'forwarding-class {self._Group(self.term.forwarding_class, lc=False)}'
                 )
 
             # forwarding-class-except
@@ -482,7 +482,7 @@ class Term(aclgenerator.Term):
 
             # Only generate ttl if inet, inet6 uses hop-limit instead.
             if self.term.ttl and self.term_type == 'inet':
-                config.Append('ttl %s;' % self.term.ttl)
+                config.Append(f'ttl {self.term.ttl};')
 
             # protocol
             if self.term.protocol:
@@ -509,15 +509,15 @@ class Term(aclgenerator.Term):
 
             # port
             if self.term.port:
-                config.Append('port %s' % self._Group(self.term.port))
+                config.Append(f'port {self._Group(self.term.port)}')
 
             # source port
             if self.term.source_port:
-                config.Append('source-port %s' % self._Group(self.term.source_port))
+                config.Append(f'source-port {self._Group(self.term.source_port)}')
 
             # destination port
             if self.term.destination_port:
-                config.Append('destination-port %s' % self._Group(self.term.destination_port))
+                config.Append(f'destination-port {self._Group(self.term.destination_port)}')
 
             # append any options beloging in the from {} section
             for next_str in from_str:
@@ -525,11 +525,11 @@ class Term(aclgenerator.Term):
 
             # packet length
             if self.term.packet_length:
-                config.Append('packet-length %s;' % self.term.packet_length)
+                config.Append(f'packet-length {self.term.packet_length};')
 
             # fragment offset
             if self.term.fragment_offset:
-                config.Append('fragment-offset %s;' % self.term.fragment_offset)
+                config.Append(f'fragment-offset {self.term.fragment_offset};')
 
             # icmp-types
             icmp_types = ['']
@@ -538,14 +538,14 @@ class Term(aclgenerator.Term):
                     self.term.icmp_type, self.term.protocol, self.term_type
                 )
             if icmp_types != ['']:
-                config.Append('icmp-type %s' % self._Group(icmp_types))
+                config.Append(f'icmp-type {self._Group(icmp_types)}')
             if self.term.icmp_code:
-                config.Append('icmp-code %s' % self._Group(self.term.icmp_code))
+                config.Append(f'icmp-code {self._Group(self.term.icmp_code)}')
             if self.term.ether_type:
-                config.Append('ether-type %s' % self._Group(self.term.ether_type))
+                config.Append(f'ether-type {self._Group(self.term.ether_type)}')
 
             if self.term.traffic_type:
-                config.Append('traffic-type %s' % self._Group(self.term.traffic_type))
+                config.Append(f'traffic-type {self._Group(self.term.traffic_type)}')
 
             if self.term.precedence:
                 # precedence may be a single integer, or a space separated list
@@ -559,28 +559,28 @@ class Term(aclgenerator.Term):
                             'Precedence value %s is out of bounds in %s'
                             % (precedence, self.term.name)
                         )
-                config.Append('precedence %s' % self._Group(sorted(policy_precedences)))
+                config.Append(f'precedence {self._Group(sorted(policy_precedences))}')
 
             # DSCP Match
             if self.term.dscp_match:
                 if self.term_type == 'inet6':
-                    config.Append('traffic-class [ %s ];' % (' '.join(self.term.dscp_match)))
+                    config.Append(f"traffic-class [ {' '.join(self.term.dscp_match)} ];")
                 else:
-                    config.Append('dscp [ %s ];' % ' '.join(self.term.dscp_match))
+                    config.Append(f"dscp [ {' '.join(self.term.dscp_match)} ];")
 
             # DSCP Except
             if self.term.dscp_except:
                 if self.term_type == 'inet6':
                     config.Append(
-                        'traffic-class-except [ %s ];' % (' '.join(self.term.dscp_except))
+                        f"traffic-class-except [ {' '.join(self.term.dscp_except)} ];"
                     )
                 else:
-                    config.Append('dscp-except [ %s ];' % ' '.join(self.term.dscp_except))
+                    config.Append(f"dscp-except [ {' '.join(self.term.dscp_except)} ];")
 
             if self.term.hop_limit:
                 # Only generate a hop-limit if inet6, inet4 has not hop-limit.
                 if self.term_type == 'inet6':
-                    config.Append('hop-limit %s;' % (self.term.hop_limit))
+                    config.Append(f'hop-limit {self.term.hop_limit};')
 
             # flexible-match
             if self.term.flexible_match_range:
@@ -645,22 +645,22 @@ class Term(aclgenerator.Term):
                 and current_action in ['discard', 'reject', 'reject tcp-reset']
             ) or (self.term_type == 'inet6' and current_action in ['reject', 'reject tcp-reset']):
                 config.Append('then {')
-                config.Append('%s;' % current_action)
+                config.Append(f'{current_action};')
                 config.Append('}')
             elif current_action == 'next_ip':
                 self.NextIpCheck(self.term.next_ip, self.term.name)
                 config.Append('then {')
                 if self.term.next_ip[0].version == 4:
-                    config.Append('next-ip %s;' % str(self.term.next_ip[0]))
+                    config.Append(f'next-ip {self.term.next_ip[0]!s};')
                 else:
-                    config.Append('next-ip6 %s;' % str(self.term.next_ip[0]))
+                    config.Append(f'next-ip6 {self.term.next_ip[0]!s};')
                 config.Append('}')
             elif current_action == 'encapsulate':
                 config.Append('then {')
-                config.Append('encapsulate %s;' % str(self.term.encapsulate))
+                config.Append(f'encapsulate {self.term.encapsulate!s};')
                 config.Append('}')
             else:
-                config.Append('then %s;' % current_action)
+                config.Append(f'then {current_action};')
         elif len(unique_actions) > 1:
             config.Append('then {')
             # logging
@@ -672,17 +672,17 @@ class Term(aclgenerator.Term):
                         config.Append('syslog;')
 
             if self.term.routing_instance:
-                config.Append('routing-instance %s;' % self.term.routing_instance)
+                config.Append(f'routing-instance {self.term.routing_instance};')
 
             if self.term.counter:
-                config.Append('count %s;' % self.term.counter)
+                config.Append(f'count {self.term.counter};')
 
             if self.term.traffic_class_count:
-                config.Append('traffic-class-count %s;' % self.term.traffic_class_count)
+                config.Append(f'traffic-class-count {self.term.traffic_class_count};')
 
             oid_length = 128
             if self.term.policer:
-                config.Append('policer %s;' % self.term.policer)
+                config.Append(f'policer {self.term.policer};')
                 if len(self.term.policer) > oid_length:
                     logging.warning(
                         'WARNING: %s is longer than %d bytes. Due to '
@@ -694,20 +694,20 @@ class Term(aclgenerator.Term):
                     )
 
             if self.term.qos:
-                config.Append('forwarding-class %s;' % self.term.qos)
+                config.Append(f'forwarding-class {self.term.qos};')
 
             if self.term.port_mirror:
                 config.Append('port-mirror;')
             if self.term.loss_priority:
-                config.Append('loss-priority %s;' % self.term.loss_priority)
+                config.Append(f'loss-priority {self.term.loss_priority};')
             if self.term.next_ip:
                 self.NextIpCheck(self.term.next_ip, self.term.name)
                 if self.term.next_ip[0].version == 4:
-                    config.Append('next-ip %s;' % str(self.term.next_ip[0]))
+                    config.Append(f'next-ip {self.term.next_ip[0]!s};')
                 else:
-                    config.Append('next-ip6 %s;' % str(self.term.next_ip[0]))
+                    config.Append(f'next-ip6 {self.term.next_ip[0]!s};')
             if self.term.encapsulate:
-                config.Append('encapsulate %s;' % str(self.term.encapsulate))
+                config.Append(f'encapsulate {self.term.encapsulate!s};')
             for action in self.extra_actions:
                 config.Append(action + ';')
 
@@ -719,9 +719,9 @@ class Term(aclgenerator.Term):
             # DSCP SET
             if self.term.dscp_set:
                 if self.term_type == 'inet6':
-                    config.Append('traffic-class %s;' % self.term.dscp_set)
+                    config.Append(f'traffic-class {self.term.dscp_set};')
                 else:
-                    config.Append('dscp %s;' % self.term.dscp_set)
+                    config.Append(f'dscp {self.term.dscp_set};')
 
             config.Append('}')  # end then{...}
 
@@ -733,11 +733,11 @@ class Term(aclgenerator.Term):
     def NextIpCheck(next_ip: list[Union[nacaddr.IPv4, nacaddr.IPv6]], term_name: str):
         if len(next_ip) > 1:
             raise JuniperNextIpError(
-                'The following term has more ' 'than one next IP value: %s' % term_name
+                f'The following term has more than one next IP value: {term_name}'
             )
         if next_ip[0].num_addresses > 1:
             raise JuniperNextIpError(
-                'The following term has a subnet ' 'instead of a host: %s' % term_name
+                f'The following term has a subnet instead of a host: {term_name}'
             )
 
     def CheckTerminatingAction(self):
@@ -748,7 +748,7 @@ class Term(aclgenerator.Term):
             action.add(self.term.routing_instance)
         if len(action) > 1:
             raise JuniperMultipleTerminatingActionError(
-                'The following term has multiple terminating actions: %s' % self.term.name
+                f'The following term has multiple terminating actions: {self.term.name}'
             )
 
     def _MinimizePrefixes(
@@ -1075,7 +1075,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
                     if term.name in term_names:
                         raise JuniperDuplicateTermError(
-                            'You have multiple terms named: %s' % term.name
+                            f'You have multiple terms named: {term.name}'
                         )
                     term_names.add(term.name)
 
@@ -1085,7 +1085,7 @@ class Juniper(aclgenerator.ACLGenerator):
 
                     if 'is-fragment' in term.option and term_filter_type == 'inet6':
                         raise JuniperFragmentInV6Error(
-                            'The term %s uses "is-fragment" but ' 'is a v6 policy.' % term.name
+                            f'The term {term.name} uses "is-fragment" but is a v6 policy.'
                         )
 
                     new_terms.append(

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -443,9 +443,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                     num_terms = len(app['protocol']) * len(app['icmp-type'])
                     apps_set_list.append(f"application-set {app['name']}-app {{")
                     for i in range(num_terms):
-                        apps_set_list.append(
-                            f"application {app['name']}{'-app%d' % (i + 1)};"
-                        )
+                        apps_set_list.append(f"application {app['name']}{'-app%d' % (i + 1)};")
                     apps_set_list.append('}')  # application-set {...}
 
                     term_counter = 0
@@ -459,9 +457,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                             target.append(f'protocol {proto};')
                             target.append(f'{proto}-type {str(code)};')
                             if app['icmp-code']:
-                                target.append(
-                                    f"{proto}-code {self._Group(app['icmp-code'])};"
-                                )
+                                target.append(f"{proto}-code {self._Group(app['icmp-code'])};")
                             if int(timeout):
                                 target.append(f'inactivity-timeout {int(timeout)};')
                             target.append('}')  # application {...}

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -98,7 +98,7 @@ class Term(juniper.Term):
                 ret_str.Append('/*')
                 for comment in self.term.comment:
                     for line in comment.split('\n'):
-                        ret_str.Append('** ' + line)
+                        ret_str.Append(f"** {line}")
                 ret_str.Append('*/')
 
         # Term verbatim output - this will skip over normal term creation
@@ -228,7 +228,7 @@ class Term(juniper.Term):
 
             ret_str.Append(
                 '%s term %s%s {'
-                % (term_prefix, self.term.name, '-' + suffix if duplicate_term else '')
+                % (term_prefix, self.term.name, f"-{suffix}" if duplicate_term else '')
             )
 
             # We only need a "from {" clause if there are any conditions to match.
@@ -303,16 +303,16 @@ class Term(juniper.Term):
                 # source prefix <except> list
                 if self.term.source_prefix or self.term.source_prefix_except:
                     for pfx in self.term.source_prefix:
-                        ret_str.Append('source-prefix-list ' + pfx + ';')
+                        ret_str.Append(f"source-prefix-list {pfx};")
                     for epfx in self.term.source_prefix_except:
-                        ret_str.Append('source-prefix-list ' + epfx + ' except;')
+                        ret_str.Append(f"source-prefix-list {epfx} except;")
 
                 # destination prefix <except> list
                 if self.term.destination_prefix or self.term.destination_prefix_except:
                     for pfx in self.term.destination_prefix:
-                        ret_str.Append('destination-prefix-list ' + pfx + ';')
+                        ret_str.Append(f"destination-prefix-list {pfx};")
                     for epfx in self.term.destination_prefix_except:
-                        ret_str.Append('destination-prefix-list ' + epfx + ' except;')
+                        ret_str.Append(f"destination-prefix-list {epfx} except;")
 
                 # APPLICATION
                 if (
@@ -323,7 +323,7 @@ class Term(juniper.Term):
                 ):
                     if hasattr(self.term, 'replacement_application_name'):
                         ret_str.Append(
-                            'application-sets ' + self.term.replacement_application_name + '-app;'
+                            f"application-sets {self.term.replacement_application_name}-app;"
                         )
                     else:
                         ret_str.Append(
@@ -337,7 +337,7 @@ class Term(juniper.Term):
             ret_str.Append('then {')
             # ACTION
             for action in self.term.action:
-                ret_str.Append(self._ACTIONS.get(str(action)) + ';')
+                ret_str.Append(f"{self._ACTIONS.get(str(action))};")
             if self.term.logging and 'disable' not in [x.value for x in self.term.logging]:
                 ret_str.Append('syslog;')
             ret_str.Append('}')  # then {...}
@@ -441,10 +441,10 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                     else:
                         timeout = 60
                     num_terms = len(app['protocol']) * len(app['icmp-type'])
-                    apps_set_list.append('application-set ' + app['name'] + '-app {')
+                    apps_set_list.append(f"application-set {app['name']}-app {{")
                     for i in range(num_terms):
                         apps_set_list.append(
-                            'application ' + app['name'] + '-app%d' % (i + 1) + ';'
+                            f"application {app['name']}{'-app%d' % (i + 1)};"
                         )
                     apps_set_list.append('}')  # application-set {...}
 
@@ -452,7 +452,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                     for i, code in enumerate(app['icmp-type']):
                         for proto in app['protocol']:
                             target.append(
-                                'application ' + app['name'] + '-app%d' % (term_counter + 1) + ' {'
+                                f"application {app['name']}{'-app%d' % (term_counter + 1)} {{"
                             )
                             if proto == 'icmp':
                                 target.append(f'application-protocol {proto};')
@@ -469,7 +469,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                 # generate non-ICMP statements
                 else:
                     i = 1
-                    apps_set_list.append('application-set ' + app['name'] + '-app {')
+                    apps_set_list.append(f"application-set {app['name']}-app {{")
 
                     for proto in app['protocol'] or ['']:
                         for sport in app['sport'] or ['']:
@@ -485,9 +485,9 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                                     chunks.append(f" inactivity-timeout {int(app['timeout'])};")
                                 if chunks:
                                     apps_set_list.append(
-                                        'application ' + app['name'] + '-app%d;' % i
+                                        f"application {app['name']}{'-app%d;' % i}"
                                     )
-                                    app_list.append('application ' + app['name'] + '-app%d {' % i)
+                                    app_list.append(f"application {app['name']}{'-app%d {' % i}")
                                     for chunk in chunks:
                                         app_list.append(chunk)
                                     app_list.append('}')
@@ -690,9 +690,9 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                 return '%d-%d' % (el[0], el[1])
 
         if len(group) > 1:
-            rval = '[ ' + ' '.join([_FormattedGroup(x, lc=lc) for x in group]) + ' ];'
+            rval = f"[ {' '.join([_FormattedGroup(x, lc=lc) for x in group])} ];"
         else:
-            rval = _FormattedGroup(group[0], lc=lc) + ';'
+            rval = f"{_FormattedGroup(group[0], lc=lc)};"
         return rval
 
     def __str__(self) -> str:
@@ -719,7 +719,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
 
             for comment in header.comment:
                 for line in comment.split('\n'):
-                    target.Append('** ' + line)
+                    target.Append(f"** {line}")
             target.Append('*/')
 
             if apply_groups:
@@ -741,7 +741,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                 target.Append('}')  # filter_name { ... }
                 target.Append('}')  # groups { ... }
                 target.Append(f'apply-groups {filter_name};')
-        return str(target) + '\n'
+        return f"{target!s}\n"
 
 
 class Error(juniper.Error):

--- a/aerleon/lib/junipermsmpc.py
+++ b/aerleon/lib/junipermsmpc.py
@@ -93,7 +93,7 @@ class Term(juniper.Term):
         # all comment processing.
         if not self.noverbose:
             if self.term.owner:
-                self.term.comment.append('Owner: %s' % self.term.owner)
+                self.term.comment.append(f'Owner: {self.term.owner}')
             if self.term.comment:
                 ret_str.Append('/*')
                 for comment in self.term.comment:
@@ -240,31 +240,31 @@ class Term(juniper.Term):
                     if source_address:
                         for saddr in source_address:
                             for comment in self._Comment(saddr):
-                                ret_str.Append('%s' % comment)
+                                ret_str.Append(f'{comment}')
                             if saddr.version == 6 and 0 < saddr.prefixlen < 16:
                                 for saddr2 in saddr.subnets(new_prefix=16):
-                                    ret_str.Append('%s;' % saddr2)
+                                    ret_str.Append(f'{saddr2};')
                             else:
                                 if saddr == nacaddr.IPv6('0::0/0'):
                                     saddr = 'any-ipv6'
                                 elif saddr == nacaddr.IPv4('0.0.0.0/0'):
                                     saddr = 'any-ipv4'
-                                ret_str.Append('%s;' % saddr)
+                                ret_str.Append(f'{saddr};')
 
                     # SOURCE ADDRESS EXCLUDE
                     if source_address_exclude:
                         for ex in source_address_exclude:
                             for comment in self._Comment(ex):
-                                ret_str.Append('%s' % comment)
+                                ret_str.Append(f'{comment}')
                             if ex.version == 6 and 0 < ex.prefixlen < 16:
                                 for ex2 in ex.subnets(new_prefix=16):
-                                    ret_str.Append('%s except;' % ex2)
+                                    ret_str.Append(f'{ex2} except;')
                             else:
                                 if ex == nacaddr.IPv6('0::0/0'):
                                     ex = 'any-ipv6'
                                 elif ex == nacaddr.IPv4('0.0.0.0/0'):
                                     ex = 'any-ipv4'
-                                ret_str.Append('%s except;' % ex)
+                                ret_str.Append(f'{ex} except;')
                     ret_str.Append('}')  # source-address {...}
 
                 # DESTINATION ADDRESS
@@ -273,31 +273,31 @@ class Term(juniper.Term):
                     if destination_address:
                         for daddr in destination_address:
                             for comment in self._Comment(daddr):
-                                ret_str.Append('%s' % comment)
+                                ret_str.Append(f'{comment}')
                             if daddr.version == 6 and 0 < daddr.prefixlen < 16:
                                 for daddr2 in daddr.subnets(new_prefix=16):
-                                    ret_str.Append('%s;' % daddr2)
+                                    ret_str.Append(f'{daddr2};')
                             else:
                                 if daddr == nacaddr.IPv6('0::0/0'):
                                     daddr = 'any-ipv6'
                                 elif daddr == nacaddr.IPv4('0.0.0.0/0'):
                                     daddr = 'any-ipv4'
-                                ret_str.Append('%s;' % daddr)
+                                ret_str.Append(f'{daddr};')
 
                     # DESTINATION ADDRESS EXCLUDE
                     if destination_address_exclude:
                         for ex in destination_address_exclude:
                             for comment in self._Comment(ex):
-                                ret_str.Append('%s' % comment)
+                                ret_str.Append(f'{comment}')
                             if ex.version == 6 and 0 < ex.prefixlen < 16:
                                 for ex2 in ex.subnets(new_prefix=16):
-                                    ret_str.Append('%s except;' % ex2)
+                                    ret_str.Append(f'{ex2} except;')
                             else:
                                 if ex == nacaddr.IPv6('0::0/0'):
                                     ex = 'any-ipv6'
                                 elif ex == nacaddr.IPv4('0.0.0.0/0'):
                                     ex = 'any-ipv4'
-                                ret_str.Append('%s except;' % ex)
+                                ret_str.Append(f'{ex} except;')
                     ret_str.Append('}')  # destination-address {...}
 
                 # source prefix <except> list
@@ -455,15 +455,15 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                                 'application ' + app['name'] + '-app%d' % (term_counter + 1) + ' {'
                             )
                             if proto == 'icmp':
-                                target.append('application-protocol %s;' % proto)
-                            target.append('protocol %s;' % proto)
+                                target.append(f'application-protocol {proto};')
+                            target.append(f'protocol {proto};')
                             target.append(f'{proto}-type {str(code)};')
                             if app['icmp-code']:
                                 target.append(
-                                    '{}-code {};'.format(proto, self._Group(app['icmp-code']))
+                                    f"{proto}-code {self._Group(app['icmp-code'])};"
                                 )
                             if int(timeout):
-                                target.append('inactivity-timeout %s;' % int(timeout))
+                                target.append(f'inactivity-timeout {int(timeout)};')
                             target.append('}')  # application {...}
                             term_counter += 1
                 # generate non-ICMP statements
@@ -476,13 +476,13 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                             for dport in app['dport'] or ['']:
                                 chunks = []
                                 if proto:
-                                    chunks.append('protocol %s;' % proto)
+                                    chunks.append(f'protocol {proto};')
                                 if sport and ('udp' in proto or 'tcp' in proto):
-                                    chunks.append('source-port %s;' % sport)
+                                    chunks.append(f'source-port {sport};')
                                 if dport and ('udp' in proto or 'tcp' in proto):
-                                    chunks.append('destination-port %s;' % dport)
+                                    chunks.append(f'destination-port {dport};')
                                 if app['timeout']:
-                                    chunks.append(' inactivity-timeout %d;' % int(app['timeout']))
+                                    chunks.append(f" inactivity-timeout {int(app['timeout'])};")
                                 if chunks:
                                     apps_set_list.append(
                                         'application ' + app['name'] + '-app%d;' % i
@@ -641,7 +641,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
                         and new_application_set != application_set
                     ):
                         raise ConflictingApplicationSetsError(
-                            'Application set %s has a conflicting entry' % modified_term_name
+                            f'Application set {modified_term_name} has a conflicting entry'
                         )
 
                 if new_application_set:
@@ -727,7 +727,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
             target.Append('services {')
             target.Append('stateful-firewall {')
             target.Append('rule %s {' % filter_name)
-            target.Append('match-direction %s;' % filter_direction)
+            target.Append(f'match-direction {filter_direction};')
             for term in terms:
                 term_str = str(term)
                 if term_str:
@@ -740,7 +740,7 @@ class JuniperMSMPC(aclgenerator.ACLGenerator):
             if apply_groups:
                 target.Append('}')  # filter_name { ... }
                 target.Append('}')  # groups { ... }
-                target.Append('apply-groups %s;' % filter_name)
+                target.Append(f'apply-groups {filter_name};')
         return str(target) + '\n'
 
 

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -131,7 +131,7 @@ class Term(aclgenerator.Term):
                 ret_str.IndentAppend(3, line)
             ret_str.IndentAppend(3, '*/')
 
-        ret_str.IndentAppend(3, 'policy ' + self.term.name + ' {')
+        ret_str.IndentAppend(3, f"policy {self.term.name} {{")
         ret_str.IndentAppend(4, 'match {')
         # SOURCE-ADDRESS
         saddrs = {i.parent_token for i in self.term.source_address}
@@ -160,10 +160,10 @@ class Term(aclgenerator.Term):
         else:
             if hasattr(self.term, 'replacement_application_name'):
                 ret_str.IndentAppend(
-                    5, 'application ' + self.term.replacement_application_name + '-app;'
+                    5, f"application {self.term.replacement_application_name}-app;"
                 )
             else:
-                ret_str.IndentAppend(5, 'application ' + self.term.name + '-app;')
+                ret_str.IndentAppend(5, f"application {self.term.name}-app;")
 
         # DSCP MATCH
         if self.term.dscp_match:
@@ -197,7 +197,7 @@ class Term(aclgenerator.Term):
 
             # VPN target can be only specified when ACTION is accept
             if str(action) == 'accept' and self.term.vpn:
-                ret_str.IndentAppend(5, self.ACTIONS.get(str(action)) + ' {')
+                ret_str.IndentAppend(5, f"{self.ACTIONS.get(str(action))} {{")
                 ret_str.IndentAppend(6, 'tunnel {')
                 ret_str.IndentAppend(7, f'ipsec-vpn {self.term.vpn[0]};')
                 if self.term.vpn[1]:
@@ -206,11 +206,11 @@ class Term(aclgenerator.Term):
                 ret_str.IndentAppend(6, '}')
                 ret_str.IndentAppend(5, '}')
             else:
-                ret_str.IndentAppend(5, self.ACTIONS.get(str(action)) + ';')
+                ret_str.IndentAppend(5, f"{self.ACTIONS.get(str(action))};")
 
             # DSCP SET
             if self.term.dscp_set:
-                ret_str.IndentAppend(5, 'dscp ' + self.term.dscp_set + ';')
+                ret_str.IndentAppend(5, f"dscp {self.term.dscp_set};")
 
             # LOGGING
             if self.term.logging:
@@ -265,9 +265,9 @@ class Term(aclgenerator.Term):
                 return '%d-%d' % (el[0], el[1])
 
         if len(group) > 1:
-            rval = '[ ' + ' '.join([_FormattedGroup(x) for x in group]) + ' ];'
+            rval = f"[ {' '.join([_FormattedGroup(x) for x in group])} ];"
         else:
-            rval = _FormattedGroup(group[0]) + ';'
+            rval = f"{_FormattedGroup(group[0])};"
         return rval
 
 
@@ -500,7 +500,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                             nacaddr.IP('0.0.0.0/0', term.name.upper(), term.name.upper())
                         ]
                     # Use the term name as the token & parent_token
-                    new_src_parent_token = term.name.upper() + '_SRC_EXCLUDE'
+                    new_src_parent_token = f"{term.name.upper()}_SRC_EXCLUDE"
                     new_src_token = new_src_parent_token
                     for i in term.source_address_exclude:
                         term.source_address = nacaddr.RemoveAddressFromList(term.source_address, i)
@@ -513,7 +513,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                         term.destination_address = [
                             nacaddr.IP('0.0.0.0/0', term.name.upper(), term.name.upper())
                         ]
-                    new_dst_parent_token = term.name.upper() + '_DST_EXCLUDE'
+                    new_dst_parent_token = f"{term.name.upper()}_DST_EXCLUDE"
                     new_dst_token = new_dst_parent_token
                     for i in term.destination_address_exclude:
                         term.destination_address = nacaddr.RemoveAddressFromList(
@@ -659,13 +659,13 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                 counter = 0
                 for chunk in src_chunks:
                     for ip in chunk:
-                        ip.parent_token = 'src_' + term.name + str(counter)
+                        ip.parent_token = f"src_{term.name}{counter!s}"
                     counter += 1
                 dst_chunks = Chunks(term.destination_address)
                 counter = 0
                 for chunk in dst_chunks:
                     for ip in chunk:
-                        ip.parent_token = 'dst_' + term.name + str(counter)
+                        ip.parent_token = f"dst_{term.name}{counter!s}"
                     counter += 1
 
                 src_dst_products = itertools.product(src_chunks, dst_chunks)
@@ -674,7 +674,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     new_term = copy.copy(term)
                     new_term.source_address = src_dst_list[0]
                     new_term.destination_address = src_dst_list[1]
-                    new_term.name = new_term.name + '_' + str(counter)
+                    new_term.name = f"{new_term.name}_{counter!s}"
                     expanded_terms.append(new_term)
                     counter += 1
             else:
@@ -706,7 +706,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
         ips = nacaddr.SortAddrList(ips)
         ips = nacaddr.CollapseAddrList(ips)
         for ip in ips:
-            target.IndentAppend(4, 'address ' + token + '_' + str(counter) + ' ' + str(ip) + ';')
+            target.IndentAppend(4, f"address {token}_{counter!s} {ip!s};")
             counter += 1
         for fqdn in fqdns:
             target.IndentAppend(4, f'address {token}_{counter} {{')
@@ -716,13 +716,13 @@ class JuniperSRX(aclgenerator.ACLGenerator):
 
     def _GenerateAddressSets(self, group, ips, fqdns) -> IndentList:
         target = IndentList(self.INDENT)
-        target.IndentAppend(4, 'address-set ' + group + ' {')
+        target.IndentAppend(4, f"address-set {group} {{")
         counter = 0
         for _ in nacaddr.CollapseAddrList(ips):
-            target.IndentAppend(5, 'address ' + group + '_' + str(counter) + ';')
+            target.IndentAppend(5, f"address {group}_{counter!s};")
             counter += 1
         for _ in fqdns:
-            target.IndentAppend(5, 'address ' + group + '_' + str(counter) + ';')
+            target.IndentAppend(5, f"address {group}_{counter!s};")
             counter += 1
         target.IndentAppend(4, '}')
         return target
@@ -755,7 +755,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
             target.IndentAppend(1, 'zones {')
             zones = self.addressbook.GetZoneNames()
             for zone in zones:
-                target.IndentAppend(2, 'security-zone ' + zone + ' {')
+                target.IndentAppend(2, f"security-zone {zone} {{")
                 target.IndentAppend(3, 'replace: address-book {')
                 for _, group, ips, fqdns in self.addressbook.Walk(zone):
                     target.extend(self._GenerateAddresses(group, ips, fqdns))
@@ -788,14 +788,14 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     # we need.
                     num_terms = len(app['protocol']) * len(app['icmp-type'])
                     if num_terms > ICMP_TERM_LIMIT:
-                        target.IndentAppend(1, 'application-set ' + app['name'] + '-app {')
+                        target.IndentAppend(1, f"application-set {app['name']}-app {{")
                         for i in range(num_terms):
                             target.IndentAppend(
-                                2, 'application ' + app['name'] + '-app%d' % (i + 1) + ';'
+                                2, f"application {app['name']}{'-app%d' % (i + 1)};"
                             )
                         target.IndentAppend(1, '}')
                     else:
-                        target.IndentAppend(1, 'application ' + app['name'] + '-app {')
+                        target.IndentAppend(1, f"application {app['name']}-app {{")
 
                     term_counter = 0
                     for i, code in enumerate(app['icmp-type']):
@@ -828,7 +828,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                 # generate non-ICMP statements
                 else:
                     i = 1
-                    apps_set_list.IndentAppend(1, 'application-set ' + app['name'] + '-app {')
+                    apps_set_list.IndentAppend(1, f"application-set {app['name']}-app {{")
 
                     for proto in app['protocol'] or ['']:
                         for sport in app['sport'] or ['']:
@@ -847,14 +847,14 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                                     chunks.append(f" inactivity-timeout {int(app['timeout'])}")
                                 if chunks:
                                     apps_set_list.IndentAppend(
-                                        2, 'application ' + app['name'] + '-app%d;' % i
+                                        2, f"application {app['name']}{'-app%d;' % i}"
                                     )
                                     app_list.IndentAppend(
-                                        1, 'application ' + app['name'] + '-app%d {' % i
+                                        1, f"application {app['name']}{'-app%d {' % i}"
                                     )
 
                                     app_list.IndentAppend(
-                                        2, 'term t%d' % i + ''.join(chunks) + ';'
+                                        2, f"{'term t%d' % i}{''.join(chunks)};"
                                     )
                                     app_list.IndentAppend(1, '}')
                                     i += 1
@@ -906,7 +906,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                 target.IndentAppend(2, 'global {')
             else:
                 target.IndentAppend(
-                    2, 'from-zone ' + filter_options[1] + ' to-zone ' + filter_options[3] + ' {'
+                    2, f"from-zone {filter_options[1]} to-zone {filter_options[3]} {{"
                 )
 
             # GROUPS

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -32,7 +32,7 @@ FQDNSUFFIX = '_FQDN'
 
 
 def JunipersrxList(name, data):
-    return '{} [ {} ];'.format(name, ' '.join(data))
+    return f"{name} [ {' '.join(data)} ];"
 
 
 class Error(aclgenerator.Error):
@@ -123,7 +123,7 @@ class Term(aclgenerator.Term):
         # COMMENTS
         comment_max_width = 68
         if self.term.owner and self.verbose:
-            self.term.comment.append('Owner: %s' % self.term.owner)
+            self.term.comment.append(f'Owner: {self.term.owner}')
         comments = aclgenerator.WrapWords(self.term.comment, comment_max_width)
         if comments and comments[0] and self.verbose:
             ret_str.IndentAppend(3, '/*')
@@ -199,9 +199,9 @@ class Term(aclgenerator.Term):
             if str(action) == 'accept' and self.term.vpn:
                 ret_str.IndentAppend(5, self.ACTIONS.get(str(action)) + ' {')
                 ret_str.IndentAppend(6, 'tunnel {')
-                ret_str.IndentAppend(7, 'ipsec-vpn %s;' % self.term.vpn[0])
+                ret_str.IndentAppend(7, f'ipsec-vpn {self.term.vpn[0]};')
                 if self.term.vpn[1]:
-                    ret_str.IndentAppend(7, 'pair-policy %s;' % self.term.vpn[1])
+                    ret_str.IndentAppend(7, f'pair-policy {self.term.vpn[1]};')
 
                 ret_str.IndentAppend(6, '}')
                 ret_str.IndentAppend(5, '}')
@@ -487,7 +487,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                     continue
                 term.name = self.FixTermLength(term.name)
                 if term.name in term_dup_check:
-                    raise SRXDuplicateTermError('You have a duplicate term: %s' % term.name)
+                    raise SRXDuplicateTermError(f'You have a duplicate term: {term.name}')
                 term_dup_check.add(term.name)
 
                 # SRX address books leverage network token names for IPs.
@@ -612,7 +612,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                         and new_application_set != application_set
                     ):
                         raise ConflictingApplicationSetsError(
-                            'Application set %s has a conflicting entry' % term.name
+                            f'Application set {term.name} has a conflicting entry'
                         )
 
                 if new_application_set:
@@ -838,13 +838,13 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                                     # SRX does not like proto vrrp
                                     if proto == 'vrrp':
                                         proto = '112'
-                                    chunks.append(' protocol %s' % proto)
+                                    chunks.append(f' protocol {proto}')
                                 if sport:
-                                    chunks.append(' source-port %s' % sport)
+                                    chunks.append(f' source-port {sport}')
                                 if dport:
-                                    chunks.append(' destination-port %s' % dport)
+                                    chunks.append(f' destination-port {dport}')
                                 if app['timeout']:
-                                    chunks.append(' inactivity-timeout %d' % int(app['timeout']))
+                                    chunks.append(f" inactivity-timeout {int(app['timeout'])}")
                                 if chunks:
                                     apps_set_list.IndentAppend(
                                         2, 'application ' + app['name'] + '-app%d;' % i

--- a/aerleon/lib/junipersrx.py
+++ b/aerleon/lib/junipersrx.py
@@ -853,9 +853,7 @@ class JuniperSRX(aclgenerator.ACLGenerator):
                                         1, f"application {app['name']}{'-app%d {' % i}"
                                     )
 
-                                    app_list.IndentAppend(
-                                        2, f"{'term t%d' % i}{''.join(chunks)};"
-                                    )
+                                    app_list.IndentAppend(2, f"{'term t%d' % i}{''.join(chunks)};")
                                     app_list.IndentAppend(1, '}')
                                     i += 1
                     apps_set_list.IndentAppend(1, '}')

--- a/aerleon/lib/k8s.py
+++ b/aerleon/lib/k8s.py
@@ -394,7 +394,7 @@ class K8s(aclgenerator.ACLGenerator):
                     term.name += '-e'
                 term.name = self.FixTermLength(term.name)
                 if term.name in term_names:
-                    raise K8sNetworkPolicyError('Duplicate term name %s' % term.name)
+                    raise K8sNetworkPolicyError(f'Duplicate term name {term.name}')
                 term_names.add(term.name)
 
                 term.direction = direction

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -54,7 +54,7 @@ def IP(
         return IPv4(ip, comment, token, strict=strict)
     elif imprecise_ip.version == 6:
         return IPv6(ip, comment, token, strict=strict)
-    raise ValueError('Provided IP string "%s" is not a valid v4 or v6 address' % ip)
+    raise ValueError(f'Provided IP string "{ip}" is not a valid v4 or v6 address')
 
 
 # TODO(robankeny) remove once at 3.7

--- a/aerleon/lib/nacaddr.py
+++ b/aerleon/lib/nacaddr.py
@@ -125,7 +125,7 @@ class IPv4(ipaddress.IPv4Network):
         """
         if self.text:
             if comment and comment not in self.text:
-                self.text += ', ' + comment
+                self.text += f", {comment}"
         else:
             self.text = comment
 
@@ -247,7 +247,7 @@ class IPv6(ipaddress.IPv6Network):
         """
         if self.text:
             if comment and comment not in self.text:
-                self.text += ', ' + comment
+                self.text += f", {comment}"
         else:
             self.text = comment
 

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -481,7 +481,7 @@ class Naming:
           service tokens.
         """
         # turn the given port and protocol into a PortProtocolPair object
-        given_ppp = portlib.PPP(query + '/' + proto)
+        given_ppp = portlib.PPP(f"{query}/{proto}")
         base_parents = []
         matches = set()
         # check each service token to see if it's a PPP or a nested group.
@@ -789,7 +789,7 @@ class Naming:
             if not self.current_symbol:
                 break
             if comment:
-                self.unit.items.append(value_piece + ' # ' + comment)
+                self.unit.items.append(f"{value_piece} # {comment}")
             else:
                 self.unit.items.append(value_piece)
                 # token?

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -751,9 +751,7 @@ class Naming:
             if definition_type == DEF_TYPE_SERVICES:
                 for port in line_parts[1].strip().split():
                     if not self.port_re.match(port):
-                        raise NamingSyntaxError(
-                            f'The following line has a syntax error: {line}'
-                        )
+                        raise NamingSyntaxError(f'The following line has a syntax error: {line}')
                 if self.current_symbol in self.services:
                     raise NamespaceCollisionError(
                         '%s %s'

--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -445,7 +445,7 @@ class Naming:
         data = query.split('#')  # Get the token keyword and remove any comment
         service_name = data[0].split()[0]  # strip and cast from list to string
         if service_name not in self.services:
-            raise UndefinedServiceError('\nNo such service: %s' % query)
+            raise UndefinedServiceError(f'\nNo such service: {query}')
 
         already_done.add(service_name)
 
@@ -678,7 +678,7 @@ class Naming:
                         self._ParseFile(file, def_type)
 
             except OSError as error_info:
-                raise NoDefinitionsError('%s' % error_info)
+                raise NoDefinitionsError(f'{error_info}')
 
     def _ParseFile(self, file_handle: list[str], def_type: str) -> None:
         for line in file_handle:
@@ -729,7 +729,7 @@ class Naming:
 
         if definition_type not in ['services', 'networks']:
             raise UnexpectedDefinitionTypeError(
-                '{} {}'.format('Received an unexpected definition type:', definition_type)
+                f'Received an unexpected definition type: {definition_type}'
             )
         line = line.strip()
         if not line or line.startswith('#'):  # Skip comments and blanks.
@@ -752,7 +752,7 @@ class Naming:
                 for port in line_parts[1].strip().split():
                     if not self.port_re.match(port):
                         raise NamingSyntaxError(
-                            '{}: {}'.format('The following line has a syntax error', line)
+                            f'The following line has a syntax error: {line}'
                         )
                 if self.current_symbol in self.services:
                     raise NamespaceCollisionError(

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -336,7 +336,7 @@ class Term(aclgenerator.Term):
             # str() trick to circumvent VarType class attr comparison checks.
             if 'disable' not in str(term.logging):
                 # Simple syslogging implementation.
-                options.append('log prefix "%s"' % term.name)
+                options.append(f'log prefix "{term.name}"')
 
         # 'counter' handling.
         # https://wiki.nftables.org/wiki-nftables/index.php/Counters
@@ -480,7 +480,7 @@ class Term(aclgenerator.Term):
         # COMMENT handling.
         if self.verbose:
             for line in self.term.comment:
-                term_ruleset.append('comment "%s"' % line)
+                term_ruleset.append(f'comment "{line}"')
 
         # ADDRESS handling.
         address_list = self._AddrStatement(
@@ -822,7 +822,7 @@ class Nftables(aclgenerator.ACLGenerator):
                 if base_chain_dict[item]['comment']:
                     # Handle multi-line comments
                     for comment in base_chain_dict[item]['comment']:
-                        nft_config.append(TabSpacer(8, 'comment "%s"' % comment))
+                        nft_config.append(TabSpacer(8, f'comment "{comment}"'))
                 nft_config.append(
                     TabSpacer(
                         8,
@@ -838,7 +838,7 @@ class Nftables(aclgenerator.ACLGenerator):
                 nft_config.append(TabSpacer(8, 'ct state established,related accept'))
                 # Reference the child chains with jump.
                 for child_chain in base_chain_dict[item]['rules'][item].keys():
-                    nft_config.append(TabSpacer(8, 'jump %s' % child_chain))
+                    nft_config.append(TabSpacer(8, f'jump {child_chain}'))
                 nft_config.append(TabSpacer(4, '}'))  # chain_end
             nft_config.append('}')  # table_end
 

--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -255,9 +255,9 @@ class Term(aclgenerator.Term):
             # IPv4 stuff.
             if icmp_type and ('icmp' in ip_protocol):
                 if len(icmp_type) > 1:
-                    statement_lines.append('icmp type' + Add(self.CreateAnonymousSet(icmp_type)))
+                    statement_lines.append(f"icmp type{Add(self.CreateAnonymousSet(icmp_type))}")
                 else:
-                    statement_lines.append('icmp type' + Add(icmp_type))
+                    statement_lines.append(f"icmp type{Add(icmp_type)}")
                 ip_protocol.remove('icmp')
             if 'icmpv6' in ip_protocol:
                 # No IPv6 protocols in IPv4 family.
@@ -266,22 +266,22 @@ class Term(aclgenerator.Term):
                 # Multi-protocol and zero-ports.
                 if len(ip_protocol) > 1 and not (src_ports or dst_ports):
                     statement_lines.append(
-                        'ip protocol' + Add(self.CreateAnonymousSet(ip_protocol))
+                        f"ip protocol{Add(self.CreateAnonymousSet(ip_protocol))}"
                     )
                 else:
                     for proto in ip_protocol:
                         if src_ports or dst_ports:
                             statement_lines.append(PortStatement(proto, src_p, dst_p))
                         else:
-                            statement_lines.append('ip protocol' + Add(proto))
+                            statement_lines.append(f"ip protocol{Add(proto)}")
 
         if address_family == 'ip6':
             # IPv6 stuff.
             if icmp_type and ('icmpv6' in ip6_protocol):
                 if len(icmp_type) > 1:
-                    statement_lines.append('icmpv6 type' + Add(self.CreateAnonymousSet(icmp_type)))
+                    statement_lines.append(f"icmpv6 type{Add(self.CreateAnonymousSet(icmp_type))}")
                 else:
-                    statement_lines.append('icmpv6 type' + Add(icmp_type))
+                    statement_lines.append(f"icmpv6 type{Add(icmp_type)}")
                 ip6_protocol.remove('icmpv6')
             if 'icmp' in ip6_protocol:
                 # No IPv4 protocols in IPv6 family.
@@ -294,7 +294,7 @@ class Term(aclgenerator.Term):
                 # https://wiki.nftables.org/wiki-nftables/index.php/Matching_packet_headers
                 if len(ip6_protocol) > 1 and not (src_ports or dst_ports):
                     statement_lines.append(
-                        'meta l4proto' + Add(self.CreateAnonymousSet(ip6_protocol))
+                        f"meta l4proto{Add(self.CreateAnonymousSet(ip6_protocol))}"
                     )
                 else:
                     # We avoid using th (transport header), instead we use single
@@ -304,7 +304,7 @@ class Term(aclgenerator.Term):
                             statement_lines.append(PortStatement(proto, src_p, dst_p))
                         else:
                             # Single proto, no ports.
-                            statement_lines.append('meta l4proto' + Add(proto))
+                            statement_lines.append(f"meta l4proto{Add(proto)}")
 
         return statement_lines
 
@@ -439,23 +439,23 @@ class Term(aclgenerator.Term):
             if address_family == 'inet' or address_family == 'ip':
                 if src_addr_book['ip']:
                     address_statement.append(
-                        'ip saddr ' + self.CreateAnonymousSet(src_addr_book['ip'])
+                        f"ip saddr {self.CreateAnonymousSet(src_addr_book['ip'])}"
                     )
             if address_family == 'inet' or address_family == 'ip6':
                 if src_addr_book['ip6']:
                     address_statement.append(
-                        'ip6 saddr ' + self.CreateAnonymousSet(src_addr_book['ip6'])
+                        f"ip6 saddr {self.CreateAnonymousSet(src_addr_book['ip6'])}"
                     )
         elif dst_addr:
             if address_family == 'inet' or address_family == 'ip':
                 if dst_addr_book['ip']:
                     address_statement.append(
-                        'ip daddr ' + self.CreateAnonymousSet(dst_addr_book['ip'])
+                        f"ip daddr {self.CreateAnonymousSet(dst_addr_book['ip'])}"
                     )
             if address_family == 'inet' or address_family == 'ip6':
                 if dst_addr_book['ip6']:
                     address_statement.append(
-                        'ip6 daddr ' + self.CreateAnonymousSet(dst_addr_book['ip6'])
+                        f"ip6 daddr {self.CreateAnonymousSet(dst_addr_book['ip6'])}"
                     )
         return address_statement
 

--- a/aerleon/lib/nsxt.py
+++ b/aerleon/lib/nsxt.py
@@ -297,7 +297,7 @@ class Nsxt(aclgenerator.ACLGenerator):
             for term in terms:
                 # Check for duplicate terms
                 if term.name in term_names:
-                    raise NsxtDuplicateTermError('There are multiple terms named: %s' % term.name)
+                    raise NsxtDuplicateTermError(f'There are multiple terms named: {term.name}')
                 term_names.add(term.name)
 
                 term.name = self.FixTermLength(term.name)
@@ -360,7 +360,7 @@ class Nsxt(aclgenerator.ACLGenerator):
                         break
                     else:
                         raise UnsupportedNsxtAccessListError(
-                            'Security Group Id is not provided for %s' % (self._PLATFORM)
+                            f'Security Group Id is not provided for {self._PLATFORM}'
                         )
 
         self._FILTER_OPTIONS_DICT['section_name'] = section_name

--- a/aerleon/lib/nsxv.py
+++ b/aerleon/lib/nsxv.py
@@ -181,7 +181,7 @@ class Term(aclgenerator.Term):
         if self.term.comment:
             for comment in self.term.comment:
                 notes = f'{notes}{comment}'
-            notes = '{}{}{}'.format(_XML_TABLE.get('noteStart'), notes, _XML_TABLE.get('noteEnd'))
+            notes = f"{_XML_TABLE.get('noteStart')}{notes}{_XML_TABLE.get('noteEnd')}"
 
         # protocol
         protocol = None
@@ -316,7 +316,7 @@ class Term(aclgenerator.Term):
                             _XML_TABLE.get('srcIpv6End'),
                         )
                     sources = f'{sources}{saddr}'
-            sources = '{}{}'.format(sources, '</sources>')
+            sources = f'{sources}</sources>'
 
         destinations = ''
         if destination_addr:
@@ -352,7 +352,7 @@ class Term(aclgenerator.Term):
                             _XML_TABLE.get('destIpv6End'),
                         )
                     destinations = f'{destinations}{daddr}'
-            destinations = '{}{}'.format(destinations, '</destinations>')
+            destinations = f'{destinations}</destinations>'
 
         services = []
         if protocol:
@@ -378,7 +378,7 @@ class Term(aclgenerator.Term):
                 _XML_TABLE.get('appliedToEnd'),
             )
             applied_to_list = f'{applied_to_list}{applied_to_element}'
-            applied_to_list = '{}{}'.format(applied_to_list, '</appliedToList>')
+            applied_to_list = f'{applied_to_list}</appliedToList>'
 
         # action
         action = '{}{}{}'.format(
@@ -432,7 +432,7 @@ class Term(aclgenerator.Term):
                         _XML_TABLE.get('icmpTypeEnd'),
                     )
                     icmp_service = f'{icmp_service}{icmp_type}'
-                icmp_service = '{}{}'.format(icmp_service, _XML_TABLE.get('serviceEnd'))
+                icmp_service = f"{icmp_service}{_XML_TABLE.get('serviceEnd')}"
                 service = f'{service}{icmp_service}'
         else:
             # handle other protocols
@@ -450,7 +450,7 @@ class Term(aclgenerator.Term):
                     if sport[0] != sport[1]:
                         str_sport.append(f'{sport[0]}-{sport[1]}')
                     else:
-                        str_sport.append('%s' % (sport[0]))
+                        str_sport.append(f'{sport[0]}')
                 service = '{}{}{}{}'.format(
                     service,
                     _XML_TABLE.get('srcPortStart'),
@@ -465,14 +465,14 @@ class Term(aclgenerator.Term):
                     if dport[0] != dport[1]:
                         str_dport.append(f'{dport[0]}-{dport[1]}')
                     else:
-                        str_dport.append('%s' % (dport[0]))
+                        str_dport.append(f'{dport[0]}')
                 service = '{}{}{}{}'.format(
                     service,
                     _XML_TABLE.get('destPortStart'),
                     ', '.join(str_dport),
                     _XML_TABLE.get('destPortEnd'),
                 )
-            service = '{}{}'.format(service, _XML_TABLE.get('serviceEnd'))
+            service = f"{service}{_XML_TABLE.get('serviceEnd')}"
 
         return service
 
@@ -535,7 +535,7 @@ class Nsxv(aclgenerator.ACLGenerator):
             for term in terms:
                 # Check for duplicate terms
                 if term.name in term_names:
-                    raise NsxvDuplicateTermError('There are multiple terms named: %s' % term.name)
+                    raise NsxvDuplicateTermError(f'There are multiple terms named: {term.name}')
                 term_names.add(term.name)
 
                 # Get the mapped action value
@@ -630,7 +630,7 @@ class Nsxv(aclgenerator.ACLGenerator):
                         break
                     else:
                         raise UnsupportedNsxvAccessListError(
-                            'Security Group Id is not provided for %s' % (self._PLATFORM)
+                            f'Security Group Id is not provided for {self._PLATFORM}'
                         )
 
         self._FILTER_OPTIONS_DICT['section_name'] = section_name
@@ -676,7 +676,7 @@ class Nsxv(aclgenerator.ACLGenerator):
 
             # ensure that the header is always first
             target = target_header + target
-            target.append('%s' % (_XML_TABLE.get('sectionEnd')))
+            target.append(f"{_XML_TABLE.get('sectionEnd')}")
             target.append('\n')
 
             target_as_xml = xml.dom.minidom.parseString(''.join(target))

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -127,13 +127,13 @@ class Term(aclgenerator.Term):
         self._SetDefaultAction()
 
         # Create a new term
-        ret_str.append('\n# term %s' % self.term.name)
+        ret_str.append(f'\n# term {self.term.name}')
 
         comments = aclgenerator.WrapWords(self.term.comment, 80)
         # append comments to output
         if comments and comments[0]:
             for line in comments:
-                ret_str.append('# %s' % str(line))
+                ret_str.append(f'# {line!s}')
 
         if str(self.term.action[0]) not in self._ACTION_TABLE:
             raise aclgenerator.UnsupportedFilterError(
@@ -312,14 +312,14 @@ class Term(aclgenerator.Term):
         stateful: bool,
     ) -> list[str]:
         """Format the string which will become a single PF entry."""
-        line = ['%s' % self._ACTION_TABLE.get(action)]
+        line = [f'{self._ACTION_TABLE.get(action)}']
 
         if direction:
             line.append(direction)
 
         quick = self._QUICK_TABLE.get(action)
         if quick:
-            line.append('%s' % quick)
+            line.append(f'{quick}')
 
         if log:
             logaction = self._LOG_TABLE.get(direction)
@@ -329,7 +329,7 @@ class Term(aclgenerator.Term):
                 line.append('log')
 
         if interface:
-            line.append('on %s' % interface)
+            line.append(f'on {interface}')
 
         if af != 'mixed':
             line.append(af)
@@ -337,17 +337,17 @@ class Term(aclgenerator.Term):
         if proto:
             line.append(self._GenerateProtoStatement(proto))
 
-        line.append('from %s' % src_addr)
+        line.append(f'from {src_addr}')
         if src_port:
-            line.append('port %s' % src_port)
+            line.append(f'port {src_port}')
 
-        line.append('to %s' % dst_addr)
+        line.append(f'to {dst_addr}')
         if dst_port:
-            line.append('port %s' % dst_port)
+            line.append(f'port {dst_port}')
 
         if tcp_flags_set and tcp_flags_check:
             line.append('flags')
-            line.append('{}/{}'.format(''.join(tcp_flags_set), ''.join(tcp_flags_check)))
+            line.append(f"{''.join(tcp_flags_set)}/{''.join(tcp_flags_check)}")
 
         if 'icmp' in proto and icmp_types:
             type_strs = [str(icmp_type) for icmp_type in icmp_types]
@@ -395,7 +395,7 @@ class Term(aclgenerator.Term):
                 addr = cast(nacaddr.IPType, addr)
                 parent_token_set.add(addr.parent_token)
             for token in parent_token_set:
-                addresses.add('<%s>' % token[:31])
+                addresses.add(f'<{token[:31]}>')
         else:
             addresses.add('any')
         if exclude_addrs != ['any']:
@@ -404,7 +404,7 @@ class Term(aclgenerator.Term):
                 addr = cast(nacaddr.IPType, addr)
                 parent_token_set.add(addr.parent_token)
             for token in parent_token_set:
-                addresses.add('!<%s>' % token[:31])
+                addresses.add(f'!<{token[:31]}>')
         return '{ %s }' % ', '.join(sorted(addresses))
 
     def _GeneratePortStatement(self, ports: list[tuple[int, int]]) -> str:
@@ -521,7 +521,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
             for term in terms:
                 term.name = self.FixTermLength(term.name)
                 if term.name in term_names:
-                    raise DuplicateTermError('You have a duplicate term: %s' % term.name)
+                    raise DuplicateTermError(f'You have a duplicate term: {term.name}')
                 term_names.add(term.name)
 
                 for source_addr in term.source_address:
@@ -617,7 +617,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
             comments = aclgenerator.WrapWords(header.comment, 70)
             if comments and comments[0]:
                 for line in comments:
-                    target.append('# %s' % line)
+                    target.append(f'# {line}')
                 target.append('#')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags('# '))

--- a/aerleon/lib/packetfilter.py
+++ b/aerleon/lib/packetfilter.py
@@ -621,7 +621,7 @@ class PacketFilter(aclgenerator.ACLGenerator):
                 target.append('#')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags('# '))
-            target.append('# ' + filter_type)
+            target.append(f"# {filter_type}")
 
             # add the terms
             for term in terms:

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -91,7 +91,7 @@ class ServiceMap:
 
         if len(service_name) > 63:
             raise PaloAltoFWNameTooLongError(
-                "Service name must be 63 characters max: %s" % service_name
+                f"Service name must be 63 characters max: {service_name}"
             )
 
         for _, service in self.entries.items():
@@ -255,7 +255,7 @@ class Rule:
                 ):
                     options["application"].append(proto_name)
                 elif proto_name in ("ah", "esp"):
-                    ipsec_app_proto = "ipsec-%s" % proto_name
+                    ipsec_app_proto = f"ipsec-{proto_name}"
                     if ipsec_app_proto not in options["application"]:
                         options["application"].append(ipsec_app_proto)
 
@@ -502,7 +502,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                     )
                 term.name = self.FixTermLength(term.name)
                 if term.name in term_dup_check:
-                    raise PaloAltoFWDuplicateTermError("You have a duplicate term: %s" % term.name)
+                    raise PaloAltoFWDuplicateTermError(f"You have a duplicate term: {term.name}")
                 term_dup_check.add(term.name)
 
                 services = {"tcp", "udp"} & set(term.protocol)
@@ -725,7 +725,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                     # The term contains ICMP types
                     for term_icmp_type_name in term.icmp_type:
                         if icmp_version == "icmp":
-                            icmp_app_name = "icmp-%s" % term_icmp_type_name
+                            icmp_app_name = f"icmp-{term_icmp_type_name}"
                             # This is to abbreviate the Application name where possible.
                             # The limit is defined by _APPLICATION_NAME_MAX_LENGTH = 31.
                             if len(icmp_app_name) > self._APPLICATION_NAME_MAX_LENGTH:
@@ -739,7 +739,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                                 )
                             term_icmp_type = policy.Term.ICMP_TYPE[4][term_icmp_type_name]
                         else:
-                            icmp_app_name = "icmp6-%s" % term_icmp_type_name
+                            icmp_app_name = f"icmp6-{term_icmp_type_name}"
                             # This is to abbreviate the Application name where possible.
                             # The limit is defined by _APPLICATION_NAME_MAX_LENGTH = 31.
                             if len(icmp_app_name) > self._APPLICATION_NAME_MAX_LENGTH:
@@ -778,7 +778,7 @@ class PaloAltoFW(aclgenerator.ACLGenerator):
                     if proto_name in self._SUPPORTED_PROTO_NAMES:
                         continue
                     raise PaloAltoFWUnsupportedProtocolError(
-                        "protocol %s is not supported" % proto_name
+                        f"protocol {proto_name} is not supported"
                     )
 
                 if term.icmp_type:

--- a/aerleon/lib/paloaltofw.py
+++ b/aerleon/lib/paloaltofw.py
@@ -155,7 +155,7 @@ class Rule:
             x = []
             for tup in ports:
                 if len(tup) > 1 and tup[0] != tup[1]:
-                    x.append(str(tup[0]) + "-" + str(tup[1]))
+                    x.append(f"{tup[0]!s}-{tup[1]!s}")
                 else:
                     x.append(str(tup[0]))
 

--- a/aerleon/lib/pcap.py
+++ b/aerleon/lib/pcap.py
@@ -234,8 +234,8 @@ class Term(aclgenerator.Term):
         if not condition_list:
             return ''
 
-        op = ' %s ' % (operator)
-        res = '(%s)' % (op.join(condition_list))
+        op = f' {operator} '
+        res = f'({op.join(condition_list)})'
         return res
 
     def _GenerateAddrStatement(
@@ -244,13 +244,13 @@ class Term(aclgenerator.Term):
         addrlist = []
         for d in addrs:
             if d != 'any' and str(d) != '::/0':
-                addrlist.append('dst net %s' % (d))
+                addrlist.append(f'dst net {d}')
 
         excludes = []
         if exclude_addrs:
             for d in exclude_addrs:
                 if d != 'any' and str(d) != '::/0':
-                    excludes.append('not dst net %s' % (d))
+                    excludes.append(f'not dst net {d}')
                 else:
                     # excluding 'any' doesn't really make sense ...
                     return ''
@@ -429,7 +429,7 @@ class PcapFilter(aclgenerator.ACLGenerator):
             for term in terms:
                 if term.name in term_names:
                     raise aclgenerator.DuplicateTermError(
-                        'You have a duplicate term: %s' % term.name
+                        f'You have a duplicate term: {term.name}'
                     )
 
                 if not term:

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -1312,9 +1312,7 @@ class Term:
                 or self.protocol
                 or self.option
             ):
-                raise ParseError(
-                    f'term "{self.name}" has both verbatim and non-verbatim tokens.'
-                )
+                raise ParseError(f'term "{self.name}" has both verbatim and non-verbatim tokens.')
         else:
             if (
                 not self.action

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -225,13 +225,13 @@ class Policy:
                 term.port = TranslatePorts(term.port, term.protocol, term.name)
                 if not term.port:
                     raise TermPortProtocolError(
-                        'no ports of the correct protocol for term %s' % (term.name)
+                        f'no ports of the correct protocol for term {term.name}'
                     )
             if term.source_port:
                 term.source_port = TranslatePorts(term.source_port, term.protocol, term.name)
                 if not term.source_port:
                     raise TermPortProtocolError(
-                        'no source ports of the correct protocol for term %s' % (term.name)
+                        f'no source ports of the correct protocol for term {term.name}'
                     )
             if term.destination_port:
                 term.destination_port = TranslatePorts(
@@ -239,7 +239,7 @@ class Policy:
                 )
                 if not term.destination_port:
                     raise TermPortProtocolError(
-                        'no destination ports of the correct protocol for term %s' % (term.name)
+                        f'no destination ports of the correct protocol for term {term.name}'
                     )
 
             # If argument is true, we optimize, otherwise just sort addresses
@@ -706,13 +706,13 @@ class Term:
 
     def __str__(self) -> str:
         ret_str = []
-        ret_str.append(' name: %s' % self.name)
+        ret_str.append(f' name: {self.name}')
         if self.address:
-            ret_str.append('  address: %s' % sorted(self.address))
+            ret_str.append(f'  address: {sorted(self.address)}')
         if self.address_exclude:
-            ret_str.append('  address_exclude: %s' % sorted(self.address_exclude))
+            ret_str.append(f'  address_exclude: {sorted(self.address_exclude)}')
         if self.source_address:
-            ret_str.append('  source_address: %s' % self._SortAddressesByFamily('source_address'))
+            ret_str.append(f"  source_address: {self._SortAddressesByFamily('source_address')}")
         if self.source_address_exclude:
             ret_str.append(
                 '  source_address_exclude: %s'
@@ -721,10 +721,10 @@ class Term:
         if self.source_fqdn:
             ret_str.append(f'  source_fqdn: {self.source_fqdn}')
         if self.source_tag:
-            ret_str.append('  source_tag: %s' % self.source_tag)
+            ret_str.append(f'  source_tag: {self.source_tag}')
         if self.destination_address:
             ret_str.append(
-                '  destination_address: %s' % self._SortAddressesByFamily('destination_address')
+                f"  destination_address: {self._SortAddressesByFamily('destination_address')}"
             )
         if self.destination_address_exclude:
             ret_str.append(
@@ -734,93 +734,93 @@ class Term:
         if self.destination_fqdn:
             ret_str.append(f'  destination_fqdn: {self.destination_fqdn}')
         if self.destination_tag:
-            ret_str.append('  destination_tag: %s' % self.destination_tag)
+            ret_str.append(f'  destination_tag: {self.destination_tag}')
         if self.target_resources:
-            ret_str.append('  target_resources: %s' % self.target_resources)
+            ret_str.append(f'  target_resources: {self.target_resources}')
         if self.target_service_accounts:
-            ret_str.append('  target_service_accounts: %s' % self.target_service_accounts)
+            ret_str.append(f'  target_service_accounts: {self.target_service_accounts}')
         if self.source_prefix:
-            ret_str.append('  source_prefix: %s' % self.source_prefix)
+            ret_str.append(f'  source_prefix: {self.source_prefix}')
         if self.source_prefix_except:
-            ret_str.append('  source_prefix_except: %s' % self.source_prefix_except)
+            ret_str.append(f'  source_prefix_except: {self.source_prefix_except}')
         if self.destination_prefix:
-            ret_str.append('  destination_prefix: %s' % self.destination_prefix)
+            ret_str.append(f'  destination_prefix: {self.destination_prefix}')
         if self.destination_prefix_except:
-            ret_str.append('  destination_prefix_except: %s' % self.destination_prefix_except)
+            ret_str.append(f'  destination_prefix_except: {self.destination_prefix_except}')
         if self.filter_term:
-            ret_str.append('  filter_term: %s' % self.filter_term)
+            ret_str.append(f'  filter_term: {self.filter_term}')
         if self.forwarding_class:
-            ret_str.append('  forwarding_class: %s' % self.forwarding_class)
+            ret_str.append(f'  forwarding_class: {self.forwarding_class}')
         if self.forwarding_class_except:
-            ret_str.append('  forwarding_class_except: %s' % self.forwarding_class_except)
+            ret_str.append(f'  forwarding_class_except: {self.forwarding_class_except}')
         if self.icmp_type:
-            ret_str.append('  icmp_type: %s' % sorted(self.icmp_type))
+            ret_str.append(f'  icmp_type: {sorted(self.icmp_type)}')
         if self.icmp_code:
-            ret_str.append('  icmp_code: %s' % sorted(self.icmp_code))
+            ret_str.append(f'  icmp_code: {sorted(self.icmp_code)}')
         if self.next_ip:
-            ret_str.append('  next_ip: %s' % self.next_ip)
+            ret_str.append(f'  next_ip: {self.next_ip}')
         if self.encapsulate:
-            ret_str.append('  encapsulate: %s' % self.encapsulate)
+            ret_str.append(f'  encapsulate: {self.encapsulate}')
         if self.protocol:
-            ret_str.append('  protocol: %s' % sorted(self.protocol))
+            ret_str.append(f'  protocol: {sorted(self.protocol)}')
         if self.protocol_except:
-            ret_str.append('  protocol-except: %s' % self.protocol_except)
+            ret_str.append(f'  protocol-except: {self.protocol_except}')
         if self.owner:
-            ret_str.append('  owner: %s' % self.owner)
+            ret_str.append(f'  owner: {self.owner}')
         if self.port:
-            ret_str.append('  port: %s' % sorted(self.port))
+            ret_str.append(f'  port: {sorted(self.port)}')
         if self.port_mirror:
-            ret_str.append('  port_mirror: %s' % self.port_mirror)
+            ret_str.append(f'  port_mirror: {self.port_mirror}')
         if self.source_port:
-            ret_str.append('  source_port: %s' % sorted(self.source_port))
+            ret_str.append(f'  source_port: {sorted(self.source_port)}')
         if self.destination_port:
-            ret_str.append('  destination_port: %s' % sorted(self.destination_port))
+            ret_str.append(f'  destination_port: {sorted(self.destination_port)}')
         if self.action:
-            ret_str.append('  action: %s' % self.action)
+            ret_str.append(f'  action: {self.action}')
         if self.option:
-            ret_str.append('  option: %s' % self.option)
+            ret_str.append(f'  option: {self.option}')
         if self.flexible_match_range:
-            ret_str.append('  flexible_match_range: %s' % self.flexible_match_range)
+            ret_str.append(f'  flexible_match_range: {self.flexible_match_range}')
         if self.qos:
-            ret_str.append('  qos: %s' % self.qos)
+            ret_str.append(f'  qos: {self.qos}')
         if self.pan_application:
-            ret_str.append('  pan_application: %s' % self.pan_application)
+            ret_str.append(f'  pan_application: {self.pan_application}')
         if self.logging:
-            ret_str.append('  logging: %s' % self.logging)
+            ret_str.append(f'  logging: {self.logging}')
         if self.log_limit:
             ret_str.append(f'  log_limit: {self.log_limit[0]}/{self.log_limit[1]}')
         if self.log_name:
-            ret_str.append('  log_name: %s' % self.log_name)
+            ret_str.append(f'  log_name: {self.log_name}')
         if self.priority:
-            ret_str.append('  priority: %s' % self.priority)
+            ret_str.append(f'  priority: {self.priority}')
         if self.counter:
-            ret_str.append('  counter: %s' % self.counter)
+            ret_str.append(f'  counter: {self.counter}')
         if self.traffic_class_count:
-            ret_str.append('  traffic_class_count: %s' % self.traffic_class_count)
+            ret_str.append(f'  traffic_class_count: {self.traffic_class_count}')
         if self.source_interface:
-            ret_str.append('  source_interface: %s' % self.source_interface)
+            ret_str.append(f'  source_interface: {self.source_interface}')
         if self.destination_interface:
-            ret_str.append('  destination_interface: %s' % self.destination_interface)
+            ret_str.append(f'  destination_interface: {self.destination_interface}')
         if self.expiration:
-            ret_str.append('  expiration: %s' % self.expiration)
+            ret_str.append(f'  expiration: {self.expiration}')
         if self.platform:
-            ret_str.append('  platform: %s' % self.platform)
+            ret_str.append(f'  platform: {self.platform}')
         if self.platform_exclude:
-            ret_str.append('  platform_exclude: %s' % self.platform_exclude)
+            ret_str.append(f'  platform_exclude: {self.platform_exclude}')
         if self.ttl:
-            ret_str.append('  ttl: %s' % self.ttl)
+            ret_str.append(f'  ttl: {self.ttl}')
         if self.timeout:
-            ret_str.append('  timeout: %s' % self.timeout)
+            ret_str.append(f'  timeout: {self.timeout}')
         if self.vpn:
             vpn_name, pair_policy = self.vpn
             if pair_policy:
                 ret_str.append(f'  vpn: name = {vpn_name}, pair_policy = {pair_policy}')
             else:
-                ret_str.append('  vpn: name = %s' % vpn_name)
+                ret_str.append(f'  vpn: name = {vpn_name}')
         if self.source_zone:
-            ret_str.append('  source_zone: %s' % sorted(self.source_zone))
+            ret_str.append(f'  source_zone: {sorted(self.source_zone)}')
         if self.destination_zone:
-            ret_str.append('  destination_zone: %s' % sorted(self.destination_zone))
+            ret_str.append(f'  destination_zone: {sorted(self.destination_zone)}')
 
         return '\n'.join(ret_str)
 
@@ -1223,7 +1223,7 @@ class Term:
                 self.verbatim.append(obj.value)
             elif obj.var_type is VarType.ACTION:
                 if str(obj) not in ACTIONS:
-                    raise InvalidTermActionError('%s is not a valid action' % obj)
+                    raise InvalidTermActionError(f'{obj} is not a valid action')
                 self.action.append(obj.value)
             elif obj.var_type is VarType.COUNTER:
                 self.counter = obj
@@ -1239,7 +1239,7 @@ class Term:
                 self.icmp_code.extend(obj.value)
             elif obj.var_type is VarType.LOGGING:
                 if str(obj) not in _LOGGING:
-                    raise InvalidTermLoggingError('%s is not a valid logging option' % obj)
+                    raise InvalidTermLoggingError(f'{obj} is not a valid logging option')
                 self.logging.append(obj)
             elif obj.var_type is VarType.LOG_LIMIT:
                 self.log_limit = obj.value
@@ -1278,7 +1278,7 @@ class Term:
             elif obj.var_type is VarType.FILTER_TERM:
                 self.filter_term = obj.value
             else:
-                raise TermObjectTypeError('%s isn\'t a type I know how to deal with' % (type(obj)))
+                raise TermObjectTypeError(f'{type(obj)} isn\'t a type I know how to deal with')
 
     def SanityCheck(self) -> None:
         """Sanity check the definition of the term.
@@ -1313,7 +1313,7 @@ class Term:
                 or self.option
             ):
                 raise ParseError(
-                    'term "%s" has both verbatim and non-verbatim tokens.' % self.name
+                    f'term "{self.name}" has both verbatim and non-verbatim tokens.'
                 )
         else:
             if (
@@ -1324,10 +1324,10 @@ class Term:
                 and not self.filter_term
                 and not self.port_mirror
             ):
-                raise TermNoActionError('no action specified for term %s' % self.name)
+                raise TermNoActionError(f'no action specified for term {self.name}')
             if self.filter_term and self.action:
                 raise InvalidTermActionError(
-                    'term "%s" has both filter and action tokens.' % self.name
+                    f'term "{self.name}" has both filter and action tokens.'
                 )
             # have we specified a port with a protocol that doesn't support ports?
             protos_no_ports = {p for p in self.protocol if p not in PROTOS_WITH_PORTS}
@@ -1389,7 +1389,7 @@ class Term:
             for icmptype in self.icmp_type:
                 if icmptype not in self.ICMP_TYPE[4] and icmptype not in self.ICMP_TYPE[6]:
                     raise TermInvalidIcmpType(
-                        'Term %s contains an invalid icmp-type:' '%s' % (self.name, icmptype)
+                        f'Term {self.name} contains an invalid icmp-type:{icmptype}'
                     )
 
         if self.ttl:
@@ -2167,22 +2167,22 @@ def p_flex_match_key_values(p):
         return
 
     if p[1] not in FLEXIBLE_MATCH_RANGE_ATTRIBUTES:
-        raise FlexibleMatchError('%s is not a valid attribute' % p[1])
+        raise FlexibleMatchError(f'{p[1]} is not a valid attribute')
     if p[1] == 'match-start':
         if p[2] not in FLEXIBLE_MATCH_START_OPTIONS:
-            raise FlexibleMatchError('%s value is not valid' % p[1])
+            raise FlexibleMatchError(f'{p[1]} value is not valid')
     # per Juniper, max bit length is 32
     elif p[1] == 'bit-length':
         if int(p[2]) not in list(range(33)):
-            raise FlexibleMatchError('%s value is not valid' % p[1])
+            raise FlexibleMatchError(f'{p[1]} value is not valid')
     # per Juniper, max bit offset is 7
     elif p[1] == 'bit-offset':
         if int(p[2]) not in list(range(8)):
-            raise FlexibleMatchError('%s value is not valid' % p[1])
+            raise FlexibleMatchError(f'{p[1]} value is not valid')
     # per Juniper, offset can be up to 256 bytes
     elif p[1] == 'byte-offset':
         if int(p[2]) not in list(range(256)):
-            raise FlexibleMatchError('%s value is not valid' % p[1])
+            raise FlexibleMatchError(f'{p[1]} value is not valid')
 
     if type(p[0]) == type([]):
         p[0].append([p.slice[1:]])
@@ -2659,9 +2659,9 @@ def _ReadFile(filename):
                 data = f.read()
             return data
         except OSError:
-            raise FileReadError('Unable to open or read file %s' % filename)
+            raise FileReadError(f'Unable to open or read file {filename}')
     else:
-        raise FileNotFoundError('Unable to open policy file %s' % filename)
+        raise FileNotFoundError(f'Unable to open policy file {filename}')
 
 
 def _Preprocess(data: str, max_depth: int = 5, base_dir: str = '') -> list[str]:
@@ -2801,7 +2801,7 @@ if __name__ == '__main__':
         try:
             ret = ParsePolicy(open(sys.argv[1]).read(), filename=sys.argv[1])
         except OSError:
-            print('ERROR: \'%s\' either does not exist or is not readable' % (sys.argv[1]))
+            print(f'ERROR: \'{sys.argv[1]}\' either does not exist or is not readable')
             ret = 1
     else:
         # default to reading stdin

--- a/aerleon/lib/policy.py
+++ b/aerleon/lib/policy.py
@@ -2240,7 +2240,7 @@ def p_packet_length_spec(p):
     if len(p) == 5:
         p[0] = VarType(VarType.PACKET_LEN, str(p[4]))
     else:
-        p[0] = VarType(VarType.PACKET_LEN, str(p[4]) + '-' + str(p[6]))
+        p[0] = VarType(VarType.PACKET_LEN, f"{p[4]!s}-{p[6]!s}")
 
 
 def p_fragment_offset_spec(p):
@@ -2249,7 +2249,7 @@ def p_fragment_offset_spec(p):
     if len(p) == 5:
         p[0] = VarType(VarType.FRAGMENT_OFFSET, str(p[4]))
     else:
-        p[0] = VarType(VarType.FRAGMENT_OFFSET, str(p[4]) + '-' + str(p[6]))
+        p[0] = VarType(VarType.FRAGMENT_OFFSET, f"{p[4]!s}-{p[6]!s}")
 
 
 def p_hop_limit_spec(p: YaccProduction) -> None:
@@ -2258,7 +2258,7 @@ def p_hop_limit_spec(p: YaccProduction) -> None:
     if len(p) == 5:
         p[0] = VarType(VarType.HOP_LIMIT, str(p[4]))
     else:
-        p[0] = VarType(VarType.HOP_LIMIT, str(p[4]) + '-' + str(p[6]))
+        p[0] = VarType(VarType.HOP_LIMIT, f"{p[4]!s}-{p[6]!s}")
 
 
 def p_one_or_more_dscps(p):

--- a/aerleon/lib/policyreader.py
+++ b/aerleon/lib/policyreader.py
@@ -98,7 +98,7 @@ class Policy:
         try:
             self.data = open(filename).readlines()
         except OSError as error_info:
-            info = str(filename) + ' cannot be opened'
+            info = f"{filename!s} cannot be opened"
             raise FileOpenError(f'{info}\n{error_info}')
 
         indent = 0

--- a/aerleon/lib/policyreader.py
+++ b/aerleon/lib/policyreader.py
@@ -49,8 +49,8 @@ class Filter:
 
     def __str__(self):
         rval = []
-        title = 'Filter: %s' % str(self.name)
-        rval.append('\n%s' % title)
+        title = f'Filter: {self.name!s}'
+        rval.append(f'\n{title}')
         rval.append('-' * len(title))
         for term in self.term:
             rval.append(str(term))
@@ -72,14 +72,14 @@ class Term:
 
     def __str__(self):
         rval = []
-        rval.append('  Term: %s' % self.name)
-        rval.append('  Source-address:: %s' % ' '.join(self.source))
-        rval.append('  Destination-address:: %s' % ' '.join(self.destination))
-        rval.append('  Source-port:: %s' % ' '.join(self.sport))
-        rval.append('  Destination-port:: %s' % ' '.join(self.dport))
-        rval.append('  Protocol:: %s' % ' '.join(self.protocol))
-        rval.append('  Option:: %s' % ' '.join(self.option))
-        rval.append('  Action:: %s' % ' '.join(self.action))
+        rval.append(f'  Term: {self.name}')
+        rval.append(f"  Source-address:: {' '.join(self.source)}")
+        rval.append(f"  Destination-address:: {' '.join(self.destination)}")
+        rval.append(f"  Source-port:: {' '.join(self.sport)}")
+        rval.append(f"  Destination-port:: {' '.join(self.dport)}")
+        rval.append(f"  Protocol:: {' '.join(self.protocol)}")
+        rval.append(f"  Option:: {' '.join(self.option)}")
+        rval.append(f"  Action:: {' '.join(self.action)}")
         return '\n'.join(rval)
 
 
@@ -212,7 +212,7 @@ class Policy:
                 if filtername == fil.name:
                     filter_list = [self.filter[idx]]
             if not filter_list:
-                raise InvalidFilterError('invalid filter name: %s' % filtername)
+                raise InvalidFilterError(f'invalid filter name: {filtername}')
 
         for findex, xfilter in enumerate(filter_list):
             mterms = []

--- a/aerleon/lib/port.py
+++ b/aerleon/lib/port.py
@@ -82,7 +82,7 @@ class PPP:
         if '-' in self.port:
             self._start = int(self.port.split('-')[0])
         else:
-            raise InvalidRange('%s is not a valid port range' % self.port)
+            raise InvalidRange(f'{self.port} is not a valid port range')
         return self._start
 
     @property
@@ -91,7 +91,7 @@ class PPP:
         if '-' in self.port:
             self._end = int(self.port.split('-')[1])
         else:
-            raise InvalidRange('%s is not a valid port range' % self.port)
+            raise InvalidRange(f'{self.port} is not a valid port range')
         return self._end
 
     def __contains__(self, other):
@@ -101,7 +101,7 @@ class PPP:
                 int(self.start) <= int(other.port) <= int(self.end)
             ) and self.protocol == other.protocol
         except:
-            raise InvalidRange('%s must be a range' % self.port)
+            raise InvalidRange(f'{self.port} must be a range')
 
     def __lt__(self, other):
         if self.is_single_port:
@@ -166,7 +166,7 @@ def Port(port):
     try:
         pval = int(port)
     except ValueError:
-        raise BadPortValue('port %s is not valid.' % port)
+        raise BadPortValue(f'port {port} is not valid.')
     if pval < 0 or pval > 65535:
-        raise BadPortRange('port %s is out of range 0-65535.' % port)
+        raise BadPortRange(f'port {port} is out of range 0-65535.')
     return pval

--- a/aerleon/lib/summarizer.py
+++ b/aerleon/lib/summarizer.py
@@ -86,7 +86,7 @@ class DSMNet:
         return False
 
     def __str__(self) -> str:
-        return ' '.join([self.address, self.netmask])
+        return f"{self.address} {self.netmask}"
 
     def MergeText(self, text: str = '') -> str:
         """Returns self.text joined with optional text.
@@ -101,7 +101,7 @@ class DSMNet:
         """
         if self.text:
             if text and text not in self.text:
-                return ', '.join([self.text, text])
+                return f"{self.text}, {text}"
             return self.text
         else:
             return text

--- a/aerleon/lib/windows.py
+++ b/aerleon/lib/windows.py
@@ -336,7 +336,7 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
             for term in terms:
                 if term.name in term_names:
                     raise aclgenerator.DuplicateTermError(
-                        'You have a duplicate term: %s' % term.name
+                        f'You have a duplicate term: {term.name}'
                     )
                 term_names.add(term.name)
 
@@ -365,7 +365,7 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
             comments = aclgenerator.WrapWords(header.comment, 70)
             if comments and comments[0]:
                 for line in comments:
-                    target.append(': %s' % line)
+                    target.append(f': {line}')
                 target.append(':')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags(': '))

--- a/aerleon/lib/windows.py
+++ b/aerleon/lib/windows.py
@@ -369,7 +369,7 @@ class WindowsGenerator(aclgenerator.ACLGenerator):
                 target.append(':')
             # add the p4 tags
             target.extend(aclgenerator.AddRepositoryTags(': '))
-            target.append(': ' + filter_type)
+            target.append(f": {filter_type}")
 
             if default_action:
                 raise aclgenerator.UnsupportedTargetOptionError(

--- a/aerleon/lib/windows_advfirewall.py
+++ b/aerleon/lib/windows_advfirewall.py
@@ -161,7 +161,7 @@ class Term(windows.Term):
             if start == end:
                 multiports.append(str(start))
             else:
-                multiports.append('-'.join([str(start), str(end)]))
+                multiports.append(f"{start!s}-{end!s}")
         return ','.join(multiports)
 
 

--- a/aerleon/lib/windows_ipsec.py
+++ b/aerleon/lib/windows_ipsec.py
@@ -199,7 +199,7 @@ class Term(windows.Term):
 
     def ComposeRule(self, policy: str):
         return self.CMD_PREFIX + self._RULE_FORMAT.substitute(
-            name=self.term_name + '-rule',
+            name=f"{self.term_name}-rule",
             policy=policy,
             filterlist=self.term_name + self._LIST_SUFFIX,
             filteraction=self.term_name + self._ACTION_SUFFIX,
@@ -231,7 +231,7 @@ class WindowsIPSec(windows.WindowsGenerator):
 
     def _HandlePolicyHeader(self, header: Header, target: list[str]) -> None:
         policy_name = header.FilterName(self._PLATFORM) + self._POLICY_SUFFIX
-        target.append(Term.CMD_PREFIX + self._POLICY_FORMAT.substitute(name=policy_name) + '\n')
+        target.append(f"{Term.CMD_PREFIX}{self._POLICY_FORMAT.substitute(name=policy_name)}\n")
 
     def _HandleTermFooter(self, header: Header, term: Term, target: list[str]):
-        target.append(term.ComposeRule(header.FilterName(self._PLATFORM)) + '\n')
+        target.append(f"{term.ComposeRule(header.FilterName(self._PLATFORM))}\n")

--- a/aerleon/utils/iputils.py
+++ b/aerleon/utils/iputils.py
@@ -34,10 +34,10 @@ def exclude_address(
     """
 
     if not isinstance(base_net, ipaddress._BaseNetwork):  # pylint disable=protected-access
-        raise TypeError('%s is not a network object' % base_net)
+        raise TypeError(f'{base_net} is not a network object')
 
     if not isinstance(exclude_net, ipaddress._BaseNetwork):  # pylint disable=protected-access
-        raise TypeError('%s is not a network object' % exclude_net)
+        raise TypeError(f'{exclude_net} is not a network object')
 
     if (
         not base_net._version == exclude_net._version

--- a/tests/lib/aclgenerator_test.py
+++ b/tests/lib/aclgenerator_test.py
@@ -208,31 +208,28 @@ class ACLGeneratorTest(absltest.TestCase):
         self.assertListEqual(expected_protocol_list, retprotocol_list)
 
     def testAddRepositoryTags(self):
-        # Format print the '$' into the RCS tags in order prevent the tags from
-        # being interpolated here.
-
         # Include all tags.
         self.assertListEqual(
             [
-                '{}Id:{}'.format('$', '$'),
-                '{}Date:{}'.format('$', '$'),
-                '{}Revision:{}'.format('$', '$'),
+                '$Id:$',
+                '$Date:$',
+                '$Revision:$',
             ],
             aclgenerator.AddRepositoryTags(),
         )
         # Remove the revision tag.
         self.assertListEqual(
-            ['{}Id:{}'.format('$', '$'), '{}Date:{}'.format('$', '$')],
+            ['$Id:$', '$Date:$'],
             aclgenerator.AddRepositoryTags(revision=False),
         )
         # Only include the Id: tag.
         self.assertListEqual(
-            ['{}Id:{}'.format('$', '$')],
+            ['$Id:$'],
             aclgenerator.AddRepositoryTags(date=False, revision=False),
         )
         # Wrap the Date: tag.
         self.assertListEqual(
-            ['"{}Date:{}"'.format('$', '$')],
+            ['"$Date:$"'],
             aclgenerator.AddRepositoryTags(revision=False, rid=False, wrap=True),
         )
 

--- a/tests/lib/policy_simple_test.py
+++ b/tests/lib/policy_simple_test.py
@@ -65,7 +65,7 @@ class FieldTest(absltest.TestCase):
                 logging.debug('Testing good "%s".', good)
                 _ = policy_simple.NamingField(good)
             except ValueError:
-                self.fail('Rejected good NamingField value "%s".' % good)
+                self.fail(f'Rejected good NamingField value "{good}".')
 
     def testNamingFieldAppendRejectsBad(self):
         f = policy_simple.NamingField('RFC1918')
@@ -89,7 +89,7 @@ class FieldTest(absltest.TestCase):
                 logging.debug('Testing good "%s".', good)
                 _ = f.Append(good)
             except ValueError:
-                self.fail('Rejected good NamingField value "%s".' % good)
+                self.fail(f'Rejected good NamingField value "{good}".')
 
     def testNamingFieldDedupes(self):
         f = policy_simple.NamingField('RFC1918 CORP_INTERNAL RFC1918')
@@ -158,7 +158,7 @@ class PolicyTest(absltest.TestCase):
             try:
                 p.AddMember(member)
             except TypeError:
-                self.fail('Policy should accept member "%s"' % member)
+                self.fail(f'Policy should accept member "{member}"')
         self.assertEqual(good, p.members)
 
         for member in bad:

--- a/tests/lib/policy_test.py
+++ b/tests/lib/policy_test.py
@@ -989,7 +989,7 @@ class PolicyTest(parameterized.TestCase):
         pol = HEADER + TERM_UNSORTED_ICMP_TYPE
         ret = policy.ParsePolicy(pol, self.naming)
         icmp_types = ['echo-reply', 'echo-request', 'unreachable']
-        expected = 'icmp_type: %s' % icmp_types
+        expected = f'icmp_type: {icmp_types}'
         self.assertIn(expected, str(ret))
 
     def testICMPCodesSorting(self):
@@ -1307,8 +1307,8 @@ class PolicyTest(parameterized.TestCase):
         pol = HEADER + GOOD_TERM_48
         result = policy.ParsePolicy(pol, self.naming)
         zones = ['zone1', 'zone2']
-        expected_source = 'source_zone: %s' % zones
-        expected_destination = 'destination_zone: %s' % zones
+        expected_source = f'source_zone: {zones}'
+        expected_destination = f'destination_zone: {zones}'
         self.assertIn(expected_source, str(result))
         self.assertIn(expected_destination, str(result))
 

--- a/tests/lib/summarizer_test.py
+++ b/tests/lib/summarizer_test.py
@@ -70,7 +70,7 @@ class SummarizerTest(absltest.TestCase):
     def testSummarizeNoNetworks(self):
         nets = []
         for octet in range(0, 256):
-            net = nacaddr.IPv4('192.' + str(255 - octet) + '.' + str(octet) + '.64/27')
+            net = nacaddr.IPv4(f"192.{255 - octet!s}.{octet!s}.64/27")
             nets.append(net)
         random.shuffle(nets)
         result = summarizer.Summarize(nets)
@@ -89,7 +89,7 @@ class SummarizerTest(absltest.TestCase):
             nacaddr.IPv4('10.0.0.0/8'),
         ]
         for octet in range(0, 256):
-            net = nacaddr.IPv4('172.16.' + str(octet) + '.96/30')
+            net = nacaddr.IPv4(f"172.16.{octet!s}.96/30")
             nets.append(net)
         random.shuffle(nets)
         result = summarizer.Summarize(nets)
@@ -105,7 +105,7 @@ class SummarizerTest(absltest.TestCase):
     def testSummarizeAllNetworks(self):
         nets = []
         for octet in range(0, 256):
-            net = nacaddr.IPv4('192.168.' + str(octet) + '.64/27')
+            net = nacaddr.IPv4(f"192.168.{octet!s}.64/27")
             nets.append(net)
         random.shuffle(nets)
         result = summarizer.Summarize(nets)
@@ -174,7 +174,7 @@ class SummarizerTest(absltest.TestCase):
 
         for octet3 in range(56, 60):
             for octet4 in fourth_octet:
-                nets.append(nacaddr.IPv4('192.168.' + str(octet3) + '.' + str(octet4) + '/31'))
+                nets.append(nacaddr.IPv4(f"192.168.{octet3!s}.{octet4!s}/31"))
 
         result = summarizer.Summarize(nets)
         self.assertEqual(
@@ -201,7 +201,7 @@ class SummarizerTest(absltest.TestCase):
         self.assertEqual(dsm_net.MergeText(existing_comment), existing_comment)
 
         dsm_net = summarizer.DSMNet(167772160, 4278190080, existing_comment)
-        self.assertEqual(dsm_net.MergeText(addition), existing_comment + ', ' + addition)
+        self.assertEqual(dsm_net.MergeText(addition), f"{existing_comment}, {addition}")
 
     def testOrder(self):
         nets = [

--- a/tests/regression/arista/arista_test.py
+++ b/tests/regression/arista/arista_test.py
@@ -217,7 +217,7 @@ class AristaTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_3 + GOOD_TERM_4, self.naming)
         acl = arista.Arista(pol, EXP_INFO)
         expected = 'remark this is a test standard acl'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = 'remark good-term-4'
         self.assertIn(expected, str(acl), str(acl))
         expected = 'test-filter remark'
@@ -282,7 +282,7 @@ class AristaTest(absltest.TestCase):
         acl = arista.Arista(pol, EXP_INFO)
         print(acl)
         expected = 'ip access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit tcp 10.1.1.0/24 any eq ssh'
         self.assertIn(expected, str(acl), str(acl))
         expected = ' permit tcp 10.1.1.0/24 any eq 6537'
@@ -297,7 +297,7 @@ class AristaTest(absltest.TestCase):
         acl = arista.Arista(pol, EXP_INFO)
         print(acl)
         expected = 'ipv6 access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit tcp 2620:1::/64 any eq ssh'
         self.assertIn(expected, str(acl), str(acl))
 
@@ -309,7 +309,7 @@ class AristaTest(absltest.TestCase):
         acl = arista.Arista(pol, EXP_INFO)
         print(acl)
         expected = 'ip access-list standard test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit 10.1.1.0/24\n'
         self.assertIn(expected, str(acl), str(acl))
 

--- a/tests/regression/arista_tp/arista_tp_test.py
+++ b/tests/regression/arista_tp/arista_tp_test.py
@@ -771,7 +771,7 @@ class AristaTpTest(absltest.TestCase):
     def testNoVerboseMixed(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP("192.168." + str(octet) + ".64/27")
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -790,7 +790,7 @@ class AristaTpTest(absltest.TestCase):
     def testNoVerboseV4(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP("192.168." + str(octet) + ".64/27")
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -809,7 +809,7 @@ class AristaTpTest(absltest.TestCase):
     def testNoVerboseV6(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IPv6("2001:db8:1010:" + str(octet) + "::64/64", strict=False)
+            net = nacaddr.IPv6(f"2001:db8:1010:{octet!s}::64/64", strict=False)
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -731,7 +731,7 @@ class CiscoTest(absltest.TestCase):
     def testDsmo(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP('192.168.' + str(octet) + '.64/27')
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
 
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -499,10 +499,8 @@ class CiscoTest(absltest.TestCase):
         )
         self.assertIn('access-list 50 remark numbered standard', str(acl), str(acl))
         self.assertIn('access-list 50 remark standard-term-1', str(acl), str(acl))
-        self.assertIn('access-list 50 remark {}Id:{}'.format('$', '$'), str(acl), str(acl))
-        self.assertNotIn(
-            'access-list 50 remark {}Revision:{}'.format('$', '$'), str(acl), str(acl)
-        )
+        self.assertIn('access-list 50 remark $Id:$', str(acl), str(acl))
+        self.assertNotIn('access-list 50 remark $Revision:$', str(acl), str(acl))
         print(acl)
 
     @capture.stdout

--- a/tests/regression/cisco/cisco_test.py
+++ b/tests/regression/cisco/cisco_test.py
@@ -450,7 +450,7 @@ class CiscoTest(absltest.TestCase):
         # this is a hacky sort of way to test that 'established' maps to HIGH_PORTS
         # in the destination port section.
         range_test = 'permit tcp any eq 80 10.0.0.0 0.255.255.255 range 1024 65535'
-        self.assertIn(range_test, str(acl), '[%s]' % str(acl))
+        self.assertIn(range_test, str(acl), f'[{acl!s}]')
         print(acl)
 
     @capture.stdout
@@ -461,8 +461,8 @@ class CiscoTest(absltest.TestCase):
         acl = cisco.Cisco(policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_14, self.naming), EXP_INFO)
         first_string = 'permit tcp any 10.0.0.0 0.255.255.255 eq 80'
         second_string = 'permit tcp any 10.0.0.0 0.255.255.255 eq 81'
-        self.assertIn(first_string, str(acl), '[%s]' % str(acl))
-        self.assertIn(second_string, str(acl), '[%s]' % str(acl))
+        self.assertIn(first_string, str(acl), f'[{acl!s}]')
+        self.assertIn(second_string, str(acl), f'[{acl!s}]')
         print(acl)
 
     @capture.stdout
@@ -543,7 +543,7 @@ class CiscoTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_STANDARD_HEADER_1 + GOOD_STANDARD_TERM_1, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
         expected = 'access-list 99 permit 10.1.1.1'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
 
         print(acl)
 
@@ -554,7 +554,7 @@ class CiscoTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_STANDARD_HEADER_1 + GOOD_STANDARD_TERM_2, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
         expected = 'access-list 99 permit 10.0.0.0 0.255.255.255'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         print(acl)
 
     @capture.stdout
@@ -564,9 +564,9 @@ class CiscoTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_STANDARD_HEADER_2 + GOOD_STANDARD_TERM_2, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
         expected = 'ip access-list standard FOO'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit 10.0.0.0 0.255.255.255\n'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         print(acl)
 
     @capture.stdout
@@ -575,7 +575,7 @@ class CiscoTest(absltest.TestCase):
 
         pol = policy.ParsePolicy(GOOD_STANDARD_HEADER_1 + GOOD_STANDARD_TERM_2, self.naming)
         acl = cisco.Cisco(pol, EXP_INFO)
-        self.assertNotIn('::', str(acl), '[%s]' % str(acl))
+        self.assertNotIn('::', str(acl), f'[{acl!s}]')
         print(acl)
 
     def testStandardFilterName(self):
@@ -640,8 +640,8 @@ class CiscoTest(absltest.TestCase):
         inet6_test1 = 'no ipv6 access-list inet6_acl'
         inet6_test2 = 'ipv6 access-list inet6_acl'
         inet6_test3 = 'permit tcp any 2001:4860:8000::/33'
-        self.assertIn(inet6_test1, str(acl), '[%s]' % str(acl))
-        self.assertIn(inet6_test2, str(acl), '[%s]' % str(acl))
+        self.assertIn(inet6_test1, str(acl), f'[{acl!s}]')
+        self.assertIn(inet6_test2, str(acl), f'[{acl!s}]')
         self.assertTrue(re.search(inet6_test3, str(acl)), str(acl))
         self.assertNotIn('10.0.0.0', str(acl), str(acl))
 
@@ -661,11 +661,11 @@ class CiscoTest(absltest.TestCase):
         inet6_test5 = 'ipv6 access-list ipv6-mixed_acl'
         inet6_test6 = 'permit tcp any 2001:4860:8000::/33'
         aclout = str(acl)
-        self.assertIn(inet6_test1, aclout, '[%s]' % aclout)
-        self.assertIn(inet6_test2, aclout, '[%s]' % aclout)
+        self.assertIn(inet6_test1, aclout, f'[{aclout}]')
+        self.assertIn(inet6_test2, aclout, f'[{aclout}]')
         self.assertTrue(re.search(inet6_test3, aclout), aclout)
-        self.assertIn(inet6_test4, aclout, '[%s]' % aclout)
-        self.assertIn(inet6_test5, aclout, '[%s]' % aclout)
+        self.assertIn(inet6_test4, aclout, f'[{aclout}]')
+        self.assertIn(inet6_test5, aclout, f'[{aclout}]')
         self.assertTrue(re.search(inet6_test6, aclout), aclout)
 
         print(acl)
@@ -698,11 +698,11 @@ class CiscoTest(absltest.TestCase):
         with mock.patch.object(cisco.logging, 'warning') as mock_warning:
             aclout = str(acl)
             mock_warning.assert_not_called()
-        self.assertIn(inet6_test1, aclout, '[%s]' % aclout)
-        self.assertIn(inet6_test2, aclout, '[%s]' % aclout)
+        self.assertIn(inet6_test1, aclout, f'[{aclout}]')
+        self.assertIn(inet6_test2, aclout, f'[{aclout}]')
         self.assertTrue(re.search(inet6_test3, aclout), aclout)
-        self.assertIn(inet6_test4, aclout, '[%s]' % aclout)
-        self.assertIn(inet6_test5, aclout, '[%s]' % aclout)
+        self.assertIn(inet6_test4, aclout, f'[{aclout}]')
+        self.assertIn(inet6_test5, aclout, f'[{aclout}]')
         self.assertFalse(re.search(inet6_test6, aclout), aclout)
 
         print(acl)
@@ -722,8 +722,8 @@ class CiscoTest(absltest.TestCase):
             ' as it has destination address match specified but '
             'no destination addresses of inet6 address family are present.'
         )
-        self.assertIn(inet6_test1, aclout, '[%s]' % aclout)
-        self.assertIn(inet6_test2, aclout, '[%s]' % aclout)
+        self.assertIn(inet6_test1, aclout, f'[{aclout}]')
+        self.assertIn(inet6_test2, aclout, f'[{aclout}]')
 
         print(acl)
 

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -221,8 +221,8 @@ class CiscoNXTest(absltest.TestCase):
         self.assertIn(expected, str(acl), str(acl))
         expected = 'test-filter remark'
         self.assertNotIn(expected, str(acl), str(acl))
-        self.assertNotIn(' remark {}Id:{}'.format('$', '$'), str(acl), str(acl))
-        self.assertIn(' remark "{}Revision:{}"'.format('$', '$'), str(acl), str(acl))
+        self.assertNotIn(' remark $Id:$', str(acl), str(acl))
+        self.assertIn(' remark "$Revision:$"', str(acl), str(acl))
         self.assertNotIn(' remark $', str(acl), str(acl))
 
         print(acl)

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -216,7 +216,7 @@ class CiscoNXTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_4, self.naming)
         acl = cisconx.CiscoNX(pol, EXP_INFO)
         expected = 'remark this is a test extended acl'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = 'remark good-term-4'
         self.assertIn(expected, str(acl), str(acl))
         expected = 'test-filter remark'
@@ -259,7 +259,7 @@ class CiscoNXTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_2 + GOOD_TERM_2 + GOOD_TERM_3, self.naming)
         acl = cisconx.CiscoNX(pol, EXP_INFO)
         expected = 'ip access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit tcp 10.1.1.0/24 any eq 22'
         self.assertIn(expected, str(acl), str(acl))
         expected = ' permit tcp 10.1.1.0/24 any eq 6537'
@@ -275,7 +275,7 @@ class CiscoNXTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_IPV6 + GOOD_TERM_2, self.naming)
         acl = cisconx.CiscoNX(pol, EXP_INFO)
         expected = 'ipv6 access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit tcp 2620:1::/64 any eq 22'
         self.assertIn(expected, str(acl), str(acl))
 

--- a/tests/regression/ciscoxr/ciscoxr_test.py
+++ b/tests/regression/ciscoxr/ciscoxr_test.py
@@ -189,7 +189,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_1, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'remark this is a test acl'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = 'remark good-term-1'
         self.assertIn(expected, str(acl), str(acl))
         expected = 'test-filter remark'
@@ -205,7 +205,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_1 + GOOD_TERM_4, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'ipv4 access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit icmp host 10.1.1.1 any'
         self.assertIn(expected, str(acl), str(acl))
         expected = ' permit ipv4 host 10.1.1.1 any'
@@ -222,7 +222,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_2 + GOOD_TERM_2 + GOOD_TERM_4, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'ipv6 access-list ipv6-test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit tcp any eq 80 host 2001::3'
         self.assertIn(expected, str(acl), str(acl))
         expected = ' permit ipv6 host 2001::3 any'
@@ -237,7 +237,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_5, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'ipv4 access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit ipv4 any any nexthop1 ipv4 10.1.1.1'
         self.assertIn(expected, str(acl), str(acl))
 
@@ -250,7 +250,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_2 + GOOD_TERM_5, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'ipv6 access-list ipv6-test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit ipv6 any any nexthop1 ipv6 2001::3'
         self.assertIn(expected, str(acl), str(acl))
 
@@ -284,7 +284,7 @@ class CiscoXRTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_6, self.naming)
         acl = ciscoxr.CiscoXR(pol, EXP_INFO)
         expected = 'ipv4 access-list test-filter'
-        self.assertIn(expected, str(acl), '[%s]' % str(acl))
+        self.assertIn(expected, str(acl), f'[{acl!s}]')
         expected = ' permit ipv4 any any'
         self.assertIn(expected, str(acl), str(acl))
         expected = 'nexthop1'

--- a/tests/regression/cloudarmor/cloudarmor_test.py
+++ b/tests/regression/cloudarmor/cloudarmor_test.py
@@ -882,7 +882,7 @@ class CloudArmorTest(absltest.TestCase):
             for _ in range(4):
                 random_ip_octets.append(str(int(random.randint(1, 255))))
             rand_ip = '.'.join(random_ip_octets)
-            test_1001_ips_list.append(str(nacaddr.IP(rand_ip + '/32')))
+            test_1001_ips_list.append(str(nacaddr.IP(f"{rand_ip}/32")))
 
         self.naming._ParseLine(
             f'GOOGLE_PUBLIC_DNS_ANYCAST = {" ".join(test_1001_ips_list)}', 'networks'

--- a/tests/regression/gcp_hf/gcp_hf_test.py
+++ b/tests/regression/gcp_hf/gcp_hf_test.py
@@ -2475,7 +2475,7 @@ SUPPORTED_SUB_TOKENS = {'action': {'accept', 'deny', 'next'}}
 
 EXP_INFO = 2
 
-MANY_IPS = ['192.168.' + str(x) + '.0/32' for x in range(0, 256)]
+MANY_IPS = [f"192.168.{x!s}.0/32" for x in range(0, 256)]
 MANY_IPS.extend(['10.0.0.1', '10.0.1.1'])
 
 

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -167,12 +167,12 @@ term good-term-5 {
 }
 """
 
-GOOD_TERM_6 = """
+GOOD_TERM_6 = f"""
 term good-term-6 {{
   comment:: "Some text describing what this block does,
              possibly including newines, blank lines,
              and extra-long comments (over 255 characters)
-             {long_line}
+             {'-' * 260}
 
              All these cause problems if passed verbatim to iptables.
              "
@@ -181,9 +181,7 @@ term good-term-6 {{
   action:: accept
 
 }}
-""".format(
-    long_line='-' * 260
-)
+"""
 
 
 GOOD_TERM_7 = """
@@ -1044,7 +1042,7 @@ class AclCheckTest(absltest.TestCase):
         acl = iptables.Iptables(pol, EXP_INFO)
         result = str(acl)
         self.assertIn(
-            '{} {}'.format('--tcp-flags ACK,FIN,RST,SYN RST', '--dport 1024:65535 -j ACCEPT'),
+            '--tcp-flags ACK,FIN,RST,SYN RST --dport 1024:65535 -j ACCEPT',
             result,
             'No rule matching packets with RST bit only.\n' + result,
         )
@@ -1103,7 +1101,7 @@ class AclCheckTest(absltest.TestCase):
             policy.ParsePolicy(GOOD_HEADER_1 + GOOD_MULTIPORT, self.naming), EXP_INFO
         )
         self.assertIn(
-            '-m multiport --sports %s' % ','.join(ports),
+            f"-m multiport --sports {','.join(ports)}",
             str(acl),
             'multiport module not used as expected.',
         )
@@ -1124,7 +1122,7 @@ class AclCheckTest(absltest.TestCase):
         acl = iptables.Iptables(
             policy.ParsePolicy(GOOD_HEADER_1 + GOOD_MULTIPORT_RANGE, self.naming), EXP_INFO
         )
-        expected = '-m multiport --dports %s' % ','.join(ports).replace('-', ':')
+        expected = f"-m multiport --dports {','.join(ports).replace('-', ':')}"
         self.assertIn(expected, str(acl), 'multiport module not used as expected.')
 
         print(acl)
@@ -1593,22 +1591,20 @@ YAML_GOOD_TERM_5 = """
       juniper: mary had third lamb
 """
 
-YAML_GOOD_TERM_6 = """
+YAML_GOOD_TERM_6 = f"""
   - name: good-term-6
     comment: |
         Some text describing what this block does,
         possibly including newines, blank lines,
         and extra-long comments (over 255 characters)
-        {long_line}
+        {'-' * 260}
 
         All these cause problems if passed verbatim to iptables.
                
     protocol: tcp
     action: accept
 
-""".format(
-    long_line='-' * 260
-)
+"""
 
 
 YAML_GOOD_TERM_7 = """

--- a/tests/regression/iptables/iptables_test.py
+++ b/tests/regression/iptables/iptables_test.py
@@ -746,16 +746,16 @@ class AclCheckTest(absltest.TestCase):
             % (len(source_range) * len(dest_range), result.count('\n')),
         )
         self.assertIn(
-            '-s 0.0.0.0/5 -j RETURN', result, 'expected address 0.0.0.0/5 to RETURN:\n' + result
+            '-s 0.0.0.0/5 -j RETURN', result, f"expected address 0.0.0.0/5 to RETURN:\n{result}"
         )
         self.assertIn(
             '-s 10.0.128.0/17 -j RETURN',
             result,
-            'expected address 10.0.128.0/17 not jumping to RETURN:\n' + result,
+            f"expected address 10.0.128.0/17 not jumping to RETURN:\n{result}",
         )
         self.assertTrue(
             re.search('--sport 80 -d 10.0.1.0/25 [^\n]* -j ACCEPT', result),
-            'expected destination addresss 10.0.1.0/25 accepted:\n' + result,
+            f"expected destination addresss 10.0.1.0/25 accepted:\n{result}",
         )
         print(result)
 
@@ -793,16 +793,16 @@ class AclCheckTest(absltest.TestCase):
             % (len(source_range) * len(dest_range), result.count('\n')),
         )
         self.assertIn(
-            '-d 0.0.0.0/5 -j RETURN', result, 'expected address 0.0.0.0/5 to RETURN:\n' + result
+            '-d 0.0.0.0/5 -j RETURN', result, f"expected address 0.0.0.0/5 to RETURN:\n{result}"
         )
         self.assertIn(
             '-d 10.0.128.0/17 -j RETURN',
             result,
-            'expected address 10.0.128.0/17 not jumping to RETURN:\n' + result,
+            f"expected address 10.0.128.0/17 not jumping to RETURN:\n{result}",
         )
         self.assertTrue(
             re.search('--sport 80 -s 10.0.1.0/25 [^\n]* -j ACCEPT', result),
-            'expected destination addresss 10.0.1.0/25 accepted:\n' + result,
+            f"expected destination addresss 10.0.1.0/25 accepted:\n{result}",
         )
         print(result)
 
@@ -1044,7 +1044,7 @@ class AclCheckTest(absltest.TestCase):
         self.assertIn(
             '--tcp-flags ACK,FIN,RST,SYN RST --dport 1024:65535 -j ACCEPT',
             result,
-            'No rule matching packets with RST bit only.\n' + result,
+            f"No rule matching packets with RST bit only.\n{result}",
         )
         self.assertNotIn(
             '--state', result, 'Nostate header should not use nf_conntrack --state flag'
@@ -1059,7 +1059,7 @@ class AclCheckTest(absltest.TestCase):
         self.assertIn(
             '-p udp --dport 1024:65535 -j ACCEPT',
             result,
-            'No rule matching TCP packets with ACK bit.\n' + result,
+            f"No rule matching TCP packets with ACK bit.\n{result}",
         )
         self.assertNotIn(
             '--state', result, 'Nostate header should not use nf_conntrack --state flag'

--- a/tests/regression/juniper/juniper_test.py
+++ b/tests/regression/juniper/juniper_test.py
@@ -1241,7 +1241,7 @@ class JuniperTest(parameterized.TestCase):
     def testNoVerboseV4(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP('192.168.' + str(octet) + '.64/27')
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -1260,7 +1260,7 @@ class JuniperTest(parameterized.TestCase):
     def testNoVerboseV6(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IPv6('2001:db8:1010:' + str(octet) + '::64/64', strict=False)
+            net = nacaddr.IPv6(f"2001:db8:1010:{octet!s}::64/64", strict=False)
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -1279,7 +1279,7 @@ class JuniperTest(parameterized.TestCase):
     def testDsmo(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP('192.168.' + str(octet) + '.64/27')
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')

--- a/tests/regression/junipermsmpc/junipermsmpc_test.py
+++ b/tests/regression/junipermsmpc/junipermsmpc_test.py
@@ -802,7 +802,7 @@ class JuniperMSMPCTest(parameterized.TestCase):
     def testNoVerboseV4(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IP('192.168.' + str(octet) + '.64/27')
+            net = nacaddr.IP(f"192.168.{octet!s}.64/27")
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -821,7 +821,7 @@ class JuniperMSMPCTest(parameterized.TestCase):
     def testNoVerboseV6(self):
         addr_list = list()
         for octet in range(0, 256):
-            net = nacaddr.IPv6('2001:db8:1010:' + str(octet) + '::64/64', strict=False)
+            net = nacaddr.IPv6(f"2001:db8:1010:{octet!s}::64/64", strict=False)
             addr_list.append(str(net))
         self.naming._ParseLine(f'SOME_HOST = {" ".join(addr_list)}', 'networks')
         self.naming._ParseLine('SMTP = 25/tcp', 'services')
@@ -1826,7 +1826,7 @@ class JuniperMSMPCTest(parameterized.TestCase):
 
     def testTermNameCollision(self):
         short_append = '1' * (junipermsmpc.MAX_IDENTIFIER_LEN // 2 - len('?ood-term-1'))
-        long_append = short_append + '1'
+        long_append = f"{short_append}1"
         not_too_long_name = TERM_NAME_COLLISION % (short_append, short_append)
         too_long_name = TERM_NAME_COLLISION % (long_append, long_append)
         pol = policy.ParsePolicy(GOOD_HEADER + too_long_name, self.naming)

--- a/tests/regression/k8s/k8s_test.py
+++ b/tests/regression/k8s/k8s_test.py
@@ -674,7 +674,7 @@ class K8sTest(parameterized.TestCase):
         for name in INVALID_TERM_NAMES:
             pol = policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_CUSTOM_NAME % name, self.naming)
             self.assertRaisesRegex(
-                k8s.K8sNetworkPolicyError, 'name %s is not valid' % name, k8s.K8s, pol, EXP_INFO
+                k8s.K8sNetworkPolicyError, f'name {name} is not valid', k8s.K8s, pol, EXP_INFO
             )
 
     def testSkipExpiredTerm(self):

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -556,11 +556,11 @@ SUPPORTED_SUB_TOKENS = {
 EXP_INFO = 2
 
 PATH_VSYS = "./devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']"
-PATH_RULES = PATH_VSYS + '/rulebase/security/rules'
-PATH_TAG = PATH_VSYS + '/tag'
-PATH_SERVICE = PATH_VSYS + '/service'
-PATH_ADDRESSES = PATH_VSYS + '/address'
-PATH_ADDRESS_GROUP = PATH_VSYS + '/address-group'
+PATH_RULES = f"{PATH_VSYS}/rulebase/security/rules"
+PATH_TAG = f"{PATH_VSYS}/tag"
+PATH_SERVICE = f"{PATH_VSYS}/service"
+PATH_ADDRESSES = f"{PATH_VSYS}/address"
+PATH_ADDRESS_GROUP = f"{PATH_VSYS}/address-group"
 
 
 class PaloAltoFWTest(absltest.TestCase):
@@ -577,7 +577,7 @@ class PaloAltoFWTest(absltest.TestCase):
             policy.ParsePolicy(GOOD_HEADER_1 + GOOD_TERM_1, self.naming), EXP_INFO
         )
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='good-term-1']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='good-term-1']")
         self.assertIsNotNone(x, output)
 
         print(output)
@@ -617,7 +617,7 @@ class PaloAltoFWTest(absltest.TestCase):
             policy.ParsePolicy(GOOD_HEADER_1 + DEFAULT_TERM_1, self.naming), EXP_INFO
         )
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='default-term-1']/action")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='default-term-1']/action")
         self.assertIsNotNone(x, output)
         self.assertEqual(x.text, 'deny', output)
         print(output)
@@ -627,7 +627,7 @@ class PaloAltoFWTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ICMP_TYPE_TERM_1, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmp']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmp']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -646,7 +646,7 @@ class PaloAltoFWTest(absltest.TestCase):
         )
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmp']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmp']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -658,7 +658,7 @@ class PaloAltoFWTest(absltest.TestCase):
         )
 
         # Check second policy as well.
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmp-2']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmp-2']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -675,7 +675,7 @@ class PaloAltoFWTest(absltest.TestCase):
         pol = policy.ParsePolicy(GOOD_HEADER_MIXED + ICMPV6_TYPE_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmpv6-types']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmpv6-types']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -695,7 +695,7 @@ class PaloAltoFWTest(absltest.TestCase):
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         x = paloalto.config.find(
-            PATH_RULES + "/entry[@name='test-icmpv6-abbreviation-types']/application"
+            f"{PATH_RULES}/entry[@name='test-icmpv6-abbreviation-types']/application"
         )
         self.assertIsNotNone(x, output)
         members = []
@@ -770,7 +770,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ICMP_ONLY_TERM_1, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmp-only']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmp-only']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -785,7 +785,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_INET6 + ICMPV6_ONLY_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-icmpv6-only']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-icmpv6-only']/application")
         self.assertIsNotNone(x, output)
         members = []
         for node in x:
@@ -806,11 +806,11 @@ term rule-1 {
         )
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='a5f554bb7a8276615edbd5de-test-icmp']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='a5f554bb7a8276615edbd5de-test-icmp']")
         self.assertIsNotNone(x, output)
 
         # Check second policy as well.
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='e7d22ea748e04110eaf0495e-test-icmp']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='e7d22ea748e04110eaf0495e-test-icmp']")
         self.assertIsNotNone(x, output)
         print(output)
 
@@ -827,7 +827,7 @@ term rule-1 {
 
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='good-term-stateless-reply']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='good-term-stateless-reply']")
         self.assertIsNone(x, output)
         print(output)
 
@@ -837,14 +837,14 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + TCP_ESTABLISHED_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='tcp-established']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='tcp-established']")
         self.assertIsNone(x, output)
         print(output)
 
         pol = policy.ParsePolicy(GOOD_HEADER_1 + UDP_ESTABLISHED_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='udp-established-term']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='udp-established-term']")
         self.assertIsNone(x, output)
         print(output)
 
@@ -871,9 +871,9 @@ term rule-1 {
             policy.ParsePolicy(GOOD_HEADER_1 + LOGGING_BOTH_TERM, self.naming), EXP_INFO
         )
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-log-both']/log-start")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-log-both']/log-start")
         self.assertEqual(x, 'yes', output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-log-both']/log-end")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-log-both']/log-end")
         self.assertEqual(x, 'yes', output)
         print(output)
 
@@ -883,9 +883,9 @@ term rule-1 {
             policy.ParsePolicy(GOOD_HEADER_1 + LOGGING_DISABLED, self.naming), EXP_INFO
         )
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-disabled-log']/log-start")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-disabled-log']/log-start")
         self.assertEqual(x, 'no', output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-disabled-log']/log-end")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-disabled-log']/log-end")
         self.assertEqual(x, 'no', output)
         print(output)
 
@@ -904,9 +904,9 @@ term rule-1 {
 
             # we don't have term name so match all elements with attribute
             # name at the entry level
-            x = paloalto.config.findall(PATH_RULES + '/entry[@name]/log-start')
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name]/log-start")
             self.assertEqual(len(x), 0, output)
-            x = paloalto.config.findall(PATH_RULES + '/entry[@name]/log-end')
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name]/log-end")
             self.assertEqual(len(x), 1, output)
             self.assertEqual(x[0].text, 'yes', output)
             print(output)
@@ -916,7 +916,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ACTION_ACCEPT_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-accept-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-accept-action']/action")
         self.assertEqual(x, 'allow', output)
         print(output)
 
@@ -925,7 +925,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ACTION_DENY_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-deny-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-deny-action']/action")
         self.assertEqual(x, 'deny', output)
         print(output)
 
@@ -934,7 +934,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ACTION_REJECT_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-reject-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-reject-action']/action")
         self.assertEqual(x, 'reset-client', output)
         print(output)
 
@@ -943,7 +943,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ACTION_RESET_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-reset-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-reset-action']/action")
         self.assertEqual(x, 'reset-client', output)
         print(output)
 
@@ -964,7 +964,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + PLATFORM_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-accept-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-accept-action']/action")
         self.assertEqual(x, 'allow', output)
         print(output)
 
@@ -973,7 +973,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + OTHER_PLATFORM_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-accept-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-accept-action']/action")
         self.assertIsNone(x, output)
         print(output)
 
@@ -982,7 +982,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + PLATFORM_EXCLUDE_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-accept-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-accept-action']/action")
         self.assertIsNone(x, output)
         print(output)
 
@@ -991,7 +991,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + OTHER_PLATFORM_EXCLUDE_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='test-accept-action']/action")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='test-accept-action']/action")
         self.assertEqual(x, 'allow', output)
         print(output)
 
@@ -1001,7 +1001,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + GRE_PROTO_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-gre-protocol']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-gre-protocol']/application")
         self.assertIsNotNone(x, output)
         self.assertEqual(len(x), 1, output)
         self.assertEqual(x[0].tag, 'member', output)
@@ -1014,7 +1014,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + AH_PROTO_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-ah-protocol']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-ah-protocol']/application")
         self.assertIsNotNone(x, output)
         self.assertEqual(len(x), 1, output)
         self.assertEqual(x[0].tag, 'member', output)
@@ -1027,14 +1027,14 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + AH_TCP_MIXED_PROTO_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        svc = paloalto.config.find(PATH_RULES + "/entry[@name='test-mixed-protocol-1']/service")
+        svc = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-mixed-protocol-1']/service")
         self.assertIsNotNone(svc, output)
         self.assertEqual(len(svc), 1, output)
         self.assertEqual(svc[0].tag, 'member', output)
         self.assertEqual(svc[0].text, 'any-tcp', output)
 
         app = paloalto.config.find(
-            PATH_RULES + "/entry[@name='test-mixed-protocol-1']/application"
+            f"{PATH_RULES}/entry[@name='test-mixed-protocol-1']/application"
         )
         self.assertIsNotNone(app, output)
         self.assertEqual(len(app), 1, output)
@@ -1042,14 +1042,14 @@ term rule-1 {
         self.assertEqual(app[0].text, 'any', output)
 
         # Check second policy as well.
-        svc = paloalto.config.find(PATH_RULES + "/entry[@name='test-mixed-protocol-2']/service")
+        svc = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-mixed-protocol-2']/service")
         self.assertIsNotNone(svc, output)
         self.assertEqual(len(svc), 1, output)
         self.assertEqual(svc[0].tag, 'member', output)
         self.assertEqual(svc[0].text, 'application-default', output)
 
         app = paloalto.config.find(
-            PATH_RULES + "/entry[@name='test-mixed-protocol-2']/application"
+            f"{PATH_RULES}/entry[@name='test-mixed-protocol-2']/application"
         )
         self.assertIsNotNone(app, output)
         self.assertEqual(len(app), 1, output)
@@ -1063,7 +1063,7 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ESP_PROTO_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='test-esp-protocol']/application")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-esp-protocol']/application")
         self.assertIsNotNone(x, output)
         self.assertEqual(len(x), 1, output)
         self.assertEqual(x[0].tag, 'member', output)
@@ -1076,14 +1076,14 @@ term rule-1 {
         pol = policy.ParsePolicy(GOOD_HEADER_1 + ESP_TCP_MIXED_PROTO_TERM, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        svc = paloalto.config.find(PATH_RULES + "/entry[@name='test-mixed-protocol-1']/service")
+        svc = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-mixed-protocol-1']/service")
         self.assertIsNotNone(svc, output)
         self.assertEqual(len(svc), 1, output)
         self.assertEqual(svc[0].tag, 'member', output)
         self.assertEqual(svc[0].text, 'any-tcp', output)
 
         app = paloalto.config.find(
-            PATH_RULES + "/entry[@name='test-mixed-protocol-1']/application"
+            f"{PATH_RULES}/entry[@name='test-mixed-protocol-1']/application"
         )
         self.assertIsNotNone(app, output)
         self.assertEqual(len(app), 1, output)
@@ -1091,14 +1091,14 @@ term rule-1 {
         self.assertEqual(app[0].text, 'any', output)
 
         # Check second policy as well.
-        svc = paloalto.config.find(PATH_RULES + "/entry[@name='test-mixed-protocol-2']/service")
+        svc = paloalto.config.find(f"{PATH_RULES}/entry[@name='test-mixed-protocol-2']/service")
         self.assertIsNotNone(svc, output)
         self.assertEqual(len(svc), 1, output)
         self.assertEqual(svc[0].tag, 'member', output)
         self.assertEqual(svc[0].text, 'application-default', output)
 
         app = paloalto.config.find(
-            PATH_RULES + "/entry[@name='test-mixed-protocol-2']/application"
+            f"{PATH_RULES}/entry[@name='test-mixed-protocol-2']/application"
         )
         self.assertIsNotNone(app, output)
         self.assertEqual(len(app), 1, output)
@@ -1113,26 +1113,26 @@ term rule-1 {
         output = str(paloalto)
 
         tag = 'trust_untrust_policy-comment-1'
-        x = paloalto.config.find(PATH_TAG + f"/entry[@name='{tag}']/comments")
+        x = paloalto.config.find(f"{PATH_TAG}/entry[@name='{tag}']/comments")
         self.assertIsNotNone(x, output)
         self.assertEqual(x.text, 'comment 1 comment 2', output)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='policy-2']/tag")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='policy-2']/tag")
         self.assertIsNotNone(x, output)
         self.assertEqual(len(x), 1, output)
         self.assertEqual(x[0].tag, 'member', output)
         self.assertEqual(x[0].text, tag, output)
 
         tag = 'trust_dmz_policy-comment-2'
-        x = paloalto.config.find(PATH_TAG + f"/entry[@name='{tag}']/comments")
+        x = paloalto.config.find(f"{PATH_TAG}/entry[@name='{tag}']/comments")
         self.assertIsNotNone(x, output)
         self.assertEqual(x.text, 'comment 3', output)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='policy-3']/tag")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='policy-3']/tag")
         self.assertIsNotNone(x, output)
         self.assertEqual(len(x), 1, output)
         self.assertEqual(x[0].tag, 'member', output)
         self.assertEqual(x[0].text, tag, output)
 
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='policy-4']/tag")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='policy-4']/tag")
         self.assertIsNone(x, output)
         print(output)
 
@@ -1145,7 +1145,7 @@ term rule-1 {
         pol = policy.ParsePolicy(ZONE_LEN_ERROR % (ZONE_MAX_LEN, 'dmz'), self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='policy']/from/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='policy']/from/member")
         self.assertEqual(x, ZONE_MAX_LEN, output)
 
         pol = policy.ParsePolicy(ZONE_LEN_ERROR % (ZONE_TOO_LONG, 'dmz'), self.naming)
@@ -1162,7 +1162,7 @@ term rule-1 {
         pol = policy.ParsePolicy(ZONE_LEN_ERROR % ('dmz', ZONE_MAX_LEN), self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='policy']/to/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='policy']/to/member")
         self.assertEqual(x, ZONE_MAX_LEN, output)
 
         pol = policy.ParsePolicy(ZONE_LEN_ERROR % ('dmz', ZONE_TOO_LONG), self.naming)
@@ -1218,9 +1218,9 @@ term rule-1 {
         output = str(paloalto)
         print(output)
 
-        x = paloalto.config.findtext(PATH_TAG + f"/entry[@name='{tag}']/comments")
+        x = paloalto.config.findtext(f"{PATH_TAG}/entry[@name='{tag}']/comments")
         self.assertEqual(x, 'C' * MAX_TAG_COMMENTS_LENGTH, output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/description")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/description")
         self.assertEqual(x, 'C' * MAX_RULE_DESCRIPTION_LENGTH, output)
 
         # maximum length + 1
@@ -1237,9 +1237,9 @@ term rule-1 {
             self.assertIn('comments exceeds maximum length', log.output[0])
             self.assertIn('description exceeds maximum length', log.output[1])
 
-        x = paloalto.config.findtext(PATH_TAG + f"/entry[@name='{tag}']/comments")
+        x = paloalto.config.findtext(f"{PATH_TAG}/entry[@name='{tag}']/comments")
         self.assertEqual(x, 'C' * MAX_TAG_COMMENTS_LENGTH, output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/description")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/description")
         self.assertEqual(x, 'C' * MAX_RULE_DESCRIPTION_LENGTH, output)
 
     @capture.stdout
@@ -1262,7 +1262,7 @@ term %s {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.find(PATH_RULES + f"/entry[@name='{term}']")
+        x = paloalto.config.find(f"{PATH_RULES}/entry[@name='{term}']")
         self.assertIsNotNone(x, output)
 
         # maximum length + 1
@@ -1353,7 +1353,7 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/application/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/application/member")
         self.assertEqual(x, 'any', output)
 
         for i, app in enumerate(APPS):
@@ -1361,7 +1361,7 @@ term rule-1 {
             paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
             output = str(paloalto)
             print(output)
-            x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/application/member")
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/application/member")
             apps = {elem.text for elem in x}
             self.assertEqual(APPS[i], apps, output)
 
@@ -1370,7 +1370,7 @@ term rule-1 {
             paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
             output = str(paloalto)
             print(output)
-            x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/application/member")
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/application/member")
             apps = {elem.text for elem in x}
             self.assertEqual(APPS[i], apps, output)
 
@@ -1378,14 +1378,14 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/service/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/service/member")
         self.assertEqual(x, 'application-default', output)
 
         pol = policy.ParsePolicy(POL3 % T1, self.naming)
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/service/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/service/member")
         self.assertEqual(x, 'any-tcp', output)
 
         definitions = naming.Naming()
@@ -1395,7 +1395,7 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/service/member")
+        x = paloalto.config.findtext(f"{PATH_RULES}/entry[@name='rule-1']/service/member")
         self.assertEqual(x, 'service-rule-1-tcp', output)
 
         regex = '^Term rule-1 contains non tcp, udp protocols ' 'with pan-application:'
@@ -1521,7 +1521,7 @@ term rule-1 {
         path = f"/entry[@name='{name}']/protocol/udp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "0-65535", output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/service/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/service/member")
         services = {elem.text for elem in x}
         self.assertEqual({"any-tcp", "any-udp"}, services, output)
 
@@ -1544,11 +1544,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1-1']/service/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1-1']/service/member")
         self.assertTrue(len(x) > 0, output)
         services = {elem.text for elem in x}
         self.assertEqual({"any-udp"}, services, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1-2']/application/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1-2']/application/member")
         self.assertTrue(len(x) > 0, output)
         applications = {elem.text for elem in x}
         self.assertEqual({"icmp"}, applications, output)
@@ -1561,11 +1561,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1-1']/service/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1-1']/service/member")
         self.assertTrue(len(x) > 0, output)
         services = {elem.text for elem in x}
         self.assertEqual({"any-udp", "any-tcp"}, services, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1-2']/application/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1-2']/application/member")
         self.assertTrue(len(x) > 0, output)
         applications = {elem.text for elem in x}
         self.assertEqual({"icmp", "gre"}, applications, output)
@@ -1585,7 +1585,7 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any"}, values, output)
@@ -1595,13 +1595,13 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any-ipv4"}, values, output)
-            x = paloalto.config.find(PATH_RULES + "/entry[@name='rule-1']/negate-source")
+            x = paloalto.config.find(f"{PATH_RULES}/entry[@name='rule-1']/negate-source")
             self.assertIsNone(x, output)
-            x = paloalto.config.find(PATH_RULES + "/entry[@name='rule-1']/negate-destination")
+            x = paloalto.config.find(f"{PATH_RULES}/entry[@name='rule-1']/negate-destination")
             self.assertIsNone(x, output)
 
         pol = policy.ParsePolicy(POL % "inet6", self.naming)
@@ -1609,13 +1609,13 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
+            x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any-ipv4"}, values, output)
-            x = paloalto.config.find(PATH_RULES + "/entry[@name='rule-1']/negate-source")
+            x = paloalto.config.find(f"{PATH_RULES}/entry[@name='rule-1']/negate-source")
             self.assertIsNotNone(x, output)
-            x = paloalto.config.find(PATH_RULES + "/entry[@name='rule-1']/negate-destination")
+            x = paloalto.config.find(f"{PATH_RULES}/entry[@name='rule-1']/negate-destination")
             self.assertIsNotNone(x, output)
 
     @capture.stdout
@@ -1650,11 +1650,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.1.0.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.2.0.0/24", "10.3.1.0/24", "10.3.2.0/24"}, addrs, output)
@@ -1667,11 +1667,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"2001:db8:0:aa::/64", "2001:db8:0:bb::/64"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"any"}, addrs, output)
@@ -1684,11 +1684,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"any"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual(
@@ -1704,11 +1704,11 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"4000::/3", "6000::/3"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"8000::/3", "a000::/3", "c000::/3", "e000::/3"}, addrs, output)
@@ -1769,39 +1769,39 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET1']/static/member")
+        x = paloalto.config.findall(f"{PATH_ADDRESS_GROUP}/entry[@name='NET1']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET1_0"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET1_0']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET1_0']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.1.0.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET2", "NET3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET2']/static/member")
+        x = paloalto.config.findall(f"{PATH_ADDRESS_GROUP}/entry[@name='NET2']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET2_0"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET2_0']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET2_0']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.2.0.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET3']/static/member")
+        x = paloalto.config.findall(f"{PATH_ADDRESS_GROUP}/entry[@name='NET3']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET3_0", "NET3_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_0']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET3_0']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.3.1.0/24"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET3_1']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET3_1']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"10.3.2.0/24"}, addrs, output)
@@ -1814,19 +1814,19 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/source/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/source/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET5"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        x = paloalto.config.findall(f"{PATH_ADDRESS_GROUP}/entry[@name='NET5']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET5_0']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"4000::/3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET5_1']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"6000::/3"}, addrs, output)
@@ -1839,19 +1839,19 @@ term rule-1 {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/destination/member")
+        x = paloalto.config.findall(f"{PATH_RULES}/entry[@name='rule-1']/destination/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET5"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESS_GROUP + "/entry[@name='NET5']/static/member")
+        x = paloalto.config.findall(f"{PATH_ADDRESS_GROUP}/entry[@name='NET5']/static/member")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"NET5_0", "NET5_1"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_0']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET5_0']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"4000::/3"}, addrs, output)
-        x = paloalto.config.findall(PATH_ADDRESSES + "/entry[@name='NET5_1']/ip-netmask")
+        x = paloalto.config.findall(f"{PATH_ADDRESSES}/entry[@name='NET5_1']/ip-netmask")
         self.assertTrue(len(x) > 0, output)
         addrs = {elem.text for elem in x}
         self.assertEqual({"6000::/3"}, addrs, output)

--- a/tests/regression/paloaltofw/paloaltofw_test.py
+++ b/tests/regression/paloaltofw/paloaltofw_test.py
@@ -1113,7 +1113,7 @@ term rule-1 {
         output = str(paloalto)
 
         tag = 'trust_untrust_policy-comment-1'
-        x = paloalto.config.find(PATH_TAG + "/entry[@name='%s']/comments" % tag)
+        x = paloalto.config.find(PATH_TAG + f"/entry[@name='{tag}']/comments")
         self.assertIsNotNone(x, output)
         self.assertEqual(x.text, 'comment 1 comment 2', output)
         x = paloalto.config.find(PATH_RULES + "/entry[@name='policy-2']/tag")
@@ -1123,7 +1123,7 @@ term rule-1 {
         self.assertEqual(x[0].text, tag, output)
 
         tag = 'trust_dmz_policy-comment-2'
-        x = paloalto.config.find(PATH_TAG + "/entry[@name='%s']/comments" % tag)
+        x = paloalto.config.find(PATH_TAG + f"/entry[@name='{tag}']/comments")
         self.assertIsNotNone(x, output)
         self.assertEqual(x.text, 'comment 3', output)
         x = paloalto.config.find(PATH_RULES + "/entry[@name='policy-3']/tag")
@@ -1218,7 +1218,7 @@ term rule-1 {
         output = str(paloalto)
         print(output)
 
-        x = paloalto.config.findtext(PATH_TAG + "/entry[@name='%s']/comments" % tag)
+        x = paloalto.config.findtext(PATH_TAG + f"/entry[@name='{tag}']/comments")
         self.assertEqual(x, 'C' * MAX_TAG_COMMENTS_LENGTH, output)
         x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/description")
         self.assertEqual(x, 'C' * MAX_RULE_DESCRIPTION_LENGTH, output)
@@ -1237,7 +1237,7 @@ term rule-1 {
             self.assertIn('comments exceeds maximum length', log.output[0])
             self.assertIn('description exceeds maximum length', log.output[1])
 
-        x = paloalto.config.findtext(PATH_TAG + "/entry[@name='%s']/comments" % tag)
+        x = paloalto.config.findtext(PATH_TAG + f"/entry[@name='{tag}']/comments")
         self.assertEqual(x, 'C' * MAX_TAG_COMMENTS_LENGTH, output)
         x = paloalto.config.findtext(PATH_RULES + "/entry[@name='rule-1']/description")
         self.assertEqual(x, 'C' * MAX_RULE_DESCRIPTION_LENGTH, output)
@@ -1262,7 +1262,7 @@ term %s {
         paloalto = paloaltofw.PaloAltoFW(pol, EXP_INFO)
         output = str(paloalto)
         print(output)
-        x = paloalto.config.find(PATH_RULES + "/entry[@name='%s']" % term)
+        x = paloalto.config.find(PATH_RULES + f"/entry[@name='{term}']")
         self.assertIsNotNone(x, output)
 
         # maximum length + 1
@@ -1447,10 +1447,10 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         name = "service-rule-1-udp"
-        path = "/entry[@name='%s']/protocol/udp/port" % name
+        path = f"/entry[@name='{name}']/protocol/udp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "123", output)
-        path = "/entry[@name='%s']/protocol/udp/source-port" % name
+        path = f"/entry[@name='{name}']/protocol/udp/source-port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertIsNone(x, output)
 
@@ -1464,10 +1464,10 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         name = "service-rule-1-udp"
-        path = "/entry[@name='%s']/protocol/udp/port" % name
+        path = f"/entry[@name='{name}']/protocol/udp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "0-65535", output)
-        path = "/entry[@name='%s']/protocol/udp/source-port" % name
+        path = f"/entry[@name='{name}']/protocol/udp/source-port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "123", output)
 
@@ -1482,10 +1482,10 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         name = "service-rule-1-tcp"
-        path = "/entry[@name='%s']/protocol/tcp/port" % name
+        path = f"/entry[@name='{name}']/protocol/tcp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "53,123", output)
-        path = "/entry[@name='%s']/protocol/tcp/source-port" % name
+        path = f"/entry[@name='{name}']/protocol/tcp/source-port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "123", output)
 
@@ -1498,10 +1498,10 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         name = "any-tcp"
-        path = "/entry[@name='%s']/protocol/tcp/port" % name
+        path = f"/entry[@name='{name}']/protocol/tcp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "0-65535", output)
-        path = "/entry[@name='%s']/protocol/tcp/source-port" % name
+        path = f"/entry[@name='{name}']/protocol/tcp/source-port"
         x = paloalto.config.find(PATH_SERVICE + path)
         self.assertIsNone(x, output)
 
@@ -1514,11 +1514,11 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         name = "any-tcp"
-        path = "/entry[@name='%s']/protocol/tcp/port" % name
+        path = f"/entry[@name='{name}']/protocol/tcp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "0-65535", output)
         name = "any-udp"
-        path = "/entry[@name='%s']/protocol/udp/port" % name
+        path = f"/entry[@name='{name}']/protocol/udp/port"
         x = paloalto.config.findtext(PATH_SERVICE + path)
         self.assertEqual(x, "0-65535", output)
         x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/service/member")
@@ -1585,7 +1585,7 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/%s/member" % srcdst)
+            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any"}, values, output)
@@ -1595,7 +1595,7 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/%s/member" % srcdst)
+            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any-ipv4"}, values, output)
@@ -1609,7 +1609,7 @@ term rule-1 {
         output = str(paloalto)
         print(output)
         for srcdst in ["source", "destination"]:
-            x = paloalto.config.findall(PATH_RULES + "/entry[@name='rule-1']/%s/member" % srcdst)
+            x = paloalto.config.findall(PATH_RULES + f"/entry[@name='rule-1']/{srcdst}/member")
             self.assertTrue(len(x) == 1, output)
             values = {elem.text for elem in x}
             self.assertEqual({"any-ipv4"}, values, output)

--- a/tests/regression/proxmox/proxmox_test.py
+++ b/tests/regression/proxmox/proxmox_test.py
@@ -363,7 +363,7 @@ class ProxmoxFWTest(absltest.TestCase):
         acl = proxmox.Proxmox(pol, EXP_INFO)
         output = str(acl)
         for t in ['redirect', 'router-advertisement', 'mask-request', 'mask-reply']:
-            self.assertIn('-icmp-type %s' % proxmox.ProxmoxIcmp.ICMPv4_MAP[t][None], output)
+            self.assertIn(f'-icmp-type {proxmox.ProxmoxIcmp.ICMPv4_MAP[t][None]}', output)
         print(output)
 
     @capture.stdout

--- a/tests/regression/windows_advfirewall/windows_advfirewall_test.py
+++ b/tests/regression/windows_advfirewall/windows_advfirewall_test.py
@@ -264,7 +264,7 @@ class WindowsAdvFirewallTest(absltest.TestCase):
 
     def assertTrue(self, strings, result, term):
         for string in strings:
-            fullstring = 'netsh advfirewall firewall add rule %s' % (string)
+            fullstring = f'netsh advfirewall firewall add rule {string}'
             super().assertIn(
                 fullstring,
                 result,

--- a/tests/regression/windows_ipsec/windows_ipsec_test.py
+++ b/tests/regression/windows_ipsec/windows_ipsec_test.py
@@ -123,7 +123,7 @@ class WindowsIPSecTest(absltest.TestCase):
     # pylint: disable=invalid-name
     def assertTrue(self, strings, result, term):
         for string in strings:
-            fullstring = 'netsh ipsec static add %s' % (string)
+            fullstring = f'netsh ipsec static add {string}'
             super().assertIn(fullstring, result, f'did not find "{fullstring}" for {term}')
 
     @capture.stdout

--- a/tests/regression/yaml/yaml_regression_test.py
+++ b/tests/regression/yaml/yaml_regression_test.py
@@ -758,7 +758,7 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
         print(pol)
         icmp_types = ['echo-reply', 'echo-request', 'unreachable']
-        expected = 'icmp_type: %s' % icmp_types
+        expected = f'icmp_type: {icmp_types}'
         self.assertIn(expected, str(pol))
 
     @capture.stdout
@@ -1318,8 +1318,8 @@ class YAMLPolicyTermTest(absltest.TestCase):
         )
         print(pol)
         zones = ['zone1', 'zone2']
-        expected_source = 'source_zone: %s' % zones
-        expected_destination = 'destination_zone: %s' % zones
+        expected_source = f'source_zone: {zones}'
+        expected_destination = f'destination_zone: {zones}'
         self.assertIn(expected_source, str(pol))
         self.assertIn(expected_destination, str(pol))
 

--- a/tests/regression_utils/capture.py
+++ b/tests/regression_utils/capture.py
@@ -124,8 +124,8 @@ def files(filenames):
 
             failed_assertion = None
             for filename in filenames:
-                file_base = ".".join([func.__qualname__, filename])
-                file_ref = ".".join([file_base, "ref"])
+                file_base = f"{func.__qualname__}.{filename}"
+                file_ref = f"{file_base}.ref"
                 try:
                     with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                         self.assertEqual(
@@ -135,7 +135,7 @@ def files(filenames):
                 except OSError:
                     try:
                         with open(
-                            os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                            os.path.join(_testdir(func), f"{file_base}.actual"),
                             "w",
                         ) as actual:
                             actual.write(_collapse_mock_writes(inner_mocks, filename))
@@ -152,7 +152,7 @@ def files(filenames):
                 except AssertionError as e:
                     try:
                         with open(
-                            os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                            os.path.join(_testdir(func), f"{file_base}.actual"),
                             "w",
                         ) as actual:
                             actual.write(_collapse_mock_writes(inner_mocks, filename))
@@ -177,15 +177,15 @@ def stdout(func):
         with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             retval = func(self, *args, **kwargs)
             base_name = ".".join(func.__qualname__.split(".")[0:-1] + [self._testMethodName])
-            file_base = ".".join([base_name, "stdout"])
-            file_ref = ".".join([file_base, "ref"])
+            file_base = f"{base_name}.stdout"
+            file_ref = f"{file_base}.ref"
             try:
                 with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                     self.assertEqual(ref_file.read(), mock_stdout.getvalue())
             except OSError:
                 try:
                     with open(
-                        os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                        os.path.join(_testdir(func), f"{file_base}.actual"),
                         "w",
                     ) as actual:
                         actual.write(mock_stdout.getvalue())
@@ -202,7 +202,7 @@ def stdout(func):
             except AssertionError as e:
                 try:
                     with open(
-                        os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                        os.path.join(_testdir(func), f"{file_base}.actual"),
                         "w",
                     ) as actual:
                         actual.write(mock_stdout.getvalue())
@@ -222,15 +222,15 @@ def stderr(func):
     def inner(self, *args, **kwargs):
         with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
             retval = func(self, *args, **kwargs)
-            file_base = ".".join([func.__qualname__, "stderr"])
-            file_ref = ".".join([file_base, "ref"])
+            file_base = f"{func.__qualname__}.stderr"
+            file_ref = f"{file_base}.ref"
             try:
                 with open(os.path.join(_testdir(func), file_ref)) as ref_file:
                     self.assertEqual(ref_file.read(), mock_stderr.getvalue())
             except OSError:
                 try:
                     with open(
-                        os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                        os.path.join(_testdir(func), f"{file_base}.actual"),
                         "w",
                     ) as actual:
                         actual.write(mock_stderr.getvalue())
@@ -247,7 +247,7 @@ def stderr(func):
             except AssertionError as e:
                 try:
                     with open(
-                        os.path.join(_testdir(func), ".".join([file_base, "actual"])),
+                        os.path.join(_testdir(func), f"{file_base}.actual"),
                         "w",
                     ) as actual:
                         actual.write(mock_stderr.getvalue())

--- a/tests/utils/iputils_test.py
+++ b/tests/utils/iputils_test.py
@@ -9,7 +9,7 @@ from aerleon.utils import iputils
 
 file_directory = pathlib.Path(__file__).parent.absolute()
 exclude_address_testcases = []
-with open(str(file_directory) + "/address_exclude_test_cases.txt") as f:
+with open(f"{file_directory!s}/address_exclude_test_cases.txt") as f:
     for line in f:
         ipstr, exstrs, restrs = line.strip().split(' ')
         ip = nacaddr.IP(ipstr)

--- a/tools/cgrep.py
+++ b/tools/cgrep.py
@@ -62,7 +62,7 @@ def is_valid_ip(arg):
     try:
         nacaddr.IP(arg)
     except:
-        raise argparse.ArgumentTypeError('%s is an invalid ip address' % arg)
+        raise argparse.ArgumentTypeError(f'{arg} is an invalid ip address')
     return arg
 
 

--- a/tools/cgrep.py
+++ b/tools/cgrep.py
@@ -215,7 +215,7 @@ def main(parser):
         logging.info('Union of %s and %s:\n %s\n', first_name, second_name, union)
         logging.info('Diff of %s and %s:', first_name, second_name)
         for i in results:
-            logging.info(' ' + i)
+            logging.info(f" {i}")
         logging.info('')
         first_obj, sec_obj = options.cmp
         if check_encapsulated('network', first_obj, sec_obj, db):
@@ -236,7 +236,7 @@ def main(parser):
             except naming.UndefinedAddressError:
                 logging.info('%s is an invalid object', obj)
             else:
-                logging.info(token + ':')
+                logging.info(f"{token}:")
                 # convert list of ip objects to strings and sort them
                 sorted_ips = nacaddr.SortAddrList(ips)
                 p([str(x) for x in sorted_ips])
@@ -250,7 +250,7 @@ def main(parser):
         else:
             for result in get_ports(options.svc, db):
                 svc, port = result
-                logging.info(svc + ':')
+                logging.info(f"{svc}:")
                 p(port)
 
     # if -p


### PR DESCRIPTION
This PR uses [`flynt`](https://pypi.org/project/flynt/) to batch reformat many "%-formatted" and .format(...) strings into Python 3.6+'s "f-strings".  As the Flynt docs say:

> Not only are they more readable, more concise, and less prone to error than other ways of formatting, but they are also faster!

Flynt does not guarantee that all formatted strings will be the same as before conversion, but this should be pretty safe.  I have not read through every change that this includes, but all tests pass and on skimming through things look good.  Also, this PR does not use the Flynt `--aggressive` flag that includes additional conversions that potentially change behavior.