### PR TITLE
Improve policy_builder.py typing

### DIFF
--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -669,7 +669,7 @@ class _Builtin:
         return cls(keyname, *cls.BUILTINS[keyname])
 
     @property
-    def recognizer(self) -> "TValue | TComposition":
+    def recognizer(self) -> TValue | TComposition:
         """The recognizer specific to this Builtin instance."""
         return BUILTIN_SPEC[self.keyname]
 

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -5,11 +5,10 @@ import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, Any, TypeAlias
+from typing import TYPE_CHECKING, Annotated, Any, TypeAlias
 
 from absl import logging
 
-from aerleon.lib.naming import Naming
 from aerleon.lib.policy import (
     FLEXIBLE_MATCH_RANGE_ATTRIBUTES,
     FLEXIBLE_MATCH_START_OPTIONS,
@@ -41,6 +40,9 @@ if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
 else:
     from typing import TypedDict
+
+if TYPE_CHECKING:
+    from aerleon.lib.naming import Naming
 
 
 # NOTE: TypedDict is just a normal dictionary, it is not a class. This syntax tells the type checker
@@ -265,14 +267,14 @@ class PolicyBuilder:
     """
 
     raw_policy: RawPolicy
-    definitions: Naming
+    definitions: "Naming"
     optimize: bool
     shade_check: bool
 
     def __init__(
         self,
         policy_dict: PolicyDict,
-        definitions: Naming,
+        definitions: "Naming",
         optimize: bool = False,
         shade_check: bool = False,
     ) -> None:

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -5,7 +5,7 @@ import sys
 import typing
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, Sequence, TypeAlias
+from typing import Annotated, Sequence, TypeAlias, Self
 
 from absl import logging
 
@@ -273,11 +273,11 @@ class PolicyBuilder:
         self,
         policy_dict: PolicyDict,
         definitions: Naming,
-        optimize=False,
-        shade_check=False,
-    ):
-        def PolicyDictToRawPolicy(input_policy):
-            raw_filters = []
+        optimize: bool = False,
+        shade_check: bool = False,
+    ) -> None:
+        def PolicyDictToRawPolicy(input_policy: PolicyDict) -> RawPolicy:
+            raw_filters: list[RawFilter] = []
             input_filters = input_policy["filters"]
             filename = input_policy.get("filename")
             for filter in input_filters:
@@ -648,13 +648,13 @@ class _Builtin:
     }
     # fmt: on
 
-    def __init__(self, keyname: str, call_convention: _CallType, var_type: VarType):
+    def __init__(self, keyname: str, call_convention: _CallType, var_type: VarType) -> None:
         self.keyname = keyname
         self.call_convention = call_convention
         self.var_type = var_type
 
     @classmethod
-    def FromKeyword(cls, keyname: str):
+    def FromKeyword(cls, keyname: str) -> Self:
         """Construct a Builtin instance from keyname.
 
         Args:

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, Any, Self, TypeAlias
+from typing import Annotated, Any, TypeAlias
 
 from absl import logging
 
@@ -654,7 +654,7 @@ class _Builtin:
         self.var_type = var_type
 
     @classmethod
-    def FromKeyword(cls, keyname: str) -> Self:
+    def FromKeyword(cls, keyname: str) -> "_Builtin":
         """Construct a Builtin instance from keyname.
 
         Args:

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -5,7 +5,7 @@ import sys
 import typing
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, TypeAlias
+from typing import Annotated, Sequence, TypeAlias
 
 from absl import logging
 
@@ -81,9 +81,9 @@ PolicyTerm = TypedDict(
         "owner": str,
         "policer": str,
         "port": WordList,
-        "precedence": int | str | list[int | str],
-        "protocol": int | str | list[int | str],
-        "protocol-except": int | str | list[int | str],
+        "precedence": int | str | Sequence[int | str],
+        "protocol": int | str | Sequence[int | str],
+        "protocol-except": int | str | Sequence[int | str],
         "qos": str,
         "pan-application": WordList,
         "routing-instance": str,
@@ -98,13 +98,13 @@ PolicyTerm = TypedDict(
         "fragment-offset": int | str,
         "hop-limit": int | str,
         "icmp-type": WordList,
-        "icmp-code": int | str | list[int | str],
+        "icmp-code": int | str | Sequence[int | str],
         "ether-type": WordList,
         "traffic-class-count": str,
         "traffic-type": WordList,
         "dscp-set": int | str,
-        "dscp-match": int | str | list[int | str],
-        "dscp-except": int | str | list[int | str],
+        "dscp-match": int | str | Sequence[int | str],
+        "dscp-except": int | str | Sequence[int | str],
         "next-ip": str,
         "flexible-match-range": dict[str, int | str],
         "source-prefix-except": WordList,
@@ -122,7 +122,7 @@ PolicyTerm = TypedDict(
         "destination-interface": str,
         "platform": WordList,
         "platform-exclude": WordList,
-        "target-resources": list[str | list[str]],
+        "target-resources": Sequence[str | list[str]],
         "target-service-accounts": WordList,
         "tags": WordList,
         "timeout": int | str,
@@ -147,7 +147,7 @@ PolicyFilterHeader = TypedDict(
 )
 
 
-TermsList = list[PolicyTerm | PolicyInclude]
+TermsList = Sequence[PolicyTerm | PolicyInclude]
 
 
 class PolicyFilter(TypedDict):

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -2,10 +2,9 @@
 
 import enum
 import sys
-import typing
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, Sequence, TypeAlias, Self
+from typing import Annotated, Any, Self, Sequence, TypeAlias
 
 from absl import logging
 
@@ -183,7 +182,7 @@ class RawFilterHeader:
     """
 
     targets: dict[str, RawTarget]
-    kvs: dict[str, typing.Any] = field(default_factory=dict)
+    kvs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -196,7 +195,7 @@ class RawTerm:
     """
 
     name: str
-    kvs: dict[str, typing.Any] = field(default_factory=dict)
+    kvs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -673,7 +672,7 @@ class _Builtin:
         """The recognizer specific to this Builtin instance."""
         return BUILTIN_SPEC[self.keyname]
 
-    def AddObjectCallSequence(self, value: typing.Any):
+    def AddObjectCallSequence(self, value: Any):
         """Construct a calling sequence for Term.AddObject or Header.AddObject for
         this builtin type.
 
@@ -796,7 +795,7 @@ class BuiltinRecognizer:
         return RecognizerValueResult(recognized=True, valueKV={context.keyword: repr})
 
     @classmethod
-    def _NormalizeValues(cls, _context: RecognizerContext, repr: typing.Any) -> typing.Any:
+    def _NormalizeValues(cls, _context: RecognizerContext, repr: Any) -> Any:
         """Subclasses of BuiltinRecognizer can implement this method to adjust the output
         of recognizeKeywordValue.
 

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -2,9 +2,10 @@
 
 import enum
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Annotated, Any, Self, Sequence, TypeAlias
+from typing import Annotated, Any, Self, TypeAlias
 
 from absl import logging
 

--- a/aerleon/lib/policy_builder.py
+++ b/aerleon/lib/policy_builder.py
@@ -4,10 +4,12 @@ import enum
 import sys
 import typing
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Annotated, TypeAlias
 
 from absl import logging
 
+from aerleon.lib.naming import Naming
 from aerleon.lib.policy import (
     FLEXIBLE_MATCH_RANGE_ATTRIBUTES,
     FLEXIBLE_MATCH_START_OPTIONS,
@@ -40,42 +42,37 @@ if sys.version_info < (3, 12):
 else:
     from typing import TypedDict
 
-if typing.TYPE_CHECKING:
-    from datetime import datetime
-
-    from aerleon.lib import naming
-
 
 # NOTE: TypedDict is just a normal dictionary, it is not a class. This syntax tells the type checker
 # what keys need to be present in the given dictionary.
 
-WordList: TypeAlias = "str | list[str]"
+WordList: TypeAlias = str | list[str]
 
 
 class VPNValue(TypedDict):
     name: str
-    policy: 'NotRequired[str]'
+    policy: NotRequired[str]
 
 
 PolicyTerm = TypedDict(
     'PolicyTerm',
     {
         "comment": str,
-        "name": "Required[str]",
+        "name": Required[str],
         "action": WordList,
         "address": WordList,
         "address-exclude": WordList,
         "restrict-address-family": str,
         "counter": str,
-        "expiration": "datetime.date | str",
+        "expiration": date | str,
         "destination-address": WordList,
         "destination-exclude": WordList,
         "destination-fqdn": WordList,
         "destination-port": WordList,
         "destination-prefix": WordList,
         "filter-term": str,
-        "forwarding-class": "list[str]",
-        "forwarding-class-except": "list[str]",
+        "forwarding-class": list[str],
+        "forwarding-class-except": list[str],
         "logging": WordList,
         "log-limit": str,
         "log-name": str,
@@ -84,9 +81,9 @@ PolicyTerm = TypedDict(
         "owner": str,
         "policer": str,
         "port": WordList,
-        "precedence": "int | str | list[int | str]",
-        "protocol": "int | str | list[int | str]",
-        "protocol-except": "int | str | list[int | str]",
+        "precedence": int | str | list[int | str],
+        "protocol": int | str | list[int | str],
+        "protocol-except": int | str | list[int | str],
         "qos": str,
         "pan-application": WordList,
         "routing-instance": str,
@@ -95,21 +92,21 @@ PolicyTerm = TypedDict(
         "source-fqdn": WordList,
         "source-port": WordList,
         "source-prefix": WordList,
-        "ttl": "int | str",
-        "verbatim": "dict[str, str]",
-        "packet-length": "int | str",
-        "fragment-offset": "int | str",
-        "hop-limit": "int | str",
+        "ttl": int | str,
+        "verbatim": dict[str, str],
+        "packet-length": int | str,
+        "fragment-offset": int | str,
+        "hop-limit": int | str,
         "icmp-type": WordList,
-        "icmp-code": "int | str | list[int | str]",
+        "icmp-code": int | str | list[int | str],
         "ether-type": WordList,
         "traffic-class-count": str,
         "traffic-type": WordList,
-        "dscp-set": "int | str",
-        "dscp-match": "int | str | list[int | str]",
-        "dscp-except": "int | str | list[int | str]",
+        "dscp-set": int | str,
+        "dscp-match": int | str | list[int | str],
+        "dscp-except": int | str | list[int | str],
         "next-ip": str,
-        "flexible-match-range": "dict[str, int | str]",
+        "flexible-match-range": dict[str, int | str],
         "source-prefix-except": WordList,
         "destination-prefix-except": WordList,
         "encapsulate": str,
@@ -120,15 +117,15 @@ PolicyTerm = TypedDict(
         "vpn": VPNValue,
         "source-tag": WordList,
         "destination-tag": WordList,
-        "priority": "int | str",
+        "priority": int | str,
         "source-interface": str,
         "destination-interface": str,
         "platform": WordList,
         "platform-exclude": WordList,
-        "target-resources": "list[str | list[str]]",
+        "target-resources": list[str | list[str]],
         "target-service-accounts": WordList,
         "tags": WordList,
-        "timeout": "int | str",
+        "timeout": int | str,
     },
     total=False,
 )
@@ -141,7 +138,7 @@ class PolicyInclude(TypedDict):
 PolicyFilterHeader = TypedDict(
     'PolicyFilterHeader',
     {
-        "targets": "Required[dict[str, str]]",
+        "targets": Required[dict[str, str]],
         "comment": str,
         "apply-groups": WordList,
         "apply-groups-except": WordList,
@@ -163,7 +160,7 @@ class PolicyFilterTermsOnly(TypedDict):
 
 
 class PolicyDict(TypedDict):
-    filters: 'list[PolicyFilter]'
+    filters: list[PolicyFilter]
     filename: NotRequired[str]
 
 
@@ -212,7 +209,7 @@ class RawFilter:
     """
 
     header: RawFilterHeader
-    terms: "list[RawTerm]"
+    terms: list[RawTerm]
 
 
 @dataclass
@@ -225,7 +222,7 @@ class RawPolicy:
     """
 
     filename: str
-    filters: "list[RawFilter]"
+    filters: list[RawFilter]
 
 
 class PolicyBuilder:
@@ -268,14 +265,14 @@ class PolicyBuilder:
     """
 
     raw_policy: RawPolicy
-    definitions: "naming.Naming"
+    definitions: Naming
     optimize: bool
     shade_check: bool
 
     def __init__(
         self,
         policy_dict: PolicyDict,
-        definitions: "naming.Naming",
+        definitions: Naming,
         optimize=False,
         shade_check=False,
     ):
@@ -448,7 +445,7 @@ class PolicyBuilder:
 # ### BUILTINS ###
 # The following section deals with the recognition and normalization of built-in keywords.
 
-BUILTIN_SPEC: "dict[str, TValue | TComposition]" = {
+BUILTIN_SPEC: dict[str, TValue | TComposition] = {
     # fmt: off
     'apply-groups':               TListStrCollapsible,
     'apply-groups-except':        TListStrCollapsible,


### PR DESCRIPTION
This PR improves type hints in policy_builder.py:
* don't quote type hints
* use covariant `Sequence` instead of `list` when allowing multiple content types
* don't import all of `typing`
* other misc type hint improvements