### PR TITLE
Nokia SRL: add support for restrict-address-family

### DIFF
--- a/aerleon/lib/nokiasrl.py
+++ b/aerleon/lib/nokiasrl.py
@@ -233,7 +233,13 @@ class NokiaSRLinux(openconfig.OpenConfig):
         """
         supported_tokens, supported_sub_tokens = super()._BuildTokens()
 
-        supported_tokens -= {'platform', 'platform_exclude', 'verbatim', 'icmp-type'}
+        supported_tokens -= {
+            'platform',
+            'platform_exclude',
+            'verbatim',
+            'icmp-type',
+            'restrict_address_family',
+        }
 
         supported_sub_tokens['action'] = {'accept', 'deny'}  # excludes 'reject'
         supported_sub_tokens['option'] = {
@@ -265,6 +271,9 @@ class NokiaSRLinux(openconfig.OpenConfig):
         afs = ['inet', 'inet6'] if address_family == 'mixed' else [address_family]
         for term in terms:
             for term_af in afs:
+                # Ignore if the term is for a different AF
+                if term.restrict_address_family and term.restrict_address_family != term_af:
+                    continue
                 t = SRLTerm(term, term_af)
                 for rule in t.ConvertToDict(filter_options):
                     self.total_rule_count += 1

--- a/docs/reference/generators.md
+++ b/docs/reference/generators.md
@@ -1134,6 +1134,7 @@ targets:
 ### Term Format
 
 * for common keys see the [common](#common) section above.
+* _restrict-address-family_: Only include the term in the matching address family filter (eg. for mixed filters).
 
 ### Sub Tokens
 

--- a/policies/pol/sample_nokia_srl_lab.pol
+++ b/policies/pol/sample_nokia_srl_lab.pol
@@ -35,6 +35,7 @@ term accept-tcp-replies {
 term deny-to-internal {
   comment:: "Deny access to rfc1918/internal."
   destination-address:: INTERNAL
+  restrict-address-family:: inet
   action:: deny
 }
 

--- a/tests/regression/nokiasrl/NokiaSRLTest.testRestrictAddressFamilyType.stdout.ref
+++ b/tests/regression/nokiasrl/NokiaSRLTest.testRestrictAddressFamilyType.stdout.ref
@@ -1,0 +1,59 @@
+[
+  {
+    "acl-filter": {
+      "_annotate": "$Id:$ $Date:$ $Revision:$",
+      "description": "GOOD_HEADER_MIXED comment.",
+      "entry": [
+        {
+          "_annotate_description": "Deny TCP & UDP 53 with saddr/daddr and logging, but for v4 only.",
+          "action": {
+            "drop": {
+              "log": true
+            }
+          },
+          "description": "good-term-1",
+          "match": {
+            "destination-ip": {
+              "prefix": "10.2.3.4/32"
+            },
+            "destination-port": {
+              "value": 53
+            },
+            "protocol": 17,
+            "source-ip": {
+              "prefix": "10.2.3.4/32"
+            }
+          },
+          "sequence-id": 5
+        },
+        {
+          "_annotate_description": "Deny TCP & UDP 53 with saddr/daddr and logging, but for v4 only.",
+          "action": {
+            "drop": {
+              "log": true
+            }
+          },
+          "description": "good-term-1",
+          "match": {
+            "destination-ip": {
+              "prefix": "10.2.3.4/32"
+            },
+            "destination-port": {
+              "value": 53
+            },
+            "protocol": 6,
+            "source-ip": {
+              "prefix": "10.2.3.4/32"
+            }
+          },
+          "sequence-id": 10
+        }
+      ],
+      "name": "good-name-mixed",
+      "statistics-per-entry": true,
+      "type": "ipv4"
+    }
+  }
+]
+
+

--- a/tests/regression/nokiasrl/nokiasrl_test.py
+++ b/tests/regression/nokiasrl/nokiasrl_test.py
@@ -114,6 +114,19 @@ term good-term-1 {
 }
 """
 
+GOOD_RESTRICTAF = """
+term good-term-1 {
+  comment:: "Deny TCP & UDP 53 with saddr/daddr and logging, but for v4 only."
+  destination-address:: CORP_EXTERNAL
+  source-address:: CORP_EXTERNAL
+  destination-port:: DNS
+  protocol:: udp tcp
+  restrict-address-family:: inet
+  action:: deny
+  logging:: True
+}
+"""
+
 GOOD_JSON_SADDR = """
 [
 {
@@ -469,6 +482,13 @@ class NokiaSRLTest(absltest.TestCase):
     def testEverything(self):
         acl = nokiasrl.NokiaSRLinux(
             policy.ParsePolicy(GOOD_HEADER_MIXED + GOOD_EVERYTHING, self.naming), EXP_INFO
+        )
+        print(acl)
+
+    @capture.stdout
+    def testRestrictAddressFamilyType(self):
+        acl = nokiasrl.NokiaSRLinux(
+            policy.ParsePolicy(GOOD_HEADER_MIXED + GOOD_RESTRICTAF, self.naming), EXP_INFO
         )
         print(acl)
 


### PR DESCRIPTION
I noticed it when pushing [this](https://gerrit.wikimedia.org/r/c/operations/homer/public/+/1296933/1/policies/srl-common-loopback.yaml) change to the target `nokiasrl: cpm mixed stats r24.3.2` :
```
      - name: allow_traceroute
        comment: T348120
        source-address: RFC1918_10
        destination-port: TRACEROUTE
        protocol: udp
```

As `RFC1918_10` is only a v4 prefix, instead of not creating a v6 term (which would be safer), it created a v6 term with no `source-address` (diff slightly modified for readability), so "wide open":
```diff
          acl-filter cpm type ipv6 {
+             entry 445 {
+                 description allow_traceroute
+                 match {
+                     ipv6 {
+                         next-header 17
+                     }
+                     transport {
+                         destination-port {
+                             range {
+                                 start 33434
+                                 end 33534
+                             }
+                         }
+                     }
+                 }
+                 action {
+                     accept {
+                     }
+                 }
+             }
          }
```

Adding `restrict-address-family` allows me to solve (or workaround) this issue, and it's a term present in other platforms too (cisco, juniper).