### PR TITLE
Remove aclcheck cast() usage

### DIFF
--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -424,7 +424,7 @@ class AclCheck:
         """
         if myport == 'any':
             return True
-        if [x for x in port_list if x[0] <= myport <= x[1]]:
+        if any(range_start <= myport <= range_end for range_start, range_end in port_list):
             return True
         return False
 

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -81,15 +81,17 @@ class AclCheck:
 
     pol_object: policy.Policy
     pol: policy.Policy
+
     src: nacaddr.IPv4 | nacaddr.IPv6 | Literal["any"]
     dst: nacaddr.IPv4 | nacaddr.IPv6 | Literal["any"]
     sport: int | Literal["any"]
     dport: int | Literal["any"]
     proto: str | Literal["any"]
-    matches: list["Match"]
-    exact_matches: list["Match"]
     source_zone: str | Literal["any"]
     destination_zone: str | Literal["any"]
+
+    matches: list["Match"]
+    exact_matches: list["Match"]
 
     @classmethod
     def FromPolicyDict(

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -412,15 +412,15 @@ class AclCheck:
         else:
             return False
 
-    def _PortInside(self, myport, port_list) -> bool:
-        """Check if port matches in a port or group of ports.
+    def _PortInside(self, myport: int | Literal["any"], port_list: list[tuple[int, int]]) -> bool:
+        """Check if a port matches a port list
 
         Args:
           myport: port number
-          port_list: list of ports
+          port_list: list of port ranges
 
         Returns:
-          bool: True of false
+          bool: True or False
         """
         if myport == 'any':
             return True

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -264,7 +264,14 @@ class AclCheck:
         """Return matched terms, but not terms with possibles or action next."""
         return self.exact_matches
 
-    def ActionMatch(self, action='any') -> list["Match"]:
+    def ActionMatch(
+        self,
+        action: (
+            Literal["accept", "deny", "next", "reject", "reject-with-tcp-rst"]
+            | str
+            | Literal['any']
+        ) = 'any',
+    ) -> list["Match"]:
         """Return list of matched terms with specified actions."""
         match_list = []
         for match in self.matches:

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -20,7 +20,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Collection, Sequence
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Literal, TypeAlias
+from typing import DefaultDict, Literal, TypeAlias, TypedDict, cast
 
 from typing_extensions import Self
 
@@ -310,12 +310,17 @@ class AclCheck:
                 text.append(matches['message'])
         return '\n'.join(text)
 
+    class SummarizeMatchTermDetails(TypedDict):
+        possibles: list[PossibleMatchReason]
+        message: str
+
     def Summarize(
         self,
-    ) -> defaultdict[
-        str, defaultdict[str, dict[Literal["possibles", "message"], list[str] | str]]
-    ]:
-        summary = defaultdict(lambda: defaultdict(dict))
+    ) -> DefaultDict[str, DefaultDict[str, "AclCheck.SummarizeMatchTermDetails"]]:
+        summary = cast(
+            DefaultDict[str, DefaultDict[str, "AclCheck.SummarizeMatchTermDetails"]],
+            defaultdict(lambda: defaultdict(dict)),
+        )
         for match in self.matches:
             summary[match.filter][match.term]["possibles"] = match.possibles
             text = []

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -60,7 +60,6 @@ class AclCheck:
 
     Attributes:
       pol_obj: policy.Policy object.
-      pol: policy.Policy object.
       src: The source IP address or network.
       dst: The destination IP address or network.
       sport: The source port.
@@ -76,11 +75,9 @@ class AclCheck:
       port.BadPortValue: An invalid source port is used
       port.BadPortRange: A port is outside of the acceptable range 0-65535
       AddressError: Incorrect ip address or format
