### PR TITLE
NokiaSRL: support named prefix-lists in ACL entries

### DIFF
--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -27,8 +27,18 @@ from aerleon.lib.policy import Term
 R24_3_2 = "r24.3.2"  # Option flag to generate release >= 24.3.2 syntax
 
 
-class IPPrefix(TypedDict):
-    prefix: str
+class PrefixListRef(TypedDict):
+    name: str
+
+
+IPPrefix = TypedDict(
+    "IPPrefix",
+    {
+        "prefix": str,
+        "prefix-list": list[PrefixListRef],
+    },
+    total=False,
+)
 
 
 class PortRange(TypedDict):
@@ -103,6 +113,10 @@ class EstablishedWithNonTcpUdpError(Error):
 
 
 class UnsupportedLogging(Error):
+    pass
+
+
+class PrefixListWithAddressError(Error):
     pass
 
 
@@ -194,11 +208,42 @@ class SRLTerm(openconfig.Term):
         ):
             self.SetProtocol(family=family, protocol="tcp", filter_options=filter_options)
 
+        # Named prefix-list references. prefix-list and a literal prefix are
+        # mutually exclusive in the SR Linux YANG model.
+        if self.term.source_prefix:
+            if self.term.GetAddressOfVersion(
+                'flattened_saddr', self.AF_MAP.get(self.inet_version)
+            ):
+                raise PrefixListWithAddressError(
+                    f'source-prefix excludes source-address in term {self.term.name}'
+                )
+            self.SetSourcePrefixList(family, self.term.source_prefix, filter_options)
+        if self.term.destination_prefix:
+            if self.term.GetAddressOfVersion(
+                'flattened_daddr', self.AF_MAP.get(self.inet_version)
+            ):
+                raise PrefixListWithAddressError(
+                    f'destination-prefix excludes destination-address in term {self.term.name}'
+                )
+            self.SetDestPrefixList(family, self.term.destination_prefix, filter_options)
+
     def SetSourceAddress(self, family: str, saddr: str, filter_options: list[str]) -> None:
         self._field(family, filter_options)['source-ip'] = {'prefix': saddr}
 
     def SetDestAddress(self, family: str, daddr: str, filter_options: list[str]) -> None:
         self._field(family, filter_options)['destination-ip'] = {'prefix': daddr}
+
+    def SetSourcePrefixList(
+        self, family: str, names: list[str], filter_options: list[str]
+    ) -> None:
+        self._field(family, filter_options)['source-ip'] = {
+            'prefix-list': [{'name': n} for n in names]
+        }
+
+    def SetDestPrefixList(self, family: str, names: list[str], filter_options: list[str]) -> None:
+        self._field(family, filter_options)['destination-ip'] = {
+            'prefix-list': [{'name': n} for n in names]
+        }
 
     def SetSourcePorts(self, start: int, end: int, filter_options: list[str]) -> None:
         if start == end:
@@ -234,6 +279,7 @@ class NokiaSRLinux(openconfig.OpenConfig):
         supported_tokens, supported_sub_tokens = super()._BuildTokens()
 
         supported_tokens -= {'platform', 'platform_exclude', 'verbatim', 'icmp-type'}
+        supported_tokens |= {'source_prefix', 'destination_prefix'}
 
         supported_sub_tokens['action'] = {'accept', 'deny'}  # excludes 'reject'
         supported_sub_tokens['option'] = {

--- a/docs/reference/generators.md
+++ b/docs/reference/generators.md
@@ -1134,6 +1134,8 @@ targets:
 ### Term Format
 
 * for common keys see the [common](#common) section above.
+* _source-prefix_: this should resolve to a named ipv4 or ipv6 prefix list under 'acl match-list'
+* _destination-prefix_: this should resolve to a named ipv4 or ipv6 prefix list under 'acl match-list'
 
 ### Sub Tokens
 

--- a/tests/regression/nokiasrl/NokiaSRLTest.testDestinationPrefixList.stdout.ref
+++ b/tests/regression/nokiasrl/NokiaSRLTest.testDestinationPrefixList.stdout.ref
@@ -1,0 +1,33 @@
+[
+  {
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "description": "The general policy comment.",
+      "entry": [
+        {
+          "_annotate_description": "Allow to named prefix-list.",
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "match": {
+            "destination-ip": {
+              "prefix-list": [
+                {
+                  "name": "CORP_PREFIXES"
+                }
+              ]
+            },
+            "protocol": 6
+          },
+          "sequence-id": 5
+        }
+      ],
+      "name": "good-name-v4",
+      "statistics-per-entry": true,
+      "type": "ipv4"
+    }
+  }
+]
+
+

--- a/tests/regression/nokiasrl/NokiaSRLTest.testMultiSourcePrefixList.stdout.ref
+++ b/tests/regression/nokiasrl/NokiaSRLTest.testMultiSourcePrefixList.stdout.ref
@@ -1,0 +1,36 @@
+[
+  {
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "description": "The general policy comment.",
+      "entry": [
+        {
+          "_annotate_description": "Allow from multiple prefix-lists.",
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "match": {
+            "protocol": 6,
+            "source-ip": {
+              "prefix-list": [
+                {
+                  "name": "CORP_PREFIXES"
+                },
+                {
+                  "name": "EXTERNAL_PREFIXES"
+                }
+              ]
+            }
+          },
+          "sequence-id": 5
+        }
+      ],
+      "name": "good-name-v4",
+      "statistics-per-entry": true,
+      "type": "ipv4"
+    }
+  }
+]
+
+

