### PR TITLE
Bump version from 1.14.0 to 1.14.1 - PLY CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aerleon"
 description = "A firewall generation tool"
 license = "Apache-2.0"
 keywords = ["firewall", "networking", "security"]
-version = "1.14.0"
+version = "1.14.1"
 dynamic = ["classifiers"]
 readme = "README.md"
 authors = [{name = "Jason Benterou", email = "jason.benterou@gmail.com"}, {name = "Rob Ankeny", email = "ankenyr@gmail.com"}]


### PR DESCRIPTION
We are making a special release to address a CVE that was reported in one of our dependencies. While it does not affect our users, ply is marked as abandoned and it is suggested to either  
1) Copy the code and make it your own.
2) Move to a different parsing library.

We are taking action by performing (1) while we evaluate if (2) makes more sense in the long term.

As part of this copying process we have removed all code that is relevant to the CVE. While it did not affect our users or the code paths we use, leaving that code in place could cause us to introduce it to our users sometime in the future, which we do not want to let happen.