### PR TITLE
Don't render terms whose protocols are all wrong-family ICMP

### DIFF
--- a/aerleon/lib/nftables.py
+++ b/aerleon/lib/nftables.py
@@ -618,6 +618,9 @@ class Nftables(aclgenerator.ACLGenerator):
     # Below mapping converts Aerleon HEADER native to nftables table.
     # In Nftables 'inet' contains both IPv4 and IPv6 addresses and rules.
     NF_TABLE_AF_MAP = {'inet': 'ip', 'inet6': 'ip6', 'mixed': 'inet'}
+    # Protocols that cannot appear in a single-family nftables table.
+    # 'inet' (mixed) is absent: it renders each family separately.
+    _AF_INCOMPATIBLE_PROTOCOLS = {'ip': frozenset(['icmpv6']), 'ip6': frozenset(['icmp'])}
 
     def _BuildTokens(self) -> tuple[set[str], dict[str, set[str]]]:
         """NFTables generator list of supported tokens and sub tokens.
@@ -698,11 +701,29 @@ class Nftables(aclgenerator.ACLGenerator):
             child_chains = collections.defaultdict(dict)
             term_names = set()
             new_terms = []
-            # TODO: Add checks for ICMP and address families.
             for term in terms:
                 if term.name in term_names:
                     raise TermError('Duplicate term name')
                 term_names.add(term.name)
+                # Skip terms whose protocols are all incompatible with this
+                # table's address family. PortsAndProtocols drops ICMPv6 in an
+                # IPv4 table (and ICMPv4 in an IPv6 table), so such a term would
+                # otherwise render with no match statement at all -- a bare
+                # verdict matching every packet in the chain.
+                incompatible_protos = self._AF_INCOMPATIBLE_PROTOCOLS.get(nf_af)
+                if (
+                    incompatible_protos
+                    and term.protocol
+                    and set(term.protocol).issubset(incompatible_protos)
+                ):
+                    logging.warning(
+                        aclgenerator.Term.NO_AF_LOG_PROTO.substitute(
+                            term=term.name,
+                            proto=', '.join(term.protocol),
+                            af=nf_af,
+                        )
+                    )
+                    continue
                 if term.stateless_reply:
                     logging.warning(
                         'WARNING: Term %s is a stateless reply ' 'term and will not be rendered.',

--- a/docs/reference/generators.md
+++ b/docs/reference/generators.md
@@ -1001,6 +1001,8 @@ When a non-deny term is processed for ACL generation, the `ct state new` is adde
 
 An implementation design for this generator is that terms with options 'established', 'tcp-established' will not rendered in the final NFT configuration.
 
+A term is likewise not rendered when every protocol it lists belongs to the other address family -- an `icmpv6` term in an `inet` filter, or an `icmp` term in an `inet6` filter. The protocol match for such a term cannot be expressed in that table, and rendering it without one would leave a rule matching every packet in the chain. A term keeping at least one protocol valid for the family is rendered as normal, minus the protocols that are not.
+
 ### Transit (forward) policies
 
 The `forward` hook renders a base chain of `type filter hook forward`, for policy applied to routed/transit traffic rather than to traffic terminating on (or originating from) the host. Terms in a forward filter typically pair with the `source-interface` and `destination-interface` keywords to express which way traffic is crossing the box.

--- a/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_nftables.nft.ref
+++ b/tests/regression/demo/TestRegressionDemo.testSmokeTest.sample_nftables.nft.ref
@@ -59,10 +59,6 @@ table ip filtering_policies {
         comment "IPv4 icmp-type test"
         icmp type { echo-request, echo-reply } ct state new accept
     }
-    chain test-icmp-type-ip6 {
-        comment "IPv6 icmp-type test"
-        ct state new accept
-    }
     chain test-protocol-udp {
         comment "All UDP traffic for both IPv4 and IPv6."
         ip protocol udp ct state new accept
@@ -94,7 +90,6 @@ table ip filtering_policies {
         ct state established,related accept
         jump test-icmp
         jump test-icmp-type-ip4
-        jump test-icmp-type-ip6
         jump test-protocol-udp
         jump test-protocol-tcp
         jump test-port-snmp

--- a/tests/regression/nftables/nftables_test.py
+++ b/tests/regression/nftables/nftables_test.py
@@ -154,6 +154,35 @@ header {
 }
 """
 
