### PR TITLE
fortigate: support source-fqdn / destination-fqdn

### DIFF
--- a/aerleon/lib/fortigate.py
+++ b/aerleon/lib/fortigate.py
@@ -215,6 +215,30 @@ class FortigateAddressGroup(FortigateObjectGroup):
         return iter(self.fortigate_addrs)
 
 
+class FortigateFqdnAddress(FortigateObjectGroup):
+    """A FortiGate ``config firewall address`` object of ``type fqdn``.
+
+    FortiGate models an FQDN as an address object (not as a per-policy field like
+    Junos ``dns-name``); it is referenced from a policy's ``srcaddr``/``dstaddr``
+    exactly like an IP address object.
+    """
+
+    def __init__(self, name: str, fqdn: str):
+        self.name = name
+        self.fqdn = fqdn
+
+    def __str__(self) -> str:
+        """Return string representation of a Fortigate fqdn address object."""
+        return '\n'.join(
+            [
+                f'    edit {self.name}',
+                '        set type fqdn',
+                f'        set fqdn "{self.fqdn}"',
+                '    next',
+            ]
+        )
+
+
 class Term(aclgenerator.Term):
     SADDR_V4 = 'srcaddr'
     DADDR_V4 = 'dstaddr'
@@ -229,6 +253,7 @@ class Term(aclgenerator.Term):
         addressgroups: FortigateDefaultDictionary,
         addressgroups_v6: FortigateDefaultDictionary,
         address_family: str,
+        fqdn_addresses: dict = None,
     ):
         """
         Initializes the Term object.
@@ -236,6 +261,9 @@ class Term(aclgenerator.Term):
             term: The term object from the policy.
             source_interface: The source interface for the term.
             destination_interface: The destination interface for the term.
+            fqdn_addresses: Shared name -> FortigateFqdnAddress map that collects
+                the `type fqdn` address objects referenced by source-fqdn /
+                destination-fqdn terms.
         """
         super().__init__(term)
         self.term = term
@@ -254,6 +282,7 @@ class Term(aclgenerator.Term):
 
         self.address_groups = addressgroups
         self.address_groups_v6 = addressgroups_v6
+        self.fqdn_addresses = fqdn_addresses if fqdn_addresses is not None else {}
         self.services = []
 
         self._TranslateAddresses(term.source_address)
@@ -270,6 +299,9 @@ class Term(aclgenerator.Term):
                 term.destination_address,
                 term.destination_address_exclude,
             )