-
     """
 
-    pol_object: policy.Policy
-    pol: policy.Policy
+    pol_obj: policy.Policy
 
     src: nacaddr.IPv4 | nacaddr.IPv6 | Literal["any"]
     dst: nacaddr.IPv4 | nacaddr.IPv6 | Literal["any"]

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -167,12 +167,14 @@ class AclCheck:
                 self.dst = nacaddr.IP(dst)
             except ValueError:
                 raise AddressError(f'bad destination address: {dst}\n')
-        # validate zones
+
+        # validate source zone
         if not source_zone or source_zone == 'any':
             self.source_zone = 'any'
         else:
             self.source_zone = str(source_zone)
 
+        # validate destination zone
         if not destination_zone or destination_zone == 'any':
             self.destination_zone = 'any'
         else:

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -374,7 +374,7 @@ class AclCheck:
     def _AddrMatch(
         self,
         addr: nacaddr.IPv4 | nacaddr.IPv6 | Literal["any"],
-        addresses: list[nacaddr.IPv4 | nacaddr.IPv6],
+        addresses: Sequence[nacaddr.IPv4 | nacaddr.IPv6],
     ) -> Literal["full", "partial", False]:
         """Check if an address matches another address or group of addresses,
         as a full match, partial match, or no match.

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -295,7 +295,11 @@ class AclCheck:
                 text.append(matches['message'])
         return '\n'.join(text)
 
-    def Summarize(self):
+    def Summarize(
+        self,
+    ) -> defaultdict[
+        str, defaultdict[str, dict[Literal["possibles", "message"], list[str] | str]]
+    ]:
         summary = defaultdict(lambda: defaultdict(dict))
         for match in self.matches:
             summary[match.filter][match.term]["possibles"] = match.possibles

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -65,6 +65,8 @@ class AclCheck:
       sport: The source port.
       dport: The destination port.
       proto: The protocol.
+      source_zone: The source zone.
+      destination_zone: The destination zone.
       matches: A list of term-related matches.
       exact_matches: A list of exact matches.
 

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -74,8 +74,8 @@ class AclCheck:
     sport: int | Literal["any"]
     dport: int | Literal["any"]
     proto: str | Literal["any"]
-    matches: list
-    exact_matches: list
+    matches: list["Match"]
+    exact_matches: list["Match"]
     source_zone: str | Literal["any"]
     destination_zone: str | Literal["any"]
 
@@ -240,15 +240,15 @@ class AclCheck:
                     )
                     break
 
-    def Matches(self):
+    def Matches(self) -> list["Match"]:
         """Return list of matched terms."""
         return self.matches
 
-    def ExactMatches(self):
+    def ExactMatches(self) -> list["Match"]:
         """Return matched terms, but not terms with possibles or action next."""
         return self.exact_matches
 
-    def ActionMatch(self, action='any'):
+    def ActionMatch(self, action='any') -> list["Match"]:
         """Return list of matched terms with specified actions."""
         match_list = []
         for match in self.matches:
@@ -258,7 +258,7 @@ class AclCheck:
                         match_list.append(match)
         return match_list
 
-    def DescribeMatches(self):
+    def DescribeMatches(self) -> str:
         """Provide sentence descriptions of matches.
 
         Returns:
@@ -270,7 +270,7 @@ class AclCheck:
             ret_str.append(text)
         return '\n'.join(ret_str)
 
-    def __str__(self):
+    def __str__(self) -> str:
         text = []
         summary = self.Summarize()
         for filter, terms in summary.items():
@@ -348,7 +348,7 @@ class AclCheck:
                 return True
         return False
 
-    def _PortInside(self, myport, port_list):
+    def _PortInside(self, myport, port_list) -> bool:
         """Check if port matches in a port or group of ports.
 
         Args:
@@ -368,14 +368,14 @@ class AclCheck:
 class Match:
     """A matching term and its associate values."""
 
-    def __init__(self, filtername, term, possibles, action, qos=None):
+    def __init__(self, filtername, term, possibles, action, qos=None) -> None:
         self.filter = filtername
         self.term = term
         self.possibles = possibles
         self.action = action[0]
         self.qos = qos
 
-    def __str__(self):
+    def __str__(self) -> str:
         text = ''
         if self.possibles:
             text += f"possible {self.action}"
@@ -387,7 +387,7 @@ class Match:
         return text
 
 
-def main():
+def main() -> None:
     pass
 
 

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -18,7 +18,7 @@
 
 import logging
 from collections import defaultdict
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Literal
 
