### PR TITLE
Collapse multiple src address + fix duplicate windows_advfirewall rules for IPv4+IPv6 ANY

### DIFF
--- a/aerleon/lib/windows_advfirewall.py
+++ b/aerleon/lib/windows_advfirewall.py
@@ -93,34 +93,56 @@ class Term(windows.Term):
         dst_port: list[str],
         ret_str: list[str],
     ) -> None:
-        # At least advfirewall supports port ranges, unlike windows ipsec,
-        # so the src and dst port lists will always be one element long.
-        for saddr in src_addr:
-            for daddr in dst_addr:
-                for proto in protocol:
-                    ret_str.append(
-                        self._ComposeRule(
-                            saddr, daddr, proto, src_port[0], dst_port[0], self.term.action[0]
-                        )
+        # advfirewall remoteip/localip accept comma-separated addresses, so collapse
+        # the address list into one rule per (daddr, proto) rather than one per src addr.
+        if not src_addr or (len(src_addr) == 1 and src_addr[0].prefixlen == 0):
+            src_str = 'any'
+        else:
+            src_str = ','.join(dict.fromkeys(str(a) for a in src_addr))
+
+        commands = []
+        for daddr in dst_addr:
+            for proto in protocol:
+                commands.append(
+                    self._ComposeRule(
+                        src_str, daddr, proto, src_port[0], dst_port[0], self.term.action[0]
                     )
+                )
+        ret_str.extend(list(dict.fromkeys(commands)))
 
     def _ComposeRule(
-        self, srcaddr: IPv4, dstaddr: IPv4, proto: str, srcport: str, dstport: str, action: str
+        self,
+        srcaddr: IPv4 | str,
+        dstaddr: IPv4,
+        proto: str,
+        srcport: str,
+        dstport: str,
+        action: str,
     ) -> str:
-        """Convert the given parameters into a netsh add rule string."""
+        """Convert the given parameters into a netsh add rule string.
+
+        srcaddr may be a nacaddr object or a pre-built comma-separated address string.
+        """
         atoms = []
-        src_label = 'local'
-        dst_label = 'remote'
 
         # We assume a default direction of OUT, but if it's IN, the Windows
         # advfirewall changes around the remote and local labels.
-        if 'in' == self.filter.lower():
+        if self.filter is None:
+            self.filter = 'out'
+        if self.filter.lower() == 'in':
             src_label = 'remote'
             dst_label = 'local'
+        elif self.filter.lower() == 'out':
+            src_label = 'local'
+            dst_label = 'remote'
+        else:
+            raise UnsupportedFilterOptionError(f"direction {self.filter} unrecognized")
 
         atoms.append(self._DIR_ATOM.substitute(dir=self.filter))
 
-        if srcaddr.prefixlen == 0:
+        if isinstance(srcaddr, str):
+            atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr=srcaddr))
+        elif srcaddr.prefixlen == 0:
             atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr='any'))
         else:
             atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr=str(srcaddr)))

--- a/aerleon/lib/windows_advfirewall.py
+++ b/aerleon/lib/windows_advfirewall.py
@@ -17,7 +17,7 @@
 
 import string
 
-from aerleon.lib import windows
+from aerleon.lib import aclgenerator, windows
 from aerleon.lib.nacaddr import IPv4, IPv6
 
 
@@ -95,35 +95,59 @@ class Term(windows.Term):
     ) -> None:
         # At least advfirewall supports port ranges, unlike windows ipsec,
         # so the src and dst port lists will always be one element long.
-        for saddr in src_addr:
-            for daddr in dst_addr:
-                for proto in protocol:
-                    ret_str.append(
-                        self._ComposeRule(
-                            saddr, daddr, proto, src_port[0], dst_port[0], self.term.action[0]
-                        )
+        #
+        # advfirewall remoteip/localip accept comma-separated addresses, so collapse
+        # the address list into one rule per (daddr, proto) rather than one per src addr.
+        # A list of only /0 prefixes (e.g. dual-stack ANY: 0.0.0.0/0 + ::/0) is
+        # netsh's 'any', which already covers both stacks -- emit that rather than
+        # spelling out every family.
+        if not src_addr or all(a.prefixlen == 0 for a in src_addr):
+            src_str = 'any'
+        else:
+            src_str = ','.join(dict.fromkeys(str(a) for a in src_addr))
+
+        commands = []
+        for daddr in dst_addr:
+            for proto in protocol:
+                commands.append(
+                    self._ComposeRule(
+                        src_str, daddr, proto, src_port[0], dst_port[0], self.term.action[0]
                     )
+                )
+        ret_str.extend(list(dict.fromkeys(commands)))
 
     def _ComposeRule(
-        self, srcaddr: IPv4, dstaddr: IPv4, proto: str, srcport: str, dstport: str, action: str
+        self,
+        srcaddr: str,
+        dstaddr: IPv4,
+        proto: str,
+        srcport: str,
+        dstport: str,
+        action: str,
     ) -> str:
-        """Convert the given parameters into a netsh add rule string."""
+        """Convert the given parameters into a netsh add rule string.
+
+        srcaddr is the pre-built comma-separated address string (or 'any')
+        assembled by _CartesianProduct.
+        """
         atoms = []
-        src_label = 'local'
-        dst_label = 'remote'
 
         # We assume a default direction of OUT, but if it's IN, the Windows
         # advfirewall changes around the remote and local labels.
-        if 'in' == self.filter.lower():
+        if self.filter.lower() == 'in':
             src_label = 'remote'
             dst_label = 'local'
+        elif self.filter.lower() == 'out':
+            src_label = 'local'
+            dst_label = 'remote'
+        else:
+            raise aclgenerator.UnsupportedFilterError(
+                f'Unrecognized windows_advfirewall direction: {self.filter}'
+            )
 
         atoms.append(self._DIR_ATOM.substitute(dir=self.filter))
 
-        if srcaddr.prefixlen == 0:
-            atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr='any'))
-        else:
-            atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr=str(srcaddr)))
+        atoms.append(self._ADDR_ATOM.substitute(dir=src_label, addr=srcaddr))
 
         if dstaddr.prefixlen == 0:
             atoms.append(self._ADDR_ATOM.substitute(dir=dst_label, addr='any'))

