### PR TITLE
fix `GetFQDN` return type hint

### DIFF
--- a/aerleon/lib/naming.py
+++ b/aerleon/lib/naming.py
@@ -547,14 +547,14 @@ class Naming:
                     services_set.add(parts[0])
         return sorted(services_set)
 
-    def GetFQDN(self, query: str) -> list[str]:
+    def GetFQDN(self, query: str) -> list[FQDN]:
         """Expand a network token into a list of FQDN objects.
 
         Args:
           query: Network definition token. May include comment text
 
         Returns:
-          List of nacaddr.IPv4 or nacaddr.IPv6 objects
+          List of FQDN objects
 
         Raises:
           UndefinedAddressError: Network token not defined
@@ -565,8 +565,8 @@ class Naming:
             raise EmptyDefinitionError(f"No FQDN values found for network: {query}")
         return results
 
-    def _GetFQDN(self, query: str, level=0) -> list[str]:
-        returnlist = []
+    def _GetFQDN(self, query: str, level=0) -> list[FQDN]:
+        returnlist: list[FQDN] = []
         data = query.split('#')
         token = data[0].split()[0]
         if token not in self.fqdn:


### PR DESCRIPTION
This PR fixes the type hint of GetFQDN to correctly be `list[FQDN]` instead of `list[str]`.