@@ -416,7 +416,40 @@ class AclCheck:
 class Match:
     """A matching term and its associate values."""
 
-    def __init__(self, filtername, term, possibles, action, qos=None) -> None:
+    filter: str
+    term: str
+    possibles: list[
+        Literal[
+            "source-ip",
+            "destination-ip",
+            "first-frag",
+            "frag-offset",
+            "packet-length",
+            "est",
+            "tcp-est",
+        ]
+    ]
+    action: Literal["accept", "deny", "next", "reject", "reject-with-tcp-rst"] | str
+    qos: object | None
+
+    def __init__(
+        self,
+        filtername: str,
+        term: str,
+        possibles: list[
+            Literal[
+                "source-ip",
+                "destination-ip",
+                "first-frag",
+                "frag-offset",
+                "packet-length",
+                "est",
+                "tcp-est",
+            ]
+        ],
+        action: Sequence[Literal["accept", "deny", "next", "reject", "reject-with-tcp-rst"] | str],
+        qos=None,
+    ) -> None:
         self.filter = filtername
         self.term = term
         self.possibles = possibles

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -430,7 +430,7 @@ class AclCheck:
           port_list: list of port ranges
 
         Returns:
-          bool: True or False
+          bool: True if `myport` is within any [start, end] port range in `port_list` (inclusive), otherwise False
         """
         if myport == 'any':
             return True

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -20,7 +20,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Collection, Sequence
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import DefaultDict, Literal, TypeAlias, TypedDict, cast
+from typing import Literal, TypeAlias, TypedDict, cast
 
 from typing_extensions import Self
 
@@ -326,9 +326,9 @@ class AclCheck:
 
     def Summarize(
         self,
-    ) -> DefaultDict[str, DefaultDict[str, "AclCheck.SummarizeMatchTermDetails"]]:
-        summary = cast(
-            DefaultDict[str, DefaultDict[str, "AclCheck.SummarizeMatchTermDetails"]],
+    ) -> defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]]:
+        summary: defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]] = cast(
+            defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]],
             defaultdict(lambda: defaultdict(dict)),
         )
         for match in self.matches:

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -190,6 +190,7 @@ class AclCheck:
             for term in terms:
                 possible = []
                 logging.debug('checking term: %s', term.name)
+
                 match self._AddrMatch(self.src, term.source_address):
                     case "full":
                         src_too_broad = False
@@ -202,6 +203,7 @@ class AclCheck:
                         continue
                     case _:
                         raise AssertionError('unhandled switch case')
+
                 match self._AddrMatch(self.dst, term.destination_address):
                     case "full":
                         dst_too_broad = False
@@ -214,18 +216,21 @@ class AclCheck:
                         continue
                     case _:
                         raise AssertionError('unhandled switch case')
+
                 # source-zone matching if requested. If the term does not specify
                 # a source_zone, treat it as 'any' (match all zones).
                 if not self._ZoneMatch(self.source_zone, term.source_zone):
                     logging.debug('source zone does not match')
                     continue
                 logging.debug('source zone matches: %s', self.source_zone)
+
                 # destination-zone matching if requested. If the term does not specify
                 # a destination_zone, treat it as 'any' (match all zones).
                 if not self._ZoneMatch(self.destination_zone, term.destination_zone):
                     logging.debug('destination zone does not match')
                     continue
                 logging.debug('destination zone matches: %s', self.destination_zone)
+
                 if (
                     self.sport != 'any'
                     and term.source_port
@@ -234,6 +239,7 @@ class AclCheck:
                     logging.debug('sport does not match')
                     continue
                 logging.debug('sport matches: %s', self.sport)
+
                 if (
                     self.dport != 'any'
                     and term.destination_port
@@ -242,14 +248,17 @@ class AclCheck:
                     logging.debug('dport does not match')
                     continue
                 logging.debug('dport matches: %s', self.dport)
+
                 if self.proto != 'any' and term.protocol and self.proto not in term.protocol:
                     logging.debug('proto does not match')
                     continue
                 logging.debug('proto matches: %s', self.proto)
+
                 if term.protocol_except and self.proto in term.protocol_except:
                     logging.debug('protocol excepted by term, no match.')
                     continue
                 logging.debug('proto not excepted: %s', self.proto)
+
                 if not term.action:  # avoid any verbatim
                     logging.debug('term had no action (verbatim?), no match.')
                     continue

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -326,8 +326,10 @@ class AclCheck:
 
     def Summarize(
         self,
-    ) -> defaultdict[str, dict[str, "AclCheck.SummarizeMatchTermDetails"]]:
-        summary: defaultdict[str, dict[str, "AclCheck.SummarizeMatchTermDetails"]] = defaultdict()
+    ) -> defaultdict[str, dict[str, SummarizeMatchTermDetails]]:
+        summary: defaultdict[str, dict[str, AclCheck.SummarizeMatchTermDetails]] = defaultdict(
+            dict
+        )
         for match in self.matches:
             text: list[str] = []
             if match.possibles:

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -20,7 +20,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Collection, Sequence
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Literal, TypeAlias, TypedDict, cast
+from typing import Literal, TypeAlias, TypedDict
 
 from typing_extensions import Self
 
@@ -326,21 +326,19 @@ class AclCheck:
 
     def Summarize(
         self,
-    ) -> defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]]:
-        summary: defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]] = cast(
-            defaultdict[str, defaultdict[str, "AclCheck.SummarizeMatchTermDetails"]],
-            defaultdict(lambda: defaultdict(dict)),
-        )
+    ) -> defaultdict[str, dict[str, "AclCheck.SummarizeMatchTermDetails"]]:
+        summary: defaultdict[str, dict[str, "AclCheck.SummarizeMatchTermDetails"]] = defaultdict()
         for match in self.matches:
-            summary[match.filter][match.term]["possibles"] = match.possibles
-            text = []
+            text: list[str] = []
             if match.possibles:
                 text.append(f"{' ' * 10}term: {match.term} (possible match)")
                 text.append(f"{' ' * 16}{match.action} if {match.possibles}")
             else:
                 text.append(f"{' ' * 10}term: {match.term}")
                 text.append(f"{' ' * 16}{match.action}")
-            summary[match.filter][match.term]["message"] = '\n'.join(text)
+            summary[match.filter][match.term] = AclCheck.SummarizeMatchTermDetails(
+                possibles=match.possibles, message='\n'.join(text)
+            )
         return summary
 
     def _PossibleMatch(

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -446,7 +446,7 @@ class Match:
     term: str
     possibles: list[PossibleMatchReason]
     action: str
-    qos: object | None
+    qos: str | None
 
     def __init__(
         self,
@@ -454,7 +454,7 @@ class Match:
         term: str,
         possibles: list[PossibleMatchReason],
         action: Sequence[str],
-        qos=None,
+        qos: str | None = None,
     ) -> None:
         self.filter = filtername
         self.term = term

--- a/aerleon/lib/aclcheck.py
+++ b/aerleon/lib/aclcheck.py
@@ -36,8 +36,6 @@ PossibleMatchReason: TypeAlias = Literal[
     "tcp-est",
 ]
 
-MatchAction: TypeAlias = Literal["accept", "deny", "next", "reject", "reject-with-tcp-rst"] | str
-
 
 class Error(Exception):
     """Base error class."""
@@ -290,7 +288,7 @@ class AclCheck:
 
     def ActionMatch(
         self,
-        action: MatchAction | Literal['any'] = 'any',
+        action: str | Literal['any'] = 'any',
     ) -> list["Match"]:
         """Return list of matched terms with specified actions."""
         match_list = []
@@ -447,7 +445,7 @@ class Match:
     filter: str
     term: str
     possibles: list[PossibleMatchReason]
-    action: MatchAction
+    action: str
     qos: object | None
 
     def __init__(
@@ -455,7 +453,7 @@ class Match:
         filtername: str,
         term: str,
         possibles: list[PossibleMatchReason],
-        action: Sequence[MatchAction],
+        action: Sequence[str],
         qos=None,
     ) -> None:
         self.filter = filtername

--- a/tests/lib/aclcheck_test.py
+++ b/tests/lib/aclcheck_test.py
@@ -14,6 +14,7 @@
 
 """Unit tests for AclCheck."""
 from ipaddress import IPv4Address, IPv4Network
+from itertools import product
 from typing import Final, Literal
 
 import pytest
@@ -130,11 +131,13 @@ class AclCheckTest(absltest.TestCase):
         dport_str = '22'
         proto = 'tcp'
 
-        for srcip in {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")}:
-            for dstip in {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")}:
-                for sport in {sport_str, int(sport_str)}:
-                    for dport in {dport_str, int(dport_str)}:
-                        self.helper_testExactMatches(srcip, dstip, sport, dport, proto)
+        for srcip, dstip, sport, dport in product(
+            {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")},
+            {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")},
+            {sport_str, int(sport_str)},
+            {dport_str, int(dport_str)},
+        ):
+            self.helper_testExactMatches(srcip, dstip, sport, dport, proto)
 
     def helper_testAclCheck(self, srcip, dstip, sport, dport, proto) -> None:
         check = aclcheck.AclCheck(
@@ -171,11 +174,13 @@ class AclCheckTest(absltest.TestCase):
         dport_str = '22'
         proto = 'tcp'
 
-        for srcip in {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")}:
-            for dstip in {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")}:
-                for sport in {sport_str, int(sport_str)}:
-                    for dport in {dport_str, int(dport_str)}:
-                        self.helper_testAclCheck(srcip, dstip, sport, dport, proto)
+        for srcip, dstip, sport, dport in product(
+            {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")},
+            {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")},
+            {sport_str, int(sport_str)},
+            {dport_str, int(dport_str)},
+        ):
+            self.helper_testAclCheck(srcip, dstip, sport, dport, proto)
 
     def helper_testSummarize(self, srcip, dstip, sport, dport, proto) -> None:
         check = aclcheck.AclCheck(
@@ -200,11 +205,13 @@ class AclCheckTest(absltest.TestCase):
         dport_str = '22'
         proto = 'tcp'
 
-        for srcip in {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")}:
-            for dstip in {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")}:
-                for sport in {sport_str, int(sport_str)}:
-                    for dport in {dport_str, int(dport_str)}:
-                        self.helper_testSummarize(srcip, dstip, sport, dport, proto)
+        for srcip, dstip, sport, dport in product(
+            {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")},
+            {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")},
+            {sport_str, int(sport_str)},
+            {dport_str, int(dport_str)},
+        ):
+            self.helper_testSummarize(srcip, dstip, sport, dport, proto)
 
     def helper_testExceptions(
         self, srcip, dstip, sport, dport, proto, bad_portrange, bad_portvalue
@@ -249,14 +256,16 @@ class AclCheckTest(absltest.TestCase):
         bad_portrange_str = '99999'
         bad_portvalue = 'port_99'
 
-        for srcip in {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")}:
-            for dstip in {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")}:
-                for sport in {sport_str, int(sport_str)}:
-                    for dport in {dport_str, int(dport_str)}:
-                        for bad_portrange in {bad_portrange_str, int(bad_portrange_str)}:
-                            self.helper_testExceptions(
-                                srcip, dstip, sport, dport, proto, bad_portrange, bad_portvalue
-                            )
+        for srcip, dstip, sport, dport, bad_portrange in product(
+            {srcip_str, IPv4Address(srcip_str), IPv4Network(srcip_str + "/32")},
+            {dstip_str, IPv4Address(dstip_str), IPv4Network(dstip_str + "/32")},
+            {sport_str, int(sport_str)},
+            {dport_str, int(dport_str)},
+            {bad_portrange_str, int(bad_portrange_str)},
+        ):
+            self.helper_testExceptions(
+                srcip, dstip, sport, dport, proto, bad_portrange, bad_portvalue
+            )
 
     def test_partial_networks_match(self) -> None:
         defs = naming.Naming(None)


### PR DESCRIPTION
This is a followup to #472.

This PR removes a usage of typing.cast() with some minor tweaks to AclCheck.Summarize().