--- a/tests/regression/windows_advfirewall/windows_advfirewall_test.py
+++ b/tests/regression/windows_advfirewall/windows_advfirewall_test.py
@@ -43,6 +43,22 @@ term good-simple {
 }
 """
 
+GOOD_HEADER_IN_DEDUP = """
+header {
+  comment:: "dedup test acl"
+  target:: windows_advfirewall in
+}
+"""
+
+DEDUP_TERM = """
+term dedup-term {
+  protocol:: tcp
+  destination-port:: HTTPS
+  source-address:: SRC_NET
+  action:: accept
+}
+"""
+
 GOOD_SIMPLE_WARNING = """
 term good-simple-warning {
   protocol:: tcp
@@ -415,6 +431,59 @@ class WindowsAdvFirewallTest(absltest.TestCase):
             'explicit miscellaneous proto',
         )
         print(result)
+
+    def _RuleLines(self, result):
+        """Just the emitted netsh rule lines, ignoring header comments."""
+        return [
+            line for line in result.splitlines() if line.startswith('netsh advfirewall firewall')
+        ]
+
+    def _RenderDedup(self, src_net):
+        self.naming._ParseLine(f'SRC_NET = {src_net}', 'networks')
+        self.naming._ParseLine('HTTPS = 443/tcp', 'services')
+        acl = windows_advfirewall.WindowsAdvFirewall(
+            policy.ParsePolicy(GOOD_HEADER_IN_DEDUP + DEDUP_TERM, self.naming), EXP_INFO
+        )
+        return self._RuleLines(str(acl))
+
+    def testDualStackAnyEmitsSingleRule(self):
+        """A dual-stack ANY must not emit one identical rule per address family.
+
+        0.0.0.0/0 and ::/0 both render as netsh 'any', so emitting a rule per
+        source address produced two byte-identical rules.
+        """
+        rules = self._RenderDedup('0.0.0.0/0 ::/0')
+        self.assertEqual(len(rules), 1, f'expected a single rule, got: {rules}')
+        self.assertEqual(len(set(rules)), len(rules), f'duplicate rules emitted: {rules}')
+        self.assertIn('remoteip=any', rules[0], f'dual-stack ANY should render as any: {rules[0]}')
+
+    def testSingleFamilyAnyRendersAsAny(self):
+        """A lone /0 keeps rendering as 'any'."""
+        rules = self._RenderDedup('0.0.0.0/0')
+        self.assertEqual(len(rules), 1, f'expected a single rule, got: {rules}')
+        self.assertIn('remoteip=any', rules[0])
+
+    def testMultipleSourcesCollapseToCommaList(self):
+        """Several source addresses collapse into one comma-separated rule."""
+        rules = self._RenderDedup('10.0.0.0/8 192.168.0.0/16')
+        self.assertEqual(len(rules), 1, f'expected a single collapsed rule, got: {rules}')
+        self.assertIn('remoteip=10.0.0.0/8,192.168.0.0/16', rules[0])
+
+    def testUnrecognizedDirectionRaises(self):
+        """An unexpected direction must fail rather than silently rendering as 'out'.
+
+        The local/remote labels are swapped for 'in', so falling through to the
+        'out' labeling would emit rules with the local/remote sense reversed.
+        """
+        self.naming._ParseLine('SRC_NET = 10.0.0.0/8', 'networks')
+        self.naming._ParseLine('HTTPS = 443/tcp', 'services')
+        acl = windows_advfirewall.WindowsAdvFirewall(
+            policy.ParsePolicy(GOOD_HEADER_IN_DEDUP + DEDUP_TERM, self.naming), EXP_INFO
+        )
+        for _, _, _, _, terms in acl.windows_policies:
+            for term in terms:
+                term.filter = 'input'
+        self.assertRaises(aclgenerator.UnsupportedFilterError, str, acl)
 
     def testBuildTokens(self):
         pol1 = windows_advfirewall.WindowsAdvFirewall(


### PR DESCRIPTION
Deduplicate composed rule strings and collapse multiple source addresses into a single comma-separated remoteip/localip list instead of emitting one rule per source address.

Also fixes direction handling in _ComposeRule: an unrecognized filter value used to fall through silently to the default "out" (local/remote) labeling — so a typo'd or unexpected direction (e.g. input instead of in) would silently render rules with the wrong local/remote sense rather than failing. Direction is now validated explicitly, defaults to out only when unset, and raises UnsupportedFilterOptionError on anything else.