+
+        self.source_fqdn_tokens = self._TranslateFqdns(term.source_fqdn)
+        self.destination_fqdn_tokens = self._TranslateFqdns(term.destination_fqdn)
 
         if term.destination_port or term.source_port:
             service = FortigateIPService(
@@ -341,6 +373,29 @@ class Term(aclgenerator.Term):
             else:
                 raise ValueError(f"Unsupported address version: {addr.version}")
 
+    def _TranslateFqdns(self, fqdns: list) -> list[str]:
+        """Register `type fqdn` address objects and return the names to reference.
+
+        Aerleon FQDN objects carry the naming ``parent_token`` and the resolved
+        ``fqdn`` string. One address object is emitted per distinct fqdn; a naming
+        object holding multiple fqdns is suffixed (``NAME_0``, ``NAME_1``, ...).
+        """
+        tokens: list[str] = []
+        by_parent: dict[str, list[str]] = {}
+        for f in fqdns:
+            by_parent.setdefault(f.parent_token, []).append(f.fqdn)
+        for parent, values in by_parent.items():
+            uniq = sorted(dict.fromkeys(values))
+            if len(uniq) == 1:
+                self.fqdn_addresses[parent] = FortigateFqdnAddress(parent, uniq[0])
+                tokens.append(parent)
+            else:
+                for i, val in enumerate(uniq):
+                    name = f"{parent}_{i}"
+                    self.fqdn_addresses[name] = FortigateFqdnAddress(name, val)
+                    tokens.append(name)
+        return tokens
+
     def _SetStrLogging(self, output):
         if self.term.logging:
             if self.logtraffic == 'log_traffic_mode_all':
@@ -387,14 +442,22 @@ class Term(aclgenerator.Term):
         destination_tokens_v4 = sorted(destination_tokens_v4)
         destination_tokens_v6 = sorted(destination_tokens_v6)
 
+        # FQDN address objects are referenced from the IPv4 srcaddr/dstaddr field
+        # (FortiGate resolves them via DNS; there is no separate FQDN field).
+        source_fqdn_tokens = [f'"{t}"' for t in self.source_fqdn_tokens]
+        destination_fqdn_tokens = [f'"{t}"' for t in self.destination_fqdn_tokens]
+
         has_v4_source_elements = bool(
-            source_tokens_v4 or any(ex.version == 4 for ex in self.term.source_address_exclude)
+            source_tokens_v4
+            or source_fqdn_tokens
+            or any(ex.version == 4 for ex in self.term.source_address_exclude)
         )
         has_v6_source_elements = bool(
             source_tokens_v6 or any(ex.version == 6 for ex in self.term.source_address_exclude)
         )
         has_v4_destination_elements = bool(
             destination_tokens_v4
+            or destination_fqdn_tokens
             or any(ex.version == 4 for ex in self.term.destination_address_exclude)
         )
         has_v6_destination_elements = bool(
@@ -470,8 +533,8 @@ class Term(aclgenerator.Term):
                 # Ensure the _TranslateExcludes created a V4 group for this term.
                 # The name needs to be consistently generated.
                 src_v4_to_set = f'"{self.term.name}-source"'  # Assumes _TranslateExcludes uses this name for the v4 version
-            elif source_tokens_v4:
-                src_v4_to_set = " ".join(source_tokens_v4)
+            elif source_tokens_v4 or source_fqdn_tokens:
+                src_v4_to_set = " ".join(source_tokens_v4 + source_fqdn_tokens)
             else:
                 src_v4_to_set = f'"{src_v4_effective_val}"'  # Use effective default (all or none)
 
@@ -480,8 +543,8 @@ class Term(aclgenerator.Term):
             )
             if destination_v4_exclude_exists:
                 dst_v4_to_set = f'"{self.term.name}-destination"'
-            elif destination_tokens_v4:
-                dst_v4_to_set = " ".join(destination_tokens_v4)
+            elif destination_tokens_v4 or destination_fqdn_tokens:
+                dst_v4_to_set = " ".join(destination_tokens_v4 + destination_fqdn_tokens)
             else:
                 dst_v4_to_set = f'"{dst_v4_effective_val}"'
 
@@ -575,6 +638,7 @@ class Fortigate(aclgenerator.ACLGenerator):
         self.term_names = set()
         self.address_groups = FortigateDefaultDictionary(FortigateAddressGroup, 'name')
         self.address_groups_v6 = FortigateDefaultDictionary(FortigateAddressGroup, 'name')
+        self.fqdn_addresses = {}  # name -> FortigateFqdnAddress
         super().__init__(name, description)
 
     @staticmethod
@@ -595,6 +659,7 @@ class Fortigate(aclgenerator.ACLGenerator):
         """
         supported_tokens, supported_sub_tokens = super()._BuildTokens()
         supported_tokens.remove('stateless_reply')
+        supported_tokens |= {'source_fqdn', 'destination_fqdn'}
         supported_sub_tokens['action'] = SUPPORTED_ACTIONS
         supported_sub_tokens['option'] = (
             FORTIGATE_LOG_TRAFFIC_VALUES | FORTIGATE_LOG_TRAFFIC_START_VALUES
@@ -646,6 +711,7 @@ class Fortigate(aclgenerator.ACLGenerator):
                     self.address_groups,
                     self.address_groups_v6,
                     af,
+                    self.fqdn_addresses,
                 )
                 self.services.extend(fortigate_term.services)
                 self.term_names.add(term.name)
@@ -690,7 +756,7 @@ class Fortigate(aclgenerator.ACLGenerator):
         output = []
 
         # IPv4
-        if self.address_groups.values():
+        if self.address_groups.values() or self.fqdn_addresses:
             # IPv4 Addresses
             output.append('config firewall address')
             for group_name in sorted(self.address_groups):
@@ -699,6 +765,9 @@ class Fortigate(aclgenerator.ACLGenerator):
                 if isinstance(group, FortigateAddressGroup):
                     for addr in sorted(self.address_groups[group_name].fortigate_addrs):
                         output.append(str(addr))
+            # FQDN address objects (type fqdn) referenced by srcaddr/dstaddr.
+            for fqdn_name in sorted(self.fqdn_addresses):
+                output.append(str(self.fqdn_addresses[fqdn_name]))
             output.append('end')
             # Address Groups
             output.append('config firewall addrgrp')

--- a/tests/regression/fortigate/FortigateTest.testDestinationFqdn.stdout.ref
+++ b/tests/regression/fortigate/FortigateTest.testDestinationFqdn.stdout.ref
@@ -1,0 +1,21 @@
+config firewall address
+    edit GOOGLE_DNS
+        set type fqdn
+        set fqdn "dns.google.com"
+    next
+end
+config firewall addrgrp
+end
+config firewall policy
+    edit 1
+        set name "to-fqdn"
+        set srcintf "port1"
+        set dstintf "port2"
+        set action accept
+        set srcaddr "all"
+        set dstaddr "GOOGLE_DNS"
+        set schedule "always"
+        set service "ALL"
+        set logtraffic disable
+    next
+end

--- a/tests/regression/fortigate/FortigateTest.testMultipleFqdnValuesExpandToIndexedObjects.stdout.ref
+++ b/tests/regression/fortigate/FortigateTest.testMultipleFqdnValuesExpandToIndexedObjects.stdout.ref
@@ -1,0 +1,25 @@
+config firewall address
+    edit MULTI_FQDN_0
+        set type fqdn
+        set fqdn "a.example.com"
+    next
+    edit MULTI_FQDN_1
+        set type fqdn
+        set fqdn "b.example.com"
+    next
+end
+config firewall addrgrp
+end
+config firewall policy
+    edit 1
+        set name "multi"
+        set srcintf "port1"
+        set dstintf "port2"
+        set action accept
+        set srcaddr "all"
+        set dstaddr "MULTI_FQDN_0" "MULTI_FQDN_1"
+        set schedule "always"
+        set service "ALL"
+        set logtraffic disable
+    next
+end

--- a/tests/regression/fortigate/FortigateTest.testSourceFqdn.stdout.ref
+++ b/tests/regression/fortigate/FortigateTest.testSourceFqdn.stdout.ref
@@ -1,0 +1,21 @@
+config firewall address
+    edit GOOGLE_DNS
+        set type fqdn
+        set fqdn "dns.google.com"
+    next
+end
+config firewall addrgrp
+end
+config firewall policy
+    edit 1
+        set name "from-fqdn"
+        set srcintf "port1"
+        set dstintf "port2"
+        set action accept
+        set srcaddr "GOOGLE_DNS"
+        set dstaddr "all"
+        set schedule "always"
+        set service "ALL"
+        set logtraffic disable
+    next
+end

--- a/tests/regression/fortigate/fortigate_test.py
+++ b/tests/regression/fortigate/fortigate_test.py
@@ -428,6 +428,20 @@ class FortigateTest(parameterized.TestCase):
         # Different IPs from MIXED_P for exclusion testing
         self.naming._ParseLine('MIXED_Q = 1.1.1.3/32 2001:db8::3/128', 'networks')
 
+        # FQDN definitions (only expressible via the object/YAML naming path).
+        self.naming.ParseDefinitionsObject(
+            {
+                'networks': {
+                    'GOOGLE_DNS': {'values': [{'fqdn': 'dns.google.com'}]},
+                    'MULTI_FQDN': {
+                        'values': [{'fqdn': 'a.example.com'}, {'fqdn': 'b.example.com'}]
+                    },
+                },
+                'services': {},
+            },
+            '',
+        )
+
     @capture.stdout
     def testNoAddressesInet6OutputsAll(self):
         pol = policy.ParsePolicy(INET6_HEADER + ALL_IPS, self.naming)
@@ -464,6 +478,57 @@ class FortigateTest(parameterized.TestCase):
         acl = fortigate.Fortigate(pol, EXP_INFO)
         self.assertNotIn('srcaddr6 ', str(acl))
         self.assertNotIn('dstaddr6 ', str(acl))
+        print(acl)
+
+    @capture.stdout
+    def testDestinationFqdn(self):
+        term = """
+  - name: to-fqdn
+    destination-fqdn: GOOGLE_DNS
+    action: accept
+"""
+        pol = yaml_frontend.ParsePolicy(
+            YAML_INET_HEADER + term, filename="fqdn", definitions=self.naming
+        )
+        acl = str(fortigate.Fortigate(pol, EXP_INFO))
+        self.assertIn('edit GOOGLE_DNS', acl)
+        self.assertIn('set type fqdn', acl)
+        self.assertIn('set fqdn "dns.google.com"', acl)
+        self.assertIn('set dstaddr "GOOGLE_DNS"', acl)
+        print(acl)
+
+    @capture.stdout
+    def testSourceFqdn(self):
+        term = """
+  - name: from-fqdn
+    source-fqdn: GOOGLE_DNS
+    action: accept
+"""
+        pol = yaml_frontend.ParsePolicy(
+            YAML_INET_HEADER + term, filename="fqdn", definitions=self.naming
+        )
+        acl = str(fortigate.Fortigate(pol, EXP_INFO))
+        self.assertIn('set type fqdn', acl)
+        self.assertIn('set fqdn "dns.google.com"', acl)
+        self.assertIn('set srcaddr "GOOGLE_DNS"', acl)
+        print(acl)
+
+    @capture.stdout
+    def testMultipleFqdnValuesExpandToIndexedObjects(self):
+        term = """
+  - name: multi
+    destination-fqdn: MULTI_FQDN
+    action: accept
+"""
+        pol = yaml_frontend.ParsePolicy(
+            YAML_INET_HEADER + term, filename="fqdn", definitions=self.naming
+        )
+        acl = str(fortigate.Fortigate(pol, EXP_INFO))
+        self.assertIn('edit MULTI_FQDN_0', acl)
+        self.assertIn('set fqdn "a.example.com"', acl)
+        self.assertIn('edit MULTI_FQDN_1', acl)
+        self.assertIn('set fqdn "b.example.com"', acl)
+        self.assertIn('set dstaddr "MULTI_FQDN_0" "MULTI_FQDN_1"', acl)
         print(acl)
 
     @capture.stdout


### PR DESCRIPTION
## Summary

FortiGate configs commonly use FQDN address objects (`config firewall address`
with `set type fqdn`), but the FortiGate generator rejects any term using
`source-fqdn`/`destination-fqdn`:

```
<term> contains unsupported keywords (destination_fqdn) for target fortigate
```

This adds FQDN support to the FortiGate generator.

## Root cause

FQDN is opt-in per generator — `ACLGenerator._BuildTokens()` does not include
`source_fqdn`/`destination_fqdn`. The Junos SRX generator advertises them and
renders `dns-name`; the FortiGate generator never advertised them and had no FQDN
rendering, so keyword validation rejects such terms.

## Change

FortiGate models an FQDN as an address object of `type fqdn` referenced from a
policy's `srcaddr`/`dstaddr` (there is no separate FQDN policy field, unlike Junos
`dns-name`):

- Advertise `source_fqdn`/`destination_fqdn` in `Fortigate._BuildTokens`.
- Add `FortigateFqdnAddress`, which emits `set type fqdn` / `set fqdn "<value>"`.
- `Term._TranslateFqdns` registers the FQDN address objects (a naming object
  holding multiple FQDNs expands to `NAME_0`/`NAME_1`) and folds their tokens into
  the v4 `srcaddr`/`dstaddr`.
- Emit the FQDN objects in the `config firewall address` section.

## Example

```yaml
filters:
  - header:
      targets:
        fortigate: from-zone port1 to-zone port2
    terms:
      - name: to-fqdn
        destination-fqdn: GOOGLE_DNS
        action: accept
```

with `GOOGLE_DNS` defined as `fqdn: dns.google.com` produces:

```text
config firewall address
    edit GOOGLE_DNS
        set type fqdn
        set fqdn "dns.google.com"
    next
end
...
        set dstaddr "GOOGLE_DNS"
```

## Tests

Adds `testDestinationFqdn`, `testSourceFqdn`, and
`testMultipleFqdnValuesExpandToIndexedObjects` to
`tests/regression/fortigate/fortigate_test.py`; the full FortiGate regression
suite passes.

## Known Rough Edges

- A single naming object carrying both an IP and an FQDN, referenced on the same
  side via both `destination-address` and `destination-fqdn`, would collide
  (`addrgrp` vs `address` with the same name); a follow-up could suffix the FQDN
  object to disambiguate.
