### PR TITLE
Support negative values for priority field in nftables

### DIFF
--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -726,7 +726,7 @@ class Nftables(aclgenerator.ACLGenerator):
         Returns:
           netfilter_family: x. filter_options[0]
           netfilter_hook: x. filter_options[1].lower()
-          netfilter_priority: numbers = [x for x in filter_options if x.isdigit()]
+          netfilter_priority: numbers = [x for x in filter_options if is_int(x)]
           policy_default_action: nftable action to take on unmatched packets.
           verbose: header and term verbosity.
         """
@@ -749,7 +749,16 @@ class Nftables(aclgenerator.ACLGenerator):
                 % (netfilter_hook, list(self._SUPPORTED_HOOKS))
             )
         if len(header_options) >= 2:
-            numbers = [x for x in header_options if x.isdigit()]
+
+            def is_int(s):
+                try:
+                    int(s)
+                    return True
+                except ValueError:
+                    return False
+
+            numbers = [x for x in header_options if is_int(x)]
+
             if not numbers:
                 netfilter_priority = self._HOOK_PRIORITY_DEFAULT
                 logging.info(

--- a/aerleon/lib/recognizers.py
+++ b/aerleon/lib/recognizers.py
@@ -117,7 +117,7 @@ class TValue(enum.Enum):
         elif self == TValue.WordString:
             if not isinstance(value, str):
                 raise TypeError("Expected string.")
-            match = re.fullmatch(r'\w+([-_+.@/]\w*)*', value.strip())
+            match = re.fullmatch(r'-?\w+([-_+.@/]\w*)*', value.strip())
             if match is None:
                 raise TypeError("Expected value class 'String'.")
             return match[0]
@@ -127,7 +127,7 @@ class TValue(enum.Enum):
                 return value
             if not isinstance(value, str):
                 raise TypeError("Expected integer or string.")
-            match = re.fullmatch(r'\d+', value.strip())
+            match = re.fullmatch(r'-?\d+', value.strip())
             if match is None:
                 raise TypeError("Expected value class 'Integer'.")
             return int(match[0])


### PR DESCRIPTION
nftables supports negative values for the priority field. Doesn't hurt to allow them. My hope was to actually be able to do rules at -10 that would override Docker etc. doing their own thing at 0, but that actually won't work. A drop at a low priority is final, an accept is not. Being able to generate rulesets that nicely coexist with other firewall technologies is thus a bit more involved...