### PR TITLE
Render VRRP as protocol 112 for Cisco NX-OS

### DIFF
--- a/aerleon/lib/cisco.py
+++ b/aerleon/lib/cisco.py
@@ -508,6 +508,8 @@ class Term(aclgenerator.Term):
                 protocol = [x if x != 'esp' else '50' for x in protocol]
             if 'ah' in protocol:
                 protocol = [x if x != 'ah' else '51' for x in protocol]
+        if self.platform == 'cisconx' and 'vrrp' in protocol:
+            protocol = [x if x != 'vrrp' else str(self.PROTO_MAP['vrrp']) for x in protocol]
 
         # addresses
         # source address

--- a/tests/regression/cisconx/cisconx_test.py
+++ b/tests/regression/cisconx/cisconx_test.py
@@ -124,6 +124,13 @@ term good-term-11 {
 }
 """
 
+GOOD_TERM_12 = """
+term good-term-12 {
+  protocol:: vrrp
+  action:: accept
+}
+"""
+
 SUPPORTED_TOKENS = {
     'action',
     'address',
@@ -312,6 +319,13 @@ class CiscoNXTest(absltest.TestCase):
         expected = 'permit icmp any any 3'
         self.assertIn(expected, str(acl), str(acl))
         print(acl)
+
+    def testVrrpUsesProtocolNumber(self):
+        acl = cisconx.CiscoNX(
+            policy.ParsePolicy(GOOD_HEADER + GOOD_TERM_12, self.naming), EXP_INFO
+        )
+        self.assertIn('permit 112 any any', str(acl))
+        self.assertNotIn('permit vrrp any any', str(acl))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cisco NX-OS does not accept `vrrp` as a protocol name in ACL entries. This renders the canonical protocol number `112` for the `cisconx` target while leaving other Cisco-based targets and protocols unchanged.

A regression test verifies the generated ACL uses `permit 112` instead of `permit vrrp`.

Fixes #380.

Tests: full suite (2,175 tests), Cisco/CiscoNX regression suites, Black, isort, and pyupgrade.