### PR TITLE
Fix missing space in nftables verdict-only statements

### DIFF
--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -391,7 +391,7 @@ class Term(aclgenerator.Term):
                 statement.append(pstat + Add(options) + Add(verdict))
         else:
             # If no addresses or ports & protocol. Verdict only statement.
-            statement.append(Add(options) + verdict)
+            statement.append((Add(options) + Add(verdict)).strip())
         return statement
 
     def _AddrStatement(

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_nftables.nft.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_nftables.nft.ref
@@ -1,6 +1,6 @@
 table inet filtering_policies {
     chain default-accept {
-         ct state newaccept
+        ct state new accept
     }
     chain root0 {
         type filter hook output priority 300; policy drop;
@@ -34,7 +34,7 @@ table inet filtering_policies {
 }
 table ip filtering_policies {
     chain allow-anything {
-         ct state newaccept
+        ct state new accept
     }
     chain root1 {
         comment "Inbound traffic nftables policy example"
@@ -43,7 +43,7 @@ table ip filtering_policies {
         jump allow-anything
     }
     chain allow-anything {
-         ct state newaccept
+        ct state new accept
     }
     chain root2 {
         comment "2 Inbound traffic nftables policy example"
@@ -61,7 +61,7 @@ table ip filtering_policies {
     }
     chain test-icmp-type-ip6 {
         comment "IPv6 icmp-type test"
-         ct state newaccept
+        ct state new accept
     }
     chain test-protocol-udp {
         comment "All UDP traffic for both IPv4 and IPv6."
@@ -115,17 +115,17 @@ table ip6 filtering_policies {
     }
     chain awesome-term {
         comment "Awesomeness."
-         ct state newaccept
+        ct state new accept
     }
     chain multiline-comment-term {
         comment "First line of comment."
         comment "Second line of defense."
         comment "Third base."
-         ct state newaccept
+        ct state new accept
     }
     chain awesome-term3 {
         comment "Awesomeness."
-         ct state newaccept
+        ct state new accept
     }
     chain root5 {
         comment "Priority outbound IPv6"

--- a/tests/regression/nftables/NftablesTest.testGoodHeader.stdout.ref
+++ b/tests/regression/nftables/NftablesTest.testGoodHeader.stdout.ref
@@ -1,6 +1,6 @@
 table ip6 filtering_policies {
     chain good-term-1 {
-         ct state newaccept
+        ct state new accept
     }
     chain root0 {
         type filter hook input priority 0; policy drop;

--- a/tests/regression/nftables/NftablesTest.testOverridePolicyHeader.stdout.ref
+++ b/tests/regression/nftables/NftablesTest.testOverridePolicyHeader.stdout.ref
@@ -1,6 +1,6 @@
 table ip filtering_policies {
     chain good-term-1 {
-         ct state newaccept
+        ct state new accept
     }
     chain root0 {
         type filter hook output priority 0; policy accept;

--- a/tests/regression/nftables/NftablesTest.testStatefulFirewall.stdout.ref
+++ b/tests/regression/nftables/NftablesTest.testStatefulFirewall.stdout.ref
@@ -1,6 +1,6 @@
 table ip6 filtering_policies {
     chain good-term-1 {
-         ct state newaccept
+        ct state new accept
     }
     chain root0 {
         type filter hook input priority 0; policy drop;


### PR DESCRIPTION
A term with only a verdict (e.g. accept-all) rendered as 'ct state newaccept' instead of 'ct state new accept'. Which is not valid and thus nftables refuses to load the policy