--- a/tests/regression/nokiasrl/NokiaSRLTest.testSourcePrefixList.stdout.ref
+++ b/tests/regression/nokiasrl/NokiaSRLTest.testSourcePrefixList.stdout.ref
@@ -1,0 +1,33 @@
+[
+  {
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "description": "The general policy comment.",
+      "entry": [
+        {
+          "_annotate_description": "Allow from named prefix-list.",
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "match": {
+            "protocol": 6,
+            "source-ip": {
+              "prefix-list": [
+                {
+                  "name": "CORP_PREFIXES"
+                }
+              ]
+            }
+          },
+          "sequence-id": 5
+        }
+      ],
+      "name": "good-name-v4",
+      "statistics-per-entry": true,
+      "type": "ipv4"
+    }
+  }
+]
+
+

--- a/tests/regression/nokiasrl/nokiasrl_test.py
+++ b/tests/regression/nokiasrl/nokiasrl_test.py
@@ -114,6 +114,53 @@ term good-term-1 {
 }
 """
 
+GOOD_SPFX = """
+term good-term-1 {
+  comment:: "Allow from named prefix-list."
+  source-prefix:: CORP_PREFIXES
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+GOOD_DPFX = """
+term good-term-1 {
+  comment:: "Allow to named prefix-list."
+  destination-prefix:: CORP_PREFIXES
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+GOOD_MULTI_SPFX = """
+term good-term-1 {
+  comment:: "Allow from multiple prefix-lists."
+  source-prefix:: CORP_PREFIXES EXTERNAL_PREFIXES
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+BAD_SPFX_AND_SADDR = """
+term bad-term-6 {
+  comment:: "source-prefix and source-address together."
+  source-prefix:: CORP_PREFIXES
+  source-address:: CORP_EXTERNAL
+  protocol:: tcp
+  action:: accept
+}
+"""
+
+BAD_DPFX_AND_DADDR = """
+term bad-term-7 {
+  comment:: "destination-prefix and destination-address together."
+  destination-prefix:: CORP_PREFIXES
+  destination-address:: CORP_EXTERNAL
+  protocol:: tcp
+  action:: accept
+}
+"""
+
 GOOD_JSON_SADDR = """
 [
 {
@@ -321,6 +368,99 @@ GOOD_JSON_MULTI_PROTO_DPORT = """
             "destination-port": { "range": { "start": 1024, "end": 65535 } }
           },
           "sequence-id": 10
+        }
+      ]
+    }
+}
+]
+"""
+
+GOOD_JSON_SPFX = """
+[
+{
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "name": "good-name-v4",
+      "description": "The general policy comment.",
+      "type": "ipv4",
+      "statistics-per-entry": true,
+      "entry": [
+        {
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "_annotate_description": "Allow from named prefix-list.",
+          "match": {
+            "protocol": 6,
+            "source-ip": {
+              "prefix-list": [ { "name": "CORP_PREFIXES" } ]
+            }
+          },
+          "sequence-id": 5
+        }
+      ]
+    }
+}
+]
+"""
+
+GOOD_JSON_DPFX = """
+[
+{
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "name": "good-name-v4",
+      "description": "The general policy comment.",
+      "type": "ipv4",
+      "statistics-per-entry": true,
+      "entry": [
+        {
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "_annotate_description": "Allow to named prefix-list.",
+          "match": {
+            "protocol": 6,
+            "destination-ip": {
+              "prefix-list": [ { "name": "CORP_PREFIXES" } ]
+            }
+          },
+          "sequence-id": 5
+        }
+      ]
+    }
+}
+]
+"""
+
+GOOD_JSON_MULTI_SPFX = """
+[
+{
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "name": "good-name-v4",
+      "description": "The general policy comment.",
+      "type": "ipv4",
+      "statistics-per-entry": true,
+      "entry": [
+        {
+          "action": {
+            "accept": {}
+          },
+          "description": "good-term-1",
+          "_annotate_description": "Allow from multiple prefix-lists.",
+          "match": {
+            "protocol": 6,
+            "source-ip": {
+              "prefix-list": [
+                { "name": "CORP_PREFIXES" },
+                { "name": "EXTERNAL_PREFIXES" }
+              ]
+            }
+          },
+          "sequence-id": 5
         }
       ]
     }
@@ -571,6 +711,46 @@ class NokiaSRLTest(absltest.TestCase):
     def testEstablishedWithNoProtocolError(self):
         acl = policy.ParsePolicy(GOOD_HEADER + BAD_TERM_4, self.naming)
         with self.assertRaises(nokiasrl.EstablishedWithNoProtocolError):
+            _ = nokiasrl.NokiaSRLinux(acl, EXP_INFO)
+
+    @capture.stdout
+    def testSourcePrefixList(self):
+        acl = nokiasrl.NokiaSRLinux(
+            policy.ParsePolicy(GOOD_HEADER + GOOD_SPFX, self.naming), EXP_INFO
+        )
+        expected = json.loads(GOOD_JSON_SPFX)
+        self.assertEqual(expected, json.loads(str(acl)))
+
+        print(acl)
+
+    @capture.stdout
+    def testDestinationPrefixList(self):
+        acl = nokiasrl.NokiaSRLinux(
+            policy.ParsePolicy(GOOD_HEADER + GOOD_DPFX, self.naming), EXP_INFO
+        )
+        expected = json.loads(GOOD_JSON_DPFX)
+        self.assertEqual(expected, json.loads(str(acl)))
+
+        print(acl)
+
+    @capture.stdout
+    def testMultiSourcePrefixList(self):
+        acl = nokiasrl.NokiaSRLinux(
+            policy.ParsePolicy(GOOD_HEADER + GOOD_MULTI_SPFX, self.naming), EXP_INFO
+        )
+        expected = json.loads(GOOD_JSON_MULTI_SPFX)
+        self.assertEqual(expected, json.loads(str(acl)))
+
+        print(acl)
+
+    def testSourcePrefixListWithAddressError(self):
+        acl = policy.ParsePolicy(GOOD_HEADER + BAD_SPFX_AND_SADDR, self.naming)
+        with self.assertRaises(nokiasrl.PrefixListWithAddressError):
+            _ = nokiasrl.NokiaSRLinux(acl, EXP_INFO)
+
+    def testDestinationPrefixListWithAddressError(self):
+        acl = policy.ParsePolicy(GOOD_HEADER + BAD_DPFX_AND_DADDR, self.naming)
+        with self.assertRaises(nokiasrl.PrefixListWithAddressError):
             _ = nokiasrl.NokiaSRLinux(acl, EXP_INFO)
 
 


### PR DESCRIPTION
Closes #483

### Summary

Adds support for `source-prefix` and `destination-prefix` tokens in the `nokiasrl` generator, so users can reference existing named prefix-lists defined in the configuration.  The tokens are already used elsewhere (juniper, arista_tp, iptables) with similar semantics.

### Example

With this patch a term like this:
```yaml
- name: allow_bgp_src
  source-prefix: bgp-sessions bgp-sessions-overlay
  protocol: tcp
  source-port: BGP
  action: accept
```
Will produce an SR-Linux ACL entry like this:

```json
{
  "action": {"accept": {}},
  "description": "allow_bgp_src",
  "match": {
    "ipv4": {
      "protocol": 6,
      "source-ip": {
        "prefix-list": [
          {"name": "bgp-sessions"},
          {"name": "bgp-sessions-overlay"}
        ]
      }
    },
    "transport": {
      "source-port": {"value": 179}
    }
  },
  "sequence-id": 5
}
```

## Notes for review

- I re-used the existing `source-prefix` / `destination-prefix` names rather than creating new Nokia-specific tokens, as the concept here is the same as the other places those names are used.

- Combining `source-prefix` and `source-address` on the same term raises an exception.  SR Linux YANG doesn't allow both in the same `source-ip` container so this seemed sensible.

### Changes

- `aerleon/lib/nokiasrl.py` — extends `IPPrefix` to accept either a literal `prefix` or a `prefix-list` array, adds `SetSourcePrefixList` / `SetDestPrefixList` setters, adds `source_prefix` / `destination_prefix` to the supported token set, and raises `PrefixListWithAddressError` when a term combines `source-prefix` with `source-address` (same for destination).
- `tests/regression/nokiasrl/nokiasrl_test.py` — five new tests: single source / destination prefix-list, multiple source prefix-lists, and the two conflict-detection error paths.
- `docs/reference/generators.md` — documents the two new tokens in the NokiaSRL section.

### Testing

- `poetry run pytest tests/regression/nokiasrl/` — 24 tests pass (19 existing + 5 new).

This is my first contribution to Aerleon, so any feedback on style or approach is very welcome.