+GOOD_HEADER_INET_INPUT = """
+header {
+  target:: nftables inet INPUT
+}
+"""
+
+ICMPV6_ONLY_TERM = """
+term icmpv6-only {
+  protocol:: icmpv6
+  icmp-type:: router-solicit router-advertisement
+  action:: accept
+}
+"""
+
+ICMP_ONLY_TERM = """
+term icmp-only {
+  protocol:: icmp
+  icmp-type:: echo-request echo-reply
+  action:: accept
+}
+"""
+
+ICMPV6_PLUS_TCP_TERM = """
+term icmpv6-plus-tcp {
+  protocol:: icmpv6 tcp
+  action:: accept
+}
+"""
+
 ESTABLISHED_OPTION_TERM = """
 term established-term {
   protocol:: udp
@@ -441,6 +470,46 @@ class NftablesTest(parameterized.TestCase):
     def testPortsAndProtocols(self, af, proto, src_p, dst_p, icmp_type, expected):
         result = self.dummyterm.PortsAndProtocols(af, proto, src_p, dst_p, icmp_type)
         self.assertEqual(result, expected)
+
+    def testIcmpv6OnlyTermSkippedInIPv4Table(self):
+        """An icmpv6-only term must not render in an inet (IPv4) filter.
+
+        PortsAndProtocols drops icmpv6 in an IPv4 table, which previously left
+        the term with no match statement -- rendering a bare verdict that
+        matched every packet reaching the chain.
+        """
+        nft = str(
+            nftables.Nftables(
+                policy.ParsePolicy(GOOD_HEADER_INET_INPUT + ICMPV6_ONLY_TERM, self.naming),
+                EXP_INFO,
+            )
+        )
+        self.assertNotIn('icmpv6-only', nft, f'AF-incompatible term was rendered:\n{nft}')
+        for line in nft.splitlines():
+            self.assertNotEqual(line.strip(), 'accept', f'bare accept rule emitted:\n{nft}')
+
+    def testIcmpOnlyTermSkippedInIPv6Table(self):
+        """The symmetric case: an icmp-only term must not render in inet6."""
+        nft = str(
+            nftables.Nftables(
+                policy.ParsePolicy(GOOD_HEADER_1 + ICMP_ONLY_TERM, self.naming), EXP_INFO
+            )
+        )
+        self.assertNotIn('icmp-only', nft, f'AF-incompatible term was rendered:\n{nft}')
+        for line in nft.splitlines():
+            self.assertNotEqual(line.strip(), 'accept', f'bare accept rule emitted:\n{nft}')
+
+    def testPartiallyCompatibleTermStillRenders(self):
+        """A term keeping at least one compatible protocol must still render."""
+        nft = str(
+            nftables.Nftables(
+                policy.ParsePolicy(GOOD_HEADER_INET_INPUT + ICMPV6_PLUS_TCP_TERM, self.naming),
+                EXP_INFO,
+            )
+        )
+        self.assertIn('icmpv6-plus-tcp', nft, f'compatible term was dropped:\n{nft}')
+        self.assertIn('ip protocol tcp', nft, f'tcp match missing:\n{nft}')
+        self.assertNotIn('icmpv6', nft.split('chain icmpv6-plus-tcp')[1].split('}')[0])
 
     @parameterized.parameters(
         'chain_name input 0 inet extraneous_target_option',


### PR DESCRIPTION
PortsAndProtocols drops icmpv6 in an IPv4 table and icmp in an IPv6 table. A term whose only protocol was the wrong family was therefore left with no match statement at all and rendered as a bare verdict.

In an input chain with "policy drop" that is an unconditional accept which also shadows every jump after it, so an inet filter containing an IPv6 NDP term silently accepts all inbound IPv4 traffic:

    chain icmpv6-only {
        ct state new accept
    }
    chain root0 {
        type filter hook input priority 0; policy drop;
        jump icmpv6-only
        jump ssh-only
    }

Skip such terms in _TranslatePolicy with the standard NO_AF_LOG_PROTO warning, matching what the windows generator already does, and drop the "TODO: Add checks for ICMP and address families" this addresses.

Terms retaining at least one compatible protocol are unaffected; the mixed ('inet') family is excluded since it renders each family separately.