### PR TITLE
Fix #440 - Nested include crash

### DIFF
--- a/aerleon/lib/yaml.py
+++ b/aerleon/lib/yaml.py
@@ -1,10 +1,10 @@
 """YAML front-end. Loads a Policy model from a .yaml file."""
 
+import copy
 import pathlib
 import typing
 from typing import Optional, Union
 
-import copy
 import yaml
 from absl import logging
 from yaml.error import YAMLError

--- a/tests/api/api_test.py
+++ b/tests/api/api_test.py
@@ -13,8 +13,8 @@ from absl.testing import absltest
 
 from aerleon import api
 from aerleon.lib import aclgenerator, naming, policy
-from aerleon.lib.yaml import ExcessiveRecursionError
 from aerleon.lib.policy_builder import PolicyDict
+from aerleon.lib.yaml import ExcessiveRecursionError
 from tests.regression_utils import capture
 
 # fmt: off
@@ -898,9 +898,18 @@ class ApiTest(absltest.TestCase):
         definitions = naming.Naming()
 
         # This should raise an exception
-        with self.assertRaisesRegex(ExcessiveRecursionError, "Excessive recursion: include depth limit of 5 reached."):
+        with self.assertRaisesRegex(
+            ExcessiveRecursionError, "Excessive recursion: include depth limit of 5 reached."
+        ):
             api.Generate(
                 [main_policy],
                 definitions,
-                includes={"include_policy_1": include_policy_1, "include_policy_2": include_policy_2, "include_policy_3": include_policy_3, "include_policy_4": include_policy_4, "include_policy_5": include_policy_5, "include_policy_6": include_policy_6},
+                includes={
+                    "include_policy_1": include_policy_1,
+                    "include_policy_2": include_policy_2,
+                    "include_policy_3": include_policy_3,
+                    "include_policy_4": include_policy_4,
+                    "include_policy_5": include_policy_5,
+                    "include_policy_6": include_policy_6,
+                },
             )


### PR DESCRIPTION
Per #440 - The Generate API did not attach debug attributes to data found in the "includes" dict, leading to a crash if an included term list contains an include.

This change corrects the issue and adds